### PR TITLE
Add setter for RetryUtil in scheduler builder

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -122,7 +122,7 @@ public class StyxScheduler implements AppInit {
   public static final int SCHEDULER_TICK_INTERVAL_SECONDS = 2;
   public static final int TRIGGER_MANAGER_TICK_INTERVAL_SECONDS = 1;
   public static final Duration DEFAULT_RETRY_BASE_DELAY = Duration.ofMinutes(3);
-  public static final int DEFAULT_RETRY_MAX_EXPONENT = 6;
+  public static final int DEFAULT_RETRY_MAX_EXPONENT = 4;
   public static final Duration DEFAULT_RETRY_BASE_DELAY_BT = Duration.ofSeconds(1);
   public static final RetryUtil DEFAULT_RETRY_UTIL =
       new RetryUtil(DEFAULT_RETRY_BASE_DELAY, DEFAULT_RETRY_MAX_EXPONENT);
@@ -195,6 +195,11 @@ public class StyxScheduler implements AppInit {
 
     public Builder setPublisherFactory(PublisherFactory publisherFactory) {
       this.publisherFactory = publisherFactory;
+      return this;
+    }
+
+    public Builder setRetryUtil(RetryUtil retryUtil) {
+      this.retryUtil = retryUtil;
       return this;
     }
 


### PR DESCRIPTION
Also lower the max backoff exponent to 4, which gives us a max retry time of 2^4*3m = 48m.