### PR TITLE
upgrade bigtable-hbase-1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
       <dependency>
         <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-1.1</artifactId>
-        <version>0.9.3</version>
+        <version>0.9.5.1</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
@@ -268,9 +268,29 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>1.9</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>3.2.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.5</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>4.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-common</artifactId>
+        <version>2.5.1</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp</groupId>
@@ -305,7 +325,7 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>3.0.0-beta-3</version>
+        <version>3.0.2</version>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
@@ -313,9 +333,9 @@
         <version>0.0.16</version>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-all</artifactId>
-        <version>4.1.1.Final</version>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
this version includes netty 4.1.6.Final which fixed a memory leak. Similar issue has been reported here. https://github.com/grpc/grpc-java/issues/2358

Due to maven upper bound rule, a few transit dependencies have been bumped.