### PR TITLE
Paginate, prepare storage

### DIFF
--- a/styx-api-service/pom.xml
+++ b/styx-api-service/pom.xml
@@ -62,6 +62,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>styx-test</artifactId>
+      <version>0.1.12-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -128,8 +128,19 @@ public class AggregateStorage implements Storage, EventStorage {
   }
 
   @Override
+  public void store(WorkflowInstance workflowInstance) throws IOException {
+    datastoreStorage.store(workflowInstance);
+  }
+
+  @Override
   public Optional<Workflow> workflow(WorkflowId workflowId) throws IOException {
     return datastoreStorage.workflow(workflowId);
+  }
+
+  @Override
+  public List<WorkflowInstance> workflowInstances(WorkflowId workflowId, String offset, int limit)
+      throws IOException {
+    return datastoreStorage.workflowInstances(workflowId, offset, limit);
   }
 
   @Override

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -96,12 +96,6 @@ public class AggregateStorage implements Storage, EventStorage {
   }
 
   @Override
-  public List<WorkflowInstanceExecutionData> executionData(WorkflowId workflowId)
-      throws IOException {
-    return bigtableStorage.executionData(workflowId);
-  }
-
-  @Override
   public boolean enabled(WorkflowId workflowId) throws IOException {
     return datastoreStorage.enabled(workflowId);
   }

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -97,7 +97,18 @@ public class InMemStorage implements Storage, EventStorage {
   }
 
   @Override
+  public List<WorkflowInstance> workflowInstances(WorkflowId workflowId, String offset, int limit)
+      throws IOException {
+    throw new UnsupportedOperationException("Unsupported Operation!");
+  }
+
+  @Override
   public void delete(WorkflowId workflowId) throws IOException {
+    throw new UnsupportedOperationException("Unsupported Operation!");
+  }
+
+  @Override
+  public void store(WorkflowInstance workflowInstance) throws IOException {
     throw new UnsupportedOperationException("Unsupported Operation!");
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -134,23 +134,6 @@ public class InMemStorage implements Storage, EventStorage {
   }
 
   @Override
-  public List<WorkflowInstanceExecutionData> executionData(WorkflowId workflowId)
-      throws IOException {
-    final Set<WorkflowInstance> workflowInstances = writtenEvents.stream()
-        .map(e -> e.event().workflowInstance())
-        .filter(wfi -> wfi.workflowId().equals(workflowId))
-        .collect(Collectors.toSet());
-
-    final List<WorkflowInstanceExecutionData> workflowInstanceDataList = Lists.newArrayList();
-    for (WorkflowInstance workflowInstance : workflowInstances) {
-      workflowInstanceDataList.add(executionData(workflowInstance));
-    }
-    workflowInstanceDataList.sort(WorkflowInstanceExecutionData.COMPARATOR);
-
-    return workflowInstanceDataList;
-  }
-
-  @Override
   public boolean enabled(WorkflowId workflowId) {
     return enabledWorkflows.contains(workflowId);
   }

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -120,14 +120,6 @@ public interface Storage {
   WorkflowInstanceExecutionData executionData(WorkflowInstance workflowInstance) throws IOException;
 
   /**
-   * Get execution information for all the {@link WorkflowInstance} of the specified {@link WorkflowId}.
-   *
-   * @param workflowId  The workflowId to get execution information for
-   * @return A {@link WorkflowInstanceExecutionData} of all the instances
-   */
-  List<WorkflowInstanceExecutionData> executionData(WorkflowId workflowId) throws IOException;
-
-  /**
    * Use workflowState instead.
    * Get enabled flag for a {@link Workflow}.
    *

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -63,6 +63,13 @@ public interface Storage {
   void store(Workflow workflow) throws IOException;
 
   /**
+   * Stores a Workflow Instance
+   *
+   * @param workflowInstance the workflow instance to store
+   */
+  void store(WorkflowInstance workflowInstance) throws IOException;
+
+  /**
    * Get a {@link Workflow} definition.
    *
    * @param workflowId  The workflow to get
@@ -71,9 +78,21 @@ public interface Storage {
   Optional<Workflow> workflow(WorkflowId workflowId) throws IOException;
 
   /**
+   * Gets a list of {@link WorkflowInstance} that have a parameter strictly greater than a given
+   * offset.
+   *
+   * @param workflowId  The workflow for which to get instances
+   * @param offset      The offset parameter
+   * @param limit       Maximum number of results to return
+   * @return A list of workflow instances
+   */
+  List<WorkflowInstance> workflowInstances(WorkflowId workflowId, String offset, int limit)
+      throws IOException;
+
+  /**
    * Removes a workflow definition.
    *
-   * @param workflowId The workflowid to remove.
+   * @param workflowId The workflow id to remove.
    */
   void delete(WorkflowId workflowId) throws IOException;
 

--- a/styx-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
@@ -34,7 +34,6 @@ import com.spotify.styx.model.WorkflowInstanceExecutionData;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import org.apache.hadoop.hbase.client.Connection;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,11 +42,9 @@ import org.junit.rules.ExpectedException;
 public class BigTableStorageTest {
 
   private static final String PARAMETER1 = "2016-01-01";
-  private static final String PARAMETER2 = "2016-01-02";
 
   private static final WorkflowId WORKFLOW_ID1 = WorkflowId.create("component", "endpoint1");
   private static final WorkflowInstance WFI1 = WorkflowInstance.create(WORKFLOW_ID1, PARAMETER1);
-  private static final WorkflowInstance WFI2 = WorkflowInstance.create(WORKFLOW_ID1, PARAMETER2);
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -83,37 +80,6 @@ public class BigTableStorageTest {
         ExecStatus.create(Instant.ofEpochMilli(1L), "SUBMITTED")));
     assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).statuses().get(1), is(
         ExecStatus.create(Instant.ofEpochMilli(2L), "STARTED")));
-  }
-
-  @Test
-  public void shouldReturnExecutionDataForWorkflow() throws Exception {
-    setUp(0);
-    storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI1, "triggerId1"), 0L, 0L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1"), 1L, 1L));
-    storage.writeEvent(SequenceEvent.create(Event.started(WFI1), 2L, 2L));
-
-    storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI2, "triggerId2"), 0L, 3L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2"), 1L, 4L));
-    storage.writeEvent(SequenceEvent.create(Event.started(WFI2), 2L, 5L));
-
-    List<WorkflowInstanceExecutionData> workflowInstanceExecutionData = storage.executionData(WORKFLOW_ID1);
-    assertThat(workflowInstanceExecutionData.size(), is(2));
-
-    assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).triggerId(), is("triggerId1"));
-    assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).executionId(), is("execId1"));
-    assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).dockerImage(), is("img1"));
-    assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).statuses()
-                   .get(0), is(ExecStatus.create(Instant.ofEpochMilli(1L), "SUBMITTED")));
-    assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).statuses()
-                   .get(1), is(ExecStatus.create(Instant.ofEpochMilli(2L), "STARTED")));
-    assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).triggerId(), is("triggerId2"));
-    assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).executionId(), is("execId2"));
-    assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).dockerImage(), is("img2"));
-    assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).statuses()
-                   .get(0), is(ExecStatus.create(Instant.ofEpochMilli(4L), "SUBMITTED")));
-    assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).statuses()
-                   .get(1), is(ExecStatus.create(Instant.ofEpochMilli(5L), "STARTED")));
-
   }
 
   @Test

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/MeteredStorage.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/MeteredStorage.java
@@ -105,12 +105,6 @@ public final class MeteredStorage extends MeteredBase implements Storage {
   }
 
   @Override
-  public List<WorkflowInstanceExecutionData> executionData(WorkflowId workflowId)
-      throws IOException {
-    return timedStorage("executionData", () -> delegate.executionData(workflowId));
-  }
-
-  @Override
   public boolean enabled(WorkflowId workflowId) throws IOException {
     return timedStorage("enabled", () -> delegate.enabled(workflowId));
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/MeteredStorage.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/MeteredStorage.java
@@ -65,8 +65,20 @@ public final class MeteredStorage extends MeteredBase implements Storage {
   }
 
   @Override
+  public void store(WorkflowInstance workflowInstance) throws IOException {
+    timedStorage("storeWorkflowInstance", () -> delegate.store(workflowInstance));
+  }
+
+  @Override
   public Optional<Workflow> workflow(WorkflowId workflowId) throws IOException {
     return timedStorage("workflow", () -> delegate.workflow(workflowId));
+  }
+
+  @Override
+  public List<WorkflowInstance> workflowInstances(WorkflowId workflowId, String offset,
+                                                  int limit) throws IOException {
+    return timedStorage("workflowInstances",
+        () -> delegate.workflowInstances(workflowId, offset, limit));
   }
 
   @Override

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StateInitializingTriggerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StateInitializingTriggerTest.java
@@ -28,6 +28,9 @@ import static java.util.Optional.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -35,11 +38,13 @@ import com.google.common.collect.Sets;
 import com.spotify.styx.model.DataEndpoint;
 import com.spotify.styx.model.Partitioning;
 import com.spotify.styx.model.Workflow;
+import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.SyncStateManager;
-import com.spotify.styx.storage.InMemStorage;
+import com.spotify.styx.storage.Storage;
 import com.spotify.styx.testdata.TestData;
+import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
@@ -57,17 +62,52 @@ public class StateInitializingTriggerTest {
           MONTHS, "2016-01"
       );
 
-  private SyncStateManager activeStates = new SyncStateManager();
-  private InMemStorage inMemStorage = new InMemStorage();
+  private SyncStateManager stateManager = new SyncStateManager();
+  private Storage storage = mock(Storage.class);
   private TriggerListener
-      trigger = new StateInitializingTrigger(RunState::fresh, activeStates, inMemStorage);
+      trigger = new StateInitializingTrigger(RunState::fresh, stateManager, storage);
+
+  @Test
+  public void shouldInitializeWorkflowInstance() throws Exception {
+    DataEndpoint endpoint = dataEndpoint(HOURS);
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, endpoint);
+    setDockerImage(workflow.id(), workflow.schedule());
+    trigger.event(workflow, "trig", TIME);
+
+    assertThat(stateManager.activeStatesSize(), is(1));
+  }
+
+  @Test
+  public void shouldInjectTriggerExecutionEventWithTriggerId() throws Exception {
+    DataEndpoint endpoint = dataEndpoint(HOURS);
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, endpoint);
+    setDockerImage(workflow.id(), workflow.schedule());
+    trigger.event(workflow, "trig", TIME);
+
+    WorkflowInstance expectedInstance = WorkflowInstance.create(workflow.id(), "2016-01-18T09");
+    RunState state = stateManager.get(expectedInstance);
+
+    // todo: assert trigger id
+    assertThat(state.state(), is(RunState.State.PREPARE));
+  }
+
+  @Test
+  public void shouldPersistTriggeredWorkflowInstance() throws Exception {
+    DataEndpoint endpoint = dataEndpoint(HOURS);
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, endpoint);
+    setDockerImage(workflow.id(), workflow.schedule());
+    trigger.event(workflow, "trig", TIME);
+
+    verify(storage).store(WorkflowInstance.create(workflow.id(), "2016-01-18T09"));
+  }
 
   @Test
   public void shouldDoNothingIfDockerInfoMissing() throws Exception {
     Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, TestData.DAILY_DATA_ENDPOINT);
+    setDockerImage(workflow.id(), workflow.schedule());
     trigger.event(workflow, "trig", TIME);
 
-    assertThat(activeStates.activeStatesSize(), is(0));
+    assertThat(stateManager.activeStatesSize(), is(0));
   }
 
   @Test
@@ -75,11 +115,11 @@ public class StateInitializingTriggerTest {
     for (Map.Entry<Partitioning, String> partitioningCase : PARTITIONING_ARG_EXPECTS.entrySet()) {
       DataEndpoint endpoint = dataEndpoint(partitioningCase.getKey(), "--date", "{}", "--bar");
       Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, endpoint);
-      inMemStorage.store(workflow);
+      setDockerImage(workflow.id(), workflow.schedule());
       trigger.event(workflow, "trig", TIME);
 
       RunState runState =
-          activeStates.get(WorkflowInstance.create(workflow.id(), partitioningCase.getValue()));
+          stateManager.get(WorkflowInstance.create(workflow.id(), partitioningCase.getValue()));
 
       assertThat(runState, is(notNullValue()));
       assertThat(runState.workflowInstance().parameter(), is(partitioningCase.getValue()));
@@ -98,5 +138,10 @@ public class StateInitializingTriggerTest {
         Optional.of("busybox"),
         Optional.of(Lists.newArrayList(args)),
         empty());
+  }
+
+  // todo: do not use deprecated getDockerImage method
+  private void setDockerImage(WorkflowId workflowId, DataEndpoint schedule) throws IOException {
+    when(storage.getDockerImage(workflowId)).thenReturn(schedule.dockerImage());
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -25,13 +25,13 @@ import static java.util.Collections.singletonList;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 
-import autovalue.shaded.com.google.common.common.base.Throwables;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.KeyQuery;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.spotify.apollo.test.ServiceHelper;
 import com.spotify.styx.docker.DockerRunner;


### PR DESCRIPTION
To efficiently paginate the `/workflows/.../instances` API, we need to have an index of triggered Workflow Instances that can be queried and paginated. The events in BigTable are not suitable for this.