### PR TITLE
[WIP] Add RateLimiter in Scheduler

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -104,6 +104,11 @@ public class AggregateStorage implements Storage {
   }
 
   @Override
+  public Optional<Double> submissionRate() throws IOException {
+    return datastoreStorage.submissionRate();
+  }
+
+  @Override
   public boolean setGlobalEnabled(boolean enabled) throws IOException {
     return datastoreStorage.setGlobalEnabled(enabled);
   }

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -94,6 +94,7 @@ class DatastoreStorage {
   public static final String PROPERTY_ALL_TRIGGERED = "allTriggered";
   public static final String PROPERTY_HALTED = "halted";
   public static final String PROPERTY_DEBUG_ENABLED = "debug";
+  public static final String PROPERTY_SUBMISSION_RATE = "submissionRate";
 
   public static final String KEY_GLOBAL_CONFIG = "styxGlobal";
 
@@ -600,5 +601,11 @@ class DatastoreStorage {
     return getOpt(datastore, globalConfigKey)
         .filter(e -> e.contains(PROPERTY_CONFIG_CONCURRENCY))
         .map(e -> e.getLong(PROPERTY_CONFIG_CONCURRENCY));
+  }
+
+  public Optional<Double> submissionRate() {
+    return getOpt(datastore, globalConfigKey)
+        .filter(e -> e.contains(PROPERTY_SUBMISSION_RATE))
+        .map(e -> e.getDouble(PROPERTY_SUBMISSION_RATE));
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -51,7 +51,8 @@ import java.util.stream.Collectors;
 public class InMemStorage implements Storage {
 
   private boolean globalEnabled = true;
-  private Optional<Long> globalConcurrency;
+  private Optional<Long> globalConcurrency = Optional.empty();
+  private Optional<Double> submissionRate = Optional.empty();
   private final Set<WorkflowId> enabledWorkflows = Sets.newConcurrentHashSet();
   private final Set<String> components = Sets.newConcurrentHashSet();
   private final ConcurrentMap<WorkflowId, Workflow> workflowStore = Maps.newConcurrentMap();
@@ -82,6 +83,11 @@ public class InMemStorage implements Storage {
   @Override
   public boolean debugEnabled() throws IOException {
     throw new UnsupportedOperationException("Unsupported Operation!");
+  }
+
+  @Override
+  public Optional<Double> submissionRate() throws IOException {
+    return submissionRate;
   }
 
   @Override

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -79,6 +79,11 @@ public interface Storage {
   boolean debugEnabled() throws IOException;
 
   /**
+   * Get the submission rate for Styx.
+   */
+  Optional<Double> submissionRate() throws IOException;
+
+  /**
    * Set the global enabled flag for Styx.
    *
    * @param enabled     The global enabled flag

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -34,6 +34,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.RateLimiter;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.BackfillBuilder;
 import com.spotify.styx.model.Event;
@@ -88,6 +89,7 @@ public class Scheduler {
 
   @VisibleForTesting
   static final String GLOBAL_RESOURCE_ID = "GLOBAL_STYX_CLUSTER";
+  private static final double DEFAULT_SUBMISSION_RATE_PER_SEC = 1000D;
 
   private final Time time;
   private final TimeoutConfig ttls;
@@ -95,18 +97,30 @@ public class Scheduler {
   private final WorkflowCache workflowCache;
   private final Storage storage;
   private final TriggerListener triggerListener;
+  private final RateLimiter rateLimiter;
 
   public Scheduler(Time time, TimeoutConfig ttls, StateManager stateManager,
-                   WorkflowCache workflowCache, Storage storage, TriggerListener triggerListener) {
+                   WorkflowCache workflowCache, Storage storage, TriggerListener triggerListener,
+                   RateLimiter rateLimiter) {
     this.time = Objects.requireNonNull(time);
     this.ttls = Objects.requireNonNull(ttls);
     this.stateManager = Objects.requireNonNull(stateManager);
     this.workflowCache = Objects.requireNonNull(workflowCache);
     this.storage = Objects.requireNonNull(storage);
     this.triggerListener = Objects.requireNonNull(triggerListener);
+    this.rateLimiter = Objects.requireNonNull(rateLimiter);
   }
 
   void tick() {
+    try {
+      Double updatedRate = storage.submissionRate().orElse(DEFAULT_SUBMISSION_RATE_PER_SEC);
+      if (Double.compare(updatedRate, rateLimiter.getRate()) != 0) {
+        rateLimiter.setRate(updatedRate);
+      }
+    } catch (IOException e) {
+      LOG.warn("Failed to fetch the submission rate config from storage, skipping RateLimiter update");
+    }
+
     final Map<String, Resource> resources;
     final Optional<Long> globalConcurrency;
     try {
@@ -164,7 +178,7 @@ public class Scheduler {
               emptySet());
 
       if (resourceRefs.isEmpty()) {
-        sendDequeue(instance);
+        sendDequeueWithThrottling(instance);
       } else {
         evaluateResourcesForDequeue(resources, currentResourceUsage, instance, resourceRefs);
       }
@@ -214,7 +228,7 @@ public class Scheduler {
     } else {
       resourceRefs.forEach(id -> currentResourceUsage.computeIfAbsent(id, id_ -> 0L));
       resourceRefs.forEach(id -> currentResourceUsage.compute(id, (id_, l) -> l + 1));
-      sendDequeue(instance);
+      sendDequeueWithThrottling(instance);
     }
   }
 
@@ -329,10 +343,11 @@ public class Scheduler {
     return !deadline.isAfter(now);
   }
 
-  private void sendDequeue(InstanceState instanceState) {
+  private void sendDequeueWithThrottling(InstanceState instanceState) {
     final WorkflowInstance workflowInstance = instanceState.workflowInstance();
     final RunState state = instanceState.runState();
 
+    rateLimiter.acquire();
     if (state.data().tries() == 0) {
       LOG.info("Triggering {}", workflowInstance.toKey());
     } else {
@@ -352,6 +367,10 @@ public class Scheduler {
         .plus(ttls.ttlOf(runState.state()));
 
     return !deadline.isAfter(now);
+  }
+
+  public static RateLimiter createRateLimiter() {
+    return RateLimiter.create(DEFAULT_SUBMISSION_RATE_PER_SEC);
   }
 
   private void sendTimeout(WorkflowInstance workflowInstance) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -316,7 +316,7 @@ public class StyxScheduler implements AppInit {
     final TriggerManager triggerManager = new TriggerManager(trigger, time, storage);
 
     final Scheduler scheduler = new Scheduler(time, timeoutConfig, stateManager, workflowCache,
-                                              storage, trigger);
+                                              storage, trigger, Scheduler.createRateLimiter());
 
     final Consumer<Workflow> workflowChangeListener = workflowChanged(workflowCache, storage,
                                                                       stats, stateManager, time);


### PR DESCRIPTION
This is one of two proposed solutions for implementing throttling of the rate of creation of Docker containers from the scheduler.
The other path to be investigated aims at adding the throttler in the DockerOutputHandler instead.