### PR TITLE
[cli] Fallback to json inspection for unknown events

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliOutput.java
@@ -20,8 +20,9 @@
 
 package com.spotify.styx.cli;
 
+import com.google.auto.value.AutoValue;
 import com.spotify.styx.api.cli.ActiveStatesPayload;
-import com.spotify.styx.api.cli.EventsPayload;
+import java.util.List;
 
 /**
  * Cli printing interface
@@ -30,5 +31,16 @@ interface CliOutput {
 
   void printActiveStates(ActiveStatesPayload activeStatesPayload);
 
-  void printEvents(EventsPayload eventsPayload);
+  void printEvents(List<EventInfo> eventInfos);
+
+  @AutoValue
+  abstract class EventInfo {
+    abstract long timestamp();
+    abstract String name();
+    abstract String info();
+
+    public static EventInfo create(long ts, String eventName, String eventInfo) {
+      return new AutoValue_CliOutput_EventInfo(ts, eventName, eventInfo);
+    }
+  }
 }

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
@@ -23,10 +23,9 @@ package com.spotify.styx.cli;
 import static com.spotify.styx.cli.CliUtil.formatTimestamp;
 
 import com.spotify.styx.api.cli.ActiveStatesPayload;
-import com.spotify.styx.api.cli.EventsPayload;
 import com.spotify.styx.model.EventSerializer;
 import com.spotify.styx.model.WorkflowId;
-import com.spotify.styx.util.EventUtil;
+import java.util.List;
 import java.util.SortedMap;
 import java.util.SortedSet;
 
@@ -63,13 +62,13 @@ class PlainCliOutput implements CliOutput {
   }
 
   @Override
-  public void printEvents(EventsPayload eventsPayload) {
-    eventsPayload.events().forEach(
-        timestampedEvent ->
+  public void printEvents(List<EventInfo> eventInfos) {
+    eventInfos.forEach(
+        eventInfo ->
             System.out.println(String.format("%s %s %s",
-                                             formatTimestamp(timestampedEvent.timestamp()),
-                                             EventUtil.name(timestampedEvent.event().toEvent()),
-                                             CliUtil.data(timestampedEvent.event().toEvent())))
+                                             formatTimestamp(eventInfo.timestamp()),
+                                             eventInfo.name(),
+                                             eventInfo.info()))
     );
   }
 }

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -31,12 +31,11 @@ import static org.fusesource.jansi.Ansi.Color.WHITE;
 import static org.fusesource.jansi.Ansi.Color.YELLOW;
 
 import com.spotify.styx.api.cli.ActiveStatesPayload;
-import com.spotify.styx.api.cli.EventsPayload;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.EventVisitor;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.WorkflowInstance;
-import com.spotify.styx.util.EventUtil;
+import java.util.List;
 import org.fusesource.jansi.Ansi;
 
 class PrettyCliOutput implements CliOutput {
@@ -74,18 +73,18 @@ class PrettyCliOutput implements CliOutput {
   }
 
   @Override
-  public void printEvents(EventsPayload eventsPayload) {
+  public void printEvents(List<EventInfo> eventInfos) {
     final String format = "%-25s %-25s %s";
     System.out.println(String.format(format,
                                      "TIME",
                                      "EVENT",
                                      "DATA"));
-    eventsPayload.events().forEach(
-        timestampedEvent ->
+    eventInfos.forEach(
+        eventInfo ->
             System.out.println(String.format(format,
-                                             formatTimestamp(timestampedEvent.timestamp()),
-                                             EventUtil.name(timestampedEvent.event().toEvent()),
-                                             CliUtil.data(timestampedEvent.event().toEvent()))));
+                                             formatTimestamp(eventInfo.timestamp()),
+                                             eventInfo.name(),
+                                             eventInfo.info())));
   }
 
   private enum LastExecutionColor implements EventVisitor<Ansi.Color> {


### PR DESCRIPTION
We keep breaking the CLI each time we add a new event, because of how we use Jackson.

This will make the cli more forgiving and fallback to just displaying the event name in case it can not parse it into the static types.