### PR TITLE
check global enabled status

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -312,7 +312,8 @@ public class StyxScheduler implements AppInit {
     final StateFactory stateFactory =
         (workflowInstance) -> RunState.fresh(workflowInstance, time, outputHandlers);
 
-    final TriggerListener trigger = trigger(storage, stateFactory, stateManager);
+    final TriggerListener trigger =
+        new StateInitializingTrigger(stateFactory, stateManager, storage);
     final TriggerManager triggerManager = new TriggerManager(trigger, time, storage);
 
     final Consumer<Workflow> workflowChangeListener = workflowChanged(cache, storage,
@@ -458,28 +459,6 @@ public class StyxScheduler implements AppInit {
     stats.registerWorkflowCount("all", allWorkflowsCount);
     stats.registerWorkflowCount("configured", configuredWorkflowsCount);
     stats.registerWorkflowCount("enabled", configuredEnabledWorkflowsCount);
-  }
-
-  private TriggerListener trigger(
-      Storage storage,
-      StateFactory stateFactory,
-      StateManager stateManager) {
-    final TriggerListener stateInitializingTrigger =
-        new StateInitializingTrigger(stateFactory, stateManager, storage);
-
-    return (workflow, trigger, instant) -> {
-      try {
-        final boolean enabled = storage.workflowState(workflow.id()).enabled().orElse(false);
-        if (!enabled || !storage.globalEnabled()) {
-          LOG.info("Triggered disabled workflow {}", workflow.endpointId());
-          return;
-        }
-      } catch (IOException e) {
-        throw Throwables.propagate(e);
-      }
-
-      stateInitializingTrigger.event(workflow, trigger, instant);
-    };
   }
 
   private static Consumer<Workflow> workflowChanged(

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/TriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/TriggerManager.java
@@ -61,6 +61,16 @@ public class TriggerManager {
   }
 
   void tick() {
+    try {
+      if (!storage.globalEnabled()) {
+        LOG.info("Triggering has been disabled globally.");
+        return;
+      }
+    } catch (IOException e) {
+      LOG.warn("Couldn't fetch global enabled status, skipping this run.");
+      return ;
+    }
+
     final Map<Workflow, Optional<Instant>> map;
     final Set<WorkflowId> enabled;
     try {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
@@ -115,6 +115,14 @@ public class TriggerManagerTest {
   }
 
   @Test
+  public void shouldNotTriggerExecutionOnDisabledGlobally() throws IOException {
+    when(storage.globalEnabled()).thenReturn(false);
+    triggerManager.tick();
+    verify(triggerListener, never()).event(any(), any(), any());
+    verify(storage, never()).updateNextNaturalTrigger(any(), any());
+  }
+
+  @Test
   public void shouldNotUpdateNextNaturalTriggerIfTriggerListenerThrows() throws Exception {
     setupWithNextNaturalTrigger(true, NEXT_EXECUTION);
     doThrow(new RuntimeException()).when(triggerListener).event(any(), any(), any());
@@ -131,6 +139,7 @@ public class TriggerManagerTest {
   }
 
   private void setupWithNextNaturalTrigger(boolean enabled, Instant nextNaturalTrigger) throws IOException {
+    when(storage.globalEnabled()).thenReturn(true);
     if (enabled) {
       when(storage.enabled()).thenReturn(ImmutableSet.of(WORKFLOW_DAILY.id()));
     } else {
@@ -142,6 +151,7 @@ public class TriggerManagerTest {
   }
 
   private void setupWithoutNextNaturalTrigger(boolean enabled) throws IOException {
+    when(storage.globalEnabled()).thenReturn(true);
     if (enabled) {
       when(storage.enabled()).thenReturn(ImmutableSet.of(WORKFLOW_DAILY.id()));
     } else {


### PR DESCRIPTION
check global enabled status before triggering all workflows, instead of
checking for each workflow.

this will also force ad-hoc triggering regardless of enabled or not.