### PR TITLE
re-prioritize docker image specs

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -359,19 +359,20 @@ class DatastoreStorage {
   }
 
   Optional<String> getDockerImage(WorkflowId workflowId) throws IOException {
+    Optional<String> dockerImage =
+        workflow(workflowId).flatMap(wf -> wf.schedule().dockerImage());
+    if (dockerImage.isPresent()) {
+      return dockerImage;
+    }
+
     final Key workflowKey = workflowKey(workflowId);
-    Optional<String> dockerImage = getOptStringProperty(datastore, workflowKey, PROPERTY_DOCKER_IMAGE);
+    dockerImage = getOptStringProperty(datastore, workflowKey, PROPERTY_DOCKER_IMAGE);
     if (dockerImage.isPresent()) {
       return dockerImage;
     }
 
     final Key componentKey = componentKeyFactory.newKey(workflowId.componentId());
-    dockerImage = getOptStringProperty(datastore, componentKey, PROPERTY_DOCKER_IMAGE);
-    if (dockerImage.isPresent()) {
-      return dockerImage;
-    }
-
-    return workflow(workflowId).flatMap(wf -> wf.schedule().dockerImage());
+    return getOptStringProperty(datastore, componentKey, PROPERTY_DOCKER_IMAGE);
   }
 
   public WorkflowState workflowState(WorkflowId workflowId) throws IOException {

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -258,42 +258,34 @@ public class DatastoreStorageTest {
   }
 
   @Test
-  public void shouldNotOverwriteDockerImageFromWorkflowWhenUsingComponent() throws Exception {
+  public void shouldOverwriteDockerImageFromWorkflowWhenUsingComponent() throws Exception {
+    storage.store(WORKFLOW_WITH_DOCKER_IMAGE);
     WorkflowState state = patchDockerImage(DOCKER_IMAGE_COMPONENT);
-
-    storage.store(WORKFLOW_WITH_DOCKER_IMAGE);
     storage.patchState(WORKFLOW_WITH_DOCKER_IMAGE.id().componentId(), state);
-    Optional<String> retrieved = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
-    assertThat(retrieved, is(Optional.of(DOCKER_IMAGE_COMPONENT)));
 
-    storage.store(WORKFLOW_WITH_DOCKER_IMAGE);
-    retrieved  = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
-    assertThat(retrieved, is(Optional.of(DOCKER_IMAGE_COMPONENT)));
+    Optional<String> retrieved = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
+    assertThat(retrieved, is(WORKFLOW_WITH_DOCKER_IMAGE.schedule().dockerImage()));
   }
 
   @Test
-  public void shouldNotOverwriteDockerImageFromWorkflowWhenUsingWorkflowId() throws Exception {
+  public void shouldOverwriteDockerImageFromWorkflowWhenUsingWorkflowId() throws Exception {
     storage.store(WORKFLOW_WITH_DOCKER_IMAGE);
     storage.patchState(WORKFLOW_WITH_DOCKER_IMAGE.id(), patchDockerImage(DOCKER_IMAGE_WORKFLOW));
     Optional<String> retrieved = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
-    assertThat(retrieved, is(Optional.of(DOCKER_IMAGE_WORKFLOW)));
-
-    storage.store(WORKFLOW_WITH_DOCKER_IMAGE);
-    retrieved  = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
-    assertThat(retrieved, is(Optional.of(DOCKER_IMAGE_WORKFLOW)));
+    assertThat(retrieved, is(WORKFLOW_WITH_DOCKER_IMAGE.schedule().dockerImage()));
   }
 
   @Test
   public void shouldNotOverwriteDockerImageFromComponentWhenUsingWorkflowId() throws Exception {
     WorkflowState state = patchDockerImage(DOCKER_IMAGE_COMPONENT);
 
-    storage.store(WORKFLOW_WITH_DOCKER_IMAGE);
-    storage.patchState(WORKFLOW_WITH_DOCKER_IMAGE.id(), patchDockerImage(DOCKER_IMAGE_WORKFLOW));
-    Optional<String> retrieved = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
+    storage.store(WORKFLOW_NO_DOCKER_IMAGE);
+    storage.patchState(WORKFLOW_NO_DOCKER_IMAGE.id(), patchDockerImage(DOCKER_IMAGE_WORKFLOW));
+    Optional<String> retrieved = storage.getDockerImage(WORKFLOW_NO_DOCKER_IMAGE.id());
     assertThat(retrieved, is(Optional.of(DOCKER_IMAGE_WORKFLOW)));
 
-    storage.patchState(WORKFLOW_WITH_DOCKER_IMAGE.id().componentId(), state);
-    retrieved = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
+    storage.patchState(WORKFLOW_NO_DOCKER_IMAGE.id().componentId(), state);
+    retrieved = storage.getDockerImage(WORKFLOW_NO_DOCKER_IMAGE.id());
     assertThat(retrieved, is(Optional.of(DOCKER_IMAGE_WORKFLOW)));
   }
 


### PR DESCRIPTION
This PR changes the order in which a docker image specification takes precedence:

old way:
1. docker image as part of state in workflow instance
2. docker image as part of state in component
3. docker image specified in workflow definition (yaml)

new way:
1. docker image specified in workflow definition (yaml)
2. docker image as part of state in workflow instance
3. docker image as part of state in component

The reason for this is that many customers find it more intuitive that a docker image specification in the yaml file should override everything else.

ping @kanterov @Xeago @fabriziodemaria @bergman @honnix 