### PR TITLE
cli overhaul

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliOutput.java
@@ -20,29 +20,15 @@
 
 package com.spotify.styx.cli;
 
-import com.spotify.apollo.Response;
 import com.spotify.styx.api.cli.ActiveStatesPayload;
 import com.spotify.styx.api.cli.EventsPayload;
-import net.sourceforge.argparse4j.inf.ArgumentParserException;
-import net.sourceforge.argparse4j.inf.Namespace;
-import okio.ByteString;
 
 /**
  * Cli printing interface
  */
-public interface CliOutput {
-
-  void parsed(Namespace namespace);
-
-  void parseError(ArgumentParserException e, String help);
-
-  void apiError(Throwable throwable);
-
-  void header(Main.Command command);
+interface CliOutput {
 
   void printActiveStates(ActiveStatesPayload activeStatesPayload);
 
   void printEvents(EventsPayload eventsPayload);
-
-  void printResponse(Response<ByteString> response);
 }

--- a/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
@@ -93,7 +93,8 @@ public final class Main {
         .metavar(" ");
 
     final Subparser list = Command.LIST.parser(subCommands);
-    list.addArgument(COMPONENT_DEST).help("Component id");
+    final Argument listComponent = list.addArgument("-c", "--component")
+        .help("only show instances for COMPONENT");
 
     final Subparser events = Command.EVENTS.parser(subCommands);
     addWorkflowInstanceArguments(events);
@@ -148,7 +149,7 @@ public final class Main {
 
       switch (command) {
         case LIST:
-          activeStates(client, namespace, cli);
+          activeStates(listComponent, client, namespace, cli);
           break;
 
         case EVENTS:
@@ -176,12 +177,13 @@ public final class Main {
     }
   }
 
-  private static void activeStates(BiConsumer<Request, Consumer<byte[]>> client,
+  private static void activeStates(Argument listComponent,
+                                   BiConsumer<Request, Consumer<byte[]>> client,
                                    Namespace namespace, CliOutput cliOutput)
       throws UnsupportedEncodingException {
 
     String uri = apiUri("activeStates");
-    String component = namespace.getString(COMPONENT_DEST);
+    String component = namespace.getString(listComponent.getDest());
     if (component != null) {
       uri += "?component=" + URLEncoder.encode(component, UTF_8);
     }

--- a/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
@@ -38,11 +38,12 @@ import com.spotify.styx.model.EventSerializer;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Argument;
@@ -59,7 +60,7 @@ public final class Main {
   private static final String UTF_8 = "UTF-8";
   private static final String ENV_VAR_PREFIX = "STYX_CLI";
   private static final String STYX_CLI_API = "http://styx.example.com/api/v1/cli";
-  private static final int TTL_REQUEST = 30;
+  private static final int TTL_REQUEST = 90;
 
   private static final String COMMAND_DEST = "command";
   private static final String COMPONENT_DEST = "component";
@@ -70,8 +71,11 @@ public final class Main {
       .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
       .registerModule(new Jdk8Module());
 
-  private Main() {
-  }
+  private static final int EXIT_CODE_SUCCESS = 0;
+  private static final int EXIT_CODE_API_ERROR = 1;
+  private static final int EXIT_CODE_ARGUMENT_ERROR = 2;
+
+  private Main() { }
 
   public static void main(String[] args) throws IOException, InterruptedException {
     final Service cliService = Services.usingName("styx-cli")
@@ -87,25 +91,19 @@ public final class Main {
         .title("commands")
         .metavar(" ");
 
-    final Subparser ls = Command.ACTIVE_STATES.parser(subCommands)
-        .description("List active workflow instances");
-    final Argument lsComponent = ls.addArgument("-c", "--component")
-        .help("only show instances for COMPONENT");
+    final Subparser list = Command.LIST.parser(subCommands);
+    list.addArgument(COMPONENT_DEST).help("Component id");
 
-    final Subparser events = Command.EVENTS.parser(subCommands)
-        .description("List all events for a workflow instance");
+    final Subparser events = Command.EVENTS.parser(subCommands);
     addWorkflowInstanceArguments(events);
 
-    final Subparser trigger = Command.TRIGGER.parser(subCommands)
-        .description("Trigger a completed workflow instance");
+    final Subparser trigger = Command.TRIGGER.parser(subCommands);
     addWorkflowInstanceArguments(trigger);
 
-    final Subparser halt = Command.HALT.parser(subCommands)
-        .description("Halt a workflow instance");
+    final Subparser halt = Command.HALT.parser(subCommands);
     addWorkflowInstanceArguments(halt);
 
-    final Subparser retry = Command.RETRY.parser(subCommands)
-        .description("Retry a workflow instance that is in a waiting state");
+    final Subparser retry = Command.RETRY.parser(subCommands);
     addWorkflowInstanceArguments(retry);
 
     final Argument plain = parser.addArgument("-p", "--plain")
@@ -113,201 +111,143 @@ public final class Main {
         .setDefault(false)
         .action(Arguments.storeTrue());
 
-    final Argument verbose = parser.addArgument("-v", "--verbose")
-        .help("increase verbosity")
-        .action(Arguments.count());
+    Namespace namespace = null;
+    try {
+      namespace = parser.parseArgs(args);
+    } catch (HelpScreenException e) {
+      System.exit(EXIT_CODE_SUCCESS);
+    } catch (ArgumentParserException e) {
+      parser.handleError(e);
+      System.exit(EXIT_CODE_ARGUMENT_ERROR);
+    }
 
-    try (Service.Instance i = cliService.start()) {
-      final Service.Signaller signaller = i.getSignaller();
-      final Namespace namespace = parser.parseArgs(args);
-      final int level = namespace.getInt(verbose.getDest());
-      final boolean plainOutput = namespace.getBoolean(plain.getDest());
-      final Command command = namespace.get(COMMAND_DEST);
-      final CliOutput cli = plainOutput
-          ? new PlainCliOutput()
-          : new PrettyCliOutput(level);
+    final boolean plainOutput = namespace.getBoolean(plain.getDest());
+    final Command command = namespace.get(COMMAND_DEST);
+    final CliOutput cli = plainOutput
+                          ? new PlainCliOutput()
+                          : new PrettyCliOutput();
+    try (Service.Instance instance = cliService.start()) {
+      final Service.Signaller signaller = instance.getSignaller();
 
-      cli.parsed(namespace);
-      cli.header(command);
-
-      final Client client = ApolloEnvironmentModule.environment(i).environment().client();
+      BiConsumer<Request, Consumer<byte[]>> client =
+          errorHandlingClient(
+              ApolloEnvironmentModule.environment(instance).environment().client(),
+              signaller);
 
       switch (command) {
-        case ACTIVE_STATES:
-          activeStates(lsComponent, client, cli, signaller, namespace);
+        case LIST:
+          activeStates(client, namespace, cli);
           break;
 
         case EVENTS:
-          eventsForWorkflowInstance(client, cli, signaller, namespace);
+          eventsForWorkflowInstance(client, namespace, cli);
           break;
 
         case TRIGGER:
-          triggerWorkflowInstance(client, cli, signaller, namespace);
+          triggerWorkflowInstance(client, namespace);
           break;
 
         case HALT:
-          haltWorkflowInstance(client, cli, signaller, namespace);
+          haltWorkflowInstance(client, namespace);
           break;
 
         case RETRY:
-          retryWorkflowInstance(client, cli, signaller, namespace);
+          retryWorkflowInstance(client, namespace);
           break;
 
         default:
+          // parsing unknown command will fail so this should never happen...
           throw new RuntimeException("Unrecognized command: " + command);
       }
 
-      i.waitForShutdown();
-    } catch (HelpScreenException h) {
-      System.exit(1);
-    } catch (ArgumentParserException e) {
-      final StringWriter sw = new StringWriter();
-      final PrintWriter pw = new PrintWriter(sw);
-      parser.printHelp(pw);
-      new PrettyCliOutput(0).parseError(e, sw.toString());
-      System.exit(2);
+      instance.waitForShutdown();
     }
   }
 
-  private static void activeStates(
-      Argument lsComponent,
-      Client client,
-      CliOutput cliOutput,
-      Service.Signaller signaller,
-      Namespace namespace) throws UnsupportedEncodingException {
+  private static void activeStates(BiConsumer<Request, Consumer<byte[]>> client,
+                                   Namespace namespace, CliOutput cliOutput)
+      throws UnsupportedEncodingException {
 
-    String uri = STYX_CLI_API + "/activeStates";
-    String component = namespace.getString(lsComponent.getDest());
+    String uri = apiUri("activeStates");
+    String component = namespace.getString(COMPONENT_DEST);
     if (component != null) {
       uri += "?component=" + URLEncoder.encode(component, UTF_8);
     }
 
-    final Request request = Request.forUri(uri);
-    client.send(request.withTtl(Duration.ofSeconds(TTL_REQUEST))).whenComplete((response, t) -> {
-      byte[] bytes = response.payload().get().toByteArray();
-      try {
-        ActiveStatesPayload activeStatePayload = OBJECT_MAPPER.readValue(
-            bytes, ActiveStatesPayload.class);
-        cliOutput.printActiveStates(activeStatePayload);
-      } catch (IOException e) {
-        cliOutput.apiError(e);
-      }
-      signaller.signalShutdown();
-    }).exceptionally(e -> {
-      cliOutput.apiError(e);
-      signaller.signalShutdown();
-      return null;
-    });
+    client.accept(
+        Request.forUri(uri).withTtl(Duration.ofSeconds(TTL_REQUEST)),
+        bytes -> {
+          try {
+            cliOutput.printActiveStates(OBJECT_MAPPER.readValue(bytes, ActiveStatesPayload.class));
+          } catch (IOException e) {
+            throw Throwables.propagate(e);
+          }
+        });
   }
 
-  private static void eventsForWorkflowInstance(
-      Client client,
-      CliOutput cliOutput,
-      Service.Signaller signaller,
-      Namespace namespace) {
+  private static void eventsForWorkflowInstance(BiConsumer<Request, Consumer<byte[]>> client,
+                                                Namespace namespace, CliOutput cliOutput) {
+    WorkflowInstance workflowInstance = getWorkflowInstance(namespace);
+    String component = workflowInstance.workflowId().componentId();
+    String workflow = workflowInstance.workflowId().endpointId();
+    String parameter = workflowInstance.parameter();
 
-    String component = namespace.getString(COMPONENT_DEST);
-    String workflow = namespace.getString(WORKFLOW_DEST);
-    String parameter = namespace.getString(PARAMETER_DEST);
-    String uri = String.format("%s/events/%s/%s/%s", STYX_CLI_API, component, workflow, parameter);
-    final Request request = Request.forUri(uri);
-    client.send(request).whenComplete((response, t) -> {
-
-      byte[] bytes = response.payload().get().toByteArray();
-
-      try {
-        final EventsPayload eventsPayload = OBJECT_MAPPER.readValue(bytes, EventsPayload.class);
-        cliOutput.printEvents(eventsPayload);
-      } catch (IOException e) {
-        cliOutput.apiError(e);
-      }
-
-      signaller.signalShutdown();
-    }).exceptionally(e -> {
-      cliOutput.apiError(e);
-      signaller.signalShutdown();
-      return null;
-    });
+    client.accept(
+        Request.forUri(apiUri("events", component, workflow, parameter))
+            .withTtl(Duration.ofSeconds(TTL_REQUEST)),
+        bytes -> {
+          try {
+            cliOutput.printEvents(OBJECT_MAPPER.readValue(bytes, EventsPayload.class));
+          } catch (IOException e) {
+            throw Throwables.propagate(e);
+          }
+        });
   }
 
-  private static void triggerWorkflowInstance(
-      Client client,
-      CliOutput cliOutput,
-      Service.Signaller signaller,
-      Namespace namespace) {
-
+  private static void triggerWorkflowInstance(BiConsumer<Request, Consumer<byte[]>> client,
+                                              Namespace namespace) {
     WorkflowInstance workflowInstance = getWorkflowInstance(namespace);
 
+    final ByteString payload;
     try {
-      final ByteString payload = ByteString.of(OBJECT_MAPPER.writeValueAsBytes(workflowInstance));
-      String uri = String.format("%s/trigger/", STYX_CLI_API);
-      final Request request = Request.forUri(uri, "POST").withPayload(payload);
-      client.send(request).whenComplete((response, t) -> {
-        cliOutput.printResponse(response);
-        signaller.signalShutdown();
-      }).exceptionally(e -> {
-        cliOutput.apiError(e);
-        signaller.signalShutdown();
-        return null;
-      });
+      payload = ByteString.of(OBJECT_MAPPER.writeValueAsBytes(workflowInstance));
     } catch (JsonProcessingException e) {
       throw Throwables.propagate(e);
     }
+    client.accept(Request.forUri(apiUri("trigger"), "POST").withPayload(payload), null);
   }
 
-  private static void haltWorkflowInstance(Client client,
-      CliOutput cliOutput,
-      Service.Signaller signaller,
-      Namespace namespace) {
-
+  private static void haltWorkflowInstance(BiConsumer<Request, Consumer<byte[]>> client,
+                                           Namespace namespace) {
     WorkflowInstance workflowInstance = getWorkflowInstance(namespace);
 
     Event halt = Event.halt(workflowInstance);
     EventSerializer.PersistentEvent persistentEvent =
         EventSerializer.convertEventToPersistentEvent(halt);
+    final ByteString payload;
     try {
-      final ByteString payload = ByteString.of(OBJECT_MAPPER.writeValueAsBytes(persistentEvent));
-      String uri = String.format("%s/events/", STYX_CLI_API);
-      final Request request = Request.forUri(uri, "POST").withPayload(payload);
-      client.send(request).whenComplete((response, t) -> {
-        cliOutput.printResponse(response);
-        signaller.signalShutdown();
-      }).exceptionally(e -> {
-        cliOutput.apiError(e);
-        signaller.signalShutdown();
-        return null;
-      });
+      payload = ByteString.of(OBJECT_MAPPER.writeValueAsBytes(persistentEvent));
     } catch (JsonProcessingException e) {
       throw Throwables.propagate(e);
     }
+    client.accept(Request.forUri(apiUri("events"), "POST").withPayload(payload), null);
   }
 
-  private static void retryWorkflowInstance(
-      Client client,
-      CliOutput cliOutput,
-      Service.Signaller signaller,
-      Namespace namespace) {
+  private static void retryWorkflowInstance(BiConsumer<Request, Consumer<byte[]>> client,
+                                            Namespace namespace) {
 
     WorkflowInstance workflowInstance = getWorkflowInstance(namespace);
 
     Event retry = Event.retry(workflowInstance);
     EventSerializer.PersistentEvent persistentEvent =
         EventSerializer.convertEventToPersistentEvent(retry);
+    final ByteString payload;
     try {
-      final ByteString payload = ByteString.of(OBJECT_MAPPER.writeValueAsBytes(persistentEvent));
-      String uri = String.format("%s/events/", STYX_CLI_API);
-      final Request request = Request.forUri(uri, "POST").withPayload(payload);
-      client.send(request).whenComplete((response, t) -> {
-        cliOutput.printResponse(response);
-        signaller.signalShutdown();
-      }).exceptionally(e -> {
-        cliOutput.apiError(e);
-        signaller.signalShutdown();
-        return null;
-      });
+      payload = ByteString.of(OBJECT_MAPPER.writeValueAsBytes(persistentEvent));
     } catch (JsonProcessingException e) {
       throw Throwables.propagate(e);
     }
+    client.accept(Request.forUri(apiUri("events"), "POST").withPayload(payload), null);
   }
 
   private static WorkflowInstance getWorkflowInstance(Namespace namespace) {
@@ -318,36 +258,72 @@ public final class Main {
         namespace.getString(PARAMETER_DEST));
   }
 
-  private static void addWorkflowInstanceArguments(Subparser events) {
-    events.addArgument(COMPONENT_DEST)
+  private static void addWorkflowInstanceArguments(Subparser subparser) {
+    subparser.addArgument(COMPONENT_DEST)
         .help("Component id");
-    events.addArgument(WORKFLOW_DEST)
+    subparser.addArgument(WORKFLOW_DEST)
         .help("Workflow id (legacy Endpoint)");
-    events.addArgument(PARAMETER_DEST)
+    subparser.addArgument(PARAMETER_DEST)
         .help("Parameter identifying the workflow instance, e.g. '2016-09-14' or '2016-09-14T17'");
   }
 
-  enum Command {
-    ACTIVE_STATES("List active states", "ls"),
-    EVENTS("events", "e"),
-    HALT("halt", ""),
-    TRIGGER("trigger", "t"),
-    RETRY("retry", "r");
+  private static BiConsumer<Request, Consumer<byte[]>> errorHandlingClient(
+      Client client, Service.Signaller signaller) {
+    return (request, consumer) -> {
+      CompletionStage<byte[]> completionStage = client.send(request)
+          .handle((response, throwable) -> {
+            if (throwable != null) {
+              throw Throwables.propagate(throwable);
+            }
+            switch (response.status().family()) {
+              case SUCCESSFUL:
+              case REDIRECTION:
+                return response.payload().orElse(ByteString.EMPTY).toByteArray();
+              default:
+                throw new RuntimeException(
+                    response.status().code() + " " + response.status().reasonPhrase());
+            }
+          });
+      if (consumer != null) {
+        completionStage.thenAccept(consumer);
+      }
+      completionStage.whenComplete((ignored, throwable) -> {
+        if (throwable != null) {
+          System.err.println("An API error occurred: "
+                             + Throwables.getRootCause(throwable).getMessage());
+          System.exit(EXIT_CODE_API_ERROR);
+        }
+        signaller.signalShutdown();
+      });
+    };
+  }
 
-    private final String help;
-    private final String[] aliases;
+  private static String apiUri(String... parts) {
+    return STYX_CLI_API + "/" + String.join("/", parts);
+  }
 
-    Command(String help, String ... aliases) {
-      this.help = help;
-      this.aliases = aliases;
+  private enum Command {
+    LIST("ls", "List active workflow instances"),
+    EVENTS("e", "List events for a workflow instance"),
+    HALT("", "Halt a workflow instance"),
+    TRIGGER("t", "Trigger a completed workflow instance"),
+    RETRY("r", "Retry a workflow instance that is in a waiting state");
+
+    private final String alias;
+    private final String description;
+
+    Command(String alias, String description) {
+      this.alias = alias;
+      this.description = description;
     }
 
     public Subparser parser(Subparsers subCommands) {
       return subCommands
           .addParser(name().toLowerCase())
-          .aliases(aliases)
+          .aliases(alias)
           .setDefault(COMMAND_DEST, this)
-          .help(help);
+          .description(description)
+          .help(description);
     }
   }
 }

--- a/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
@@ -319,7 +319,7 @@ public final class Main {
   private enum Command {
     LIST("ls", "List active workflow instances"),
     EVENTS("e", "List events for a workflow instance"),
-    HALT("", "Halt a workflow instance"),
+    HALT("h", "Halt a workflow instance"),
     TRIGGER("t", "Trigger a completed workflow instance"),
     RETRY("r", "Retry a workflow instance that is in a waiting state");
 

--- a/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
@@ -59,7 +59,8 @@ public final class Main {
 
   private static final String UTF_8 = "UTF-8";
   private static final String ENV_VAR_PREFIX = "STYX_CLI";
-  private static final String STYX_CLI_API = "http://styx.example.com/api/v1/cli";
+  private static final String STYX_CLI_API_ENDPOINT = "/api/v1/cli";
+  private static String STYX_API_HOST;
   private static final int TTL_REQUEST = 90;
 
   private static final String COMMAND_DEST = "command";
@@ -106,6 +107,10 @@ public final class Main {
     final Subparser retry = Command.RETRY.parser(subCommands);
     addWorkflowInstanceArguments(retry);
 
+    final Argument host = parser.addArgument("-H", "--host")
+        .help("Styx API host (can also be set with environment variable " + ENV_VAR_PREFIX + "_HOST")
+        .action(Arguments.store());
+
     final Argument plain = parser.addArgument("-p", "--plain")
         .help("plain output")
         .setDefault(false)
@@ -114,6 +119,13 @@ public final class Main {
     Namespace namespace = null;
     try {
       namespace = parser.parseArgs(args);
+      STYX_API_HOST = namespace.getString(host.getDest());
+      if (STYX_API_HOST == null) {
+        STYX_API_HOST = System.getenv(ENV_VAR_PREFIX + "_HOST");
+      }
+      if (STYX_API_HOST == null) {
+        throw new ArgumentParserException("Styx API host not set", parser);
+      }
     } catch (HelpScreenException e) {
       System.exit(EXIT_CODE_SUCCESS);
     } catch (ArgumentParserException e) {
@@ -299,7 +311,7 @@ public final class Main {
   }
 
   private static String apiUri(String... parts) {
-    return STYX_CLI_API + "/" + String.join("/", parts);
+    return "http://" + STYX_API_HOST + STYX_CLI_API_ENDPOINT + "/" + String.join("/", parts);
   }
 
   private enum Command {

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
@@ -22,58 +22,27 @@ package com.spotify.styx.cli;
 
 import static com.spotify.styx.cli.CliUtil.formatTimestamp;
 
-import com.spotify.apollo.Response;
 import com.spotify.styx.api.cli.ActiveStatesPayload;
 import com.spotify.styx.api.cli.EventsPayload;
-import com.spotify.styx.api.cli.EventsPayload.TimestampedPersistentEvent;
 import com.spotify.styx.model.EventSerializer;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.util.EventUtil;
 import java.util.SortedMap;
 import java.util.SortedSet;
-import net.sourceforge.argparse4j.inf.ArgumentParserException;
-import net.sourceforge.argparse4j.inf.Namespace;
-import okio.ByteString;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Cli output printer that prints more unix tool friendly output
  */
-public class PlainCliOutput implements CliOutput {
-
-  private static final Logger LOG = LoggerFactory.getLogger(PlainCliOutput.class);
-
-  @Override
-  public void parsed(Namespace namespace) {
-    // noop
-  }
-
-  @Override
-  public void parseError(ArgumentParserException e, String help) {
-    LOG.warn(e.getMessage());
-    LOG.info(help);
-  }
-
-  @Override
-  public void apiError(Throwable throwable) {
-    LOG.warn("An API error occurred", throwable);
-  }
-
-  @Override
-  public void header(Main.Command command) {
-    // noop
-  }
+class PlainCliOutput implements CliOutput {
 
   @Override
   public void printActiveStates(ActiveStatesPayload activeStatesPayload) {
-    LOG.info("COMPONENT WORKFLOW INSTANCE STATE LAST_EXECUTION_ID PREVIOUS_EXECUTION_INFO");
-
     SortedMap<WorkflowId, SortedSet<ActiveStatesPayload.ActiveState>> groupedActiveStates =
         CliUtil.groupActiveStates(activeStatesPayload.activeStates());
 
-    for (WorkflowId workflowId : groupedActiveStates.keySet()) {
-      for (ActiveStatesPayload.ActiveState activeState : groupedActiveStates.get(workflowId)) {
+    groupedActiveStates.entrySet().forEach(entry -> {
+      WorkflowId workflowId = entry.getKey();
+      entry.getValue().forEach(activeState -> {
         final String previousExecutionInfo;
         if (activeState.previousExecutionLastEvent().isPresent()) {
           final EventSerializer.PersistentEvent
@@ -82,31 +51,25 @@ public class PlainCliOutput implements CliOutput {
         } else {
           previousExecutionInfo = "No data found";
         }
-        LOG.info(String.format("%s %s %s %s %s %s",
-                               workflowId.componentId(),
-                               workflowId.endpointId(),
-                               activeState.workflowInstance().parameter(),
-                               activeState.state(),
-                               activeState.lastExecutionId(),
-                               previousExecutionInfo));
-      }
-    }
+        System.out.println(String.format("%s %s %s %s %s %s",
+                                         workflowId.componentId(),
+                                         workflowId.endpointId(),
+                                         activeState.workflowInstance().parameter(),
+                                         activeState.state(),
+                                         activeState.lastExecutionId(),
+                                         previousExecutionInfo));
+      });
+    });
   }
 
   @Override
   public void printEvents(EventsPayload eventsPayload) {
-    LOG.info("TIME EVENT DATA");
-
-    for (TimestampedPersistentEvent timestampedEvent : eventsPayload.events()) {
-      LOG.info(String.format("%s %s %s",
-                             formatTimestamp(timestampedEvent.timestamp()),
-                             EventUtil.name(timestampedEvent.event().toEvent()),
-                             CliUtil.data(timestampedEvent.event().toEvent())));
-    }
-  }
-
-  @Override
-  public void printResponse(Response<ByteString> response) {
-    LOG.info(response.status().toString());
+    eventsPayload.events().forEach(
+        timestampedEvent ->
+            System.out.println(String.format("%s %s %s",
+                                             formatTimestamp(timestampedEvent.timestamp()),
+                                             EventUtil.name(timestampedEvent.event().toEvent()),
+                                             CliUtil.data(timestampedEvent.event().toEvent())))
+    );
   }
 }

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -20,169 +20,72 @@
 
 package com.spotify.styx.cli;
 
-import static com.spotify.apollo.Status.OK;
 import static com.spotify.styx.cli.CliUtil.colored;
 import static com.spotify.styx.cli.CliUtil.formatTimestamp;
-import static com.spotify.styx.model.EventSerializer.PersistentEvent;
+import static org.fusesource.jansi.Ansi.Color.BLUE;
 import static org.fusesource.jansi.Ansi.Color.CYAN;
+import static org.fusesource.jansi.Ansi.Color.DEFAULT;
 import static org.fusesource.jansi.Ansi.Color.GREEN;
 import static org.fusesource.jansi.Ansi.Color.MAGENTA;
 import static org.fusesource.jansi.Ansi.Color.WHITE;
 import static org.fusesource.jansi.Ansi.Color.YELLOW;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.ConsoleAppender;
-import com.spotify.apollo.Response;
 import com.spotify.styx.api.cli.ActiveStatesPayload;
-import com.spotify.styx.api.cli.ActiveStatesPayload.ActiveState;
 import com.spotify.styx.api.cli.EventsPayload;
-import com.spotify.styx.api.cli.EventsPayload.TimestampedPersistentEvent;
+import com.spotify.styx.model.Event;
 import com.spotify.styx.model.EventVisitor;
 import com.spotify.styx.model.ExecutionDescription;
-import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.util.EventUtil;
-import java.util.SortedMap;
-import java.util.SortedSet;
-import net.sourceforge.argparse4j.inf.ArgumentParserException;
-import net.sourceforge.argparse4j.inf.Namespace;
-import okio.ByteString;
 import org.fusesource.jansi.Ansi;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-final class PrettyCliOutput implements CliOutput {
-
-  private static final Logger LOG = LoggerFactory.getLogger(PrettyCliOutput.class);
-
-  PrettyCliOutput(int level) {
-    init(level);
-  }
-
-  @Override
-  public void parsed(Namespace namespace) {
-    LOG.debug("Parsed namespace {}", namespace);
-  }
-
-  @Override
-  public void parseError(ArgumentParserException e, String help) {
-    LOG.warn(e.getMessage());
-    LOG.info(help);
-  }
-
-  @Override
-  public void apiError(Throwable throwable) {
-    LOG.warn("An API error occurred", throwable);
-  }
-
-  @Override
-  public void header(Main.Command command) {
-    LOG.info("{}", colored(MAGENTA, "      _                   "));
-    LOG.info("{}", colored(MAGENTA, "   __| |_ _  ___ __       "));
-    LOG.info("{}", colored(MAGENTA, "  (_-<  _| || \\ \\ /     "));
-    LOG.info("{}", colored(MAGENTA, "  /__/\\__|\\_, /_\\_\\   "));
-    LOG.info("{}", colored(MAGENTA, "          |__/            "));
-    LOG.info("");
-    LOG.info("> {}", colored(CYAN, command));
-    LOG.info("");
-  }
+class PrettyCliOutput implements CliOutput {
 
   @Override
   public void printActiveStates(ActiveStatesPayload activeStatesPayload) {
-    SortedMap<WorkflowId, SortedSet<ActiveState>> groupedActiveStates =
-        CliUtil.groupActiveStates(activeStatesPayload.activeStates());
-
-    LOG.info(String.format("%-30.30s %-30.30s %-30.30s %-30.30s",
-                             "WORKFLOW INSTANCE",
-                             "STATE",
-                             "LAST EXECUTION ID",
-                             "PREVIOUS EXECUTION INFO"));
-    LOG.info(String.format("%-30.30s %-30.30s %-30.30s %-30.30s",
-                           "-----------------------",
-                           "-----------------------",
-                           "-----------------------",
-                           "-----------------------"));
-    for (WorkflowId workflowId : groupedActiveStates.keySet()) {
-      LOG.info("{} <> {}",
-               colored(CYAN, workflowId.componentId()),
-               colored(CYAN, workflowId.endpointId()));
-      for (ActiveState activeState : groupedActiveStates.get(workflowId)) {
+    final String format = "  %-20s %-16s %-47s %s";
+    System.out.println(String.format(format,
+                                     "WORKFLOW INSTANCE",
+                                     "STATE",
+                                     "LAST EXECUTION ID",
+                                     "PREVIOUS EXECUTION INFO"));
+    CliUtil.groupActiveStates(activeStatesPayload.activeStates()).entrySet().forEach(entry -> {
+      System.out.println();
+      System.out.println(String.format("%s %s",
+                                       colored(CYAN, entry.getKey().componentId()),
+                                       colored(BLUE, entry.getKey().endpointId())));
+      entry.getValue().forEach(activeState -> {
         final Ansi previousExecutionInfo;
         if (activeState.previousExecutionLastEvent().isPresent()) {
-          final PersistentEvent persistentEvent = activeState.previousExecutionLastEvent().get();
-          final String message = CliUtil.lastExecutionMessage(persistentEvent.toEvent());
-          final Ansi.Color messageColor = persistentEvent.toEvent().accept(LastExecutionColor.LAST_EXECUTION_COLOR);
+          final Event event = activeState.previousExecutionLastEvent().get().toEvent();
+          final String message = CliUtil.lastExecutionMessage(event);
+          final Ansi.Color messageColor = event.accept(LastExecutionColor.LAST_EXECUTION_COLOR);
           previousExecutionInfo = colored(messageColor, message);
         } else {
-          previousExecutionInfo = colored(WHITE, "No data found");
+          previousExecutionInfo = colored(DEFAULT, "No data found");
         }
-        LOG.info(String.format("%s %-27.30s %-30.30s %-30.30s %s",
-                               colored(CYAN, "\\_"),
-                               activeState.workflowInstance().parameter(),
-                               activeState.state(),
-                               activeState.lastExecutionId(),
-                               previousExecutionInfo));
-      }
-    }
+        System.out.println(String.format(format,
+                                         activeState.workflowInstance().parameter(),
+                                         activeState.state(),
+                                         activeState.lastExecutionId(),
+                                         previousExecutionInfo));
+      });
+    });
   }
 
   @Override
   public void printEvents(EventsPayload eventsPayload) {
-    LOG.info(String.format("%-25.25s %-25.25s %-25.25s",
-                           "TIME",
-                           "EVENT",
-                           "DATA"));
-    LOG.info(String.format("%-25.25s %-25.25s %-25.25s",
-                           "-------------------",
-                           "-------------------",
-                           "-------------------"));
-    for (TimestampedPersistentEvent timestampedEvent : eventsPayload.events()) {
-      LOG.info(String.format("%-25.25s %-25.25s %s",
-                             formatTimestamp(timestampedEvent.timestamp()),
-                             EventUtil.name(timestampedEvent.event().toEvent()),
-                             CliUtil.data(timestampedEvent.event().toEvent())));
-    }
-  }
-
-  @Override
-  public void printResponse(Response<ByteString> response) {
-    if (OK.equals(response.status())) {
-      LOG.info(String.valueOf(colored(GREEN, "Success")));
-    } else {
-      LOG.info(String.valueOf(colored(MAGENTA, "Code: " + response.status().code())));
-      LOG.info(String.valueOf(colored(MAGENTA, response.status().reasonPhrase())));
-    }
-  }
-
-  private void init(int level) {
-    final ch.qos.logback.classic.Logger
-        logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("com.spotify.styx.cli");
-
-    if (level > 1) {
-      logger.setLevel(Level.TRACE);
-    } else if (level > 0) {
-      logger.setLevel(Level.DEBUG);
-    }
-
-    if (level > 0) {
-      final LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-      final ch.qos.logback.classic.Logger
-          rootLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(
-          ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
-      final ConsoleAppender<ILoggingEvent> stdout =
-          (ConsoleAppender<ILoggingEvent>) rootLogger.getAppender("STDOUT");
-      final PatternLayoutEncoder layout = new PatternLayoutEncoder();
-      layout.setPattern("%gray(%d{HH:mm:ss.SSS}) %highlight(| %-5level| %-10logger{0}) "
-                        + "%green(|>) %msg%n");
-      layout.setContext(lc);
-      layout.start();
-
-      stdout.setEncoder(layout);
-      stdout.start();
-    }
+    final String format = "%-25s %-25s %s";
+    System.out.println(String.format(format,
+                                     "TIME",
+                                     "EVENT",
+                                     "DATA"));
+    eventsPayload.events().forEach(
+        timestampedEvent ->
+            System.out.println(String.format(format,
+                                             formatTimestamp(timestampedEvent.timestamp()),
+                                             EventUtil.name(timestampedEvent.event().toEvent()),
+                                             CliUtil.data(timestampedEvent.event().toEvent()))));
   }
 
   private enum LastExecutionColor implements EventVisitor<Ansi.Color> {
@@ -216,7 +119,8 @@ final class PrettyCliOutput implements CliOutput {
     }
 
     @Override
-    public Ansi.Color created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
+    public Ansi.Color created(WorkflowInstance workflowInstance, String executionId,
+                              String dockerImage) {
       return WHITE;
     }
 
@@ -256,7 +160,8 @@ final class PrettyCliOutput implements CliOutput {
     }
 
     @Override
-    public Ansi.Color submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription) {
+    public Ansi.Color submit(WorkflowInstance workflowInstance,
+                             ExecutionDescription executionDescription) {
       return WHITE;
     }
 

--- a/styx-cli/src/main/resources/logback.xml
+++ b/styx-cli/src/main/resources/logback.xml
@@ -1,13 +1,3 @@
 <configuration>
-  <root level="info">
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-      <name>STDOUT</name>
-      <encoder>
-        <!--<pattern>%gray(%d{HH:mm:ss.SSS}) %highlight(| %-5level| %-10logger{0}) %green(|>) %msg%n</pattern>-->
-        <pattern>%msg%n</pattern>
-      </encoder>
-    </appender>
-  </root>
-
-  <logger name="com.spotify.apollo" level="warn"/>
+   <!-- empty config to disable apollo client logging -->
 </configuration>


### PR DESCRIPTION
- ~~make --component option to `ls` command a positional argument~~
- handle errors in single place
- remove header in output
- use System.{out,err} for output instead of logback
- longer timeout (90 seconds)
- specify api host with `-H` or env variable `STYX_CLI_HOST`