### PR TITLE
Get container exit code reliably

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
@@ -54,27 +54,12 @@ public final class KubernetesPodEventTranslator {
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   private static class TerminationLogMessage {
-    String componentId;
-    String workflowId;
-    String parameter;
-    String executionId;
-    String event;
     int exitCode;
 
     @JsonCreator
     public TerminationLogMessage(
-        @JsonProperty(value = "component_id", required = true) String componentId,
-        @JsonProperty(value = "workflow_id", required = true) String workflowId,
-        @JsonProperty(value = "parameter", required = true) String parameter,
-        @JsonProperty(value = "execution_id", required = true) String executionId,
-        @JsonProperty(value = "event", required = true) String event,
         @JsonProperty(value = "exit_code", required = true) int exitCode
     ) {
-      this.componentId = componentId;
-      this.workflowId = workflowId;
-      this.parameter = parameter;
-      this.executionId = executionId;
-      this.event = event;
       this.exitCode = exitCode;
     }
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
@@ -127,7 +127,9 @@ class LocalDockerRunner implements DockerRunner {
       }
 
       if (!containerInfo.state().running()) {
-        final int exitCode = containerInfo.state().exitCode(); // FIXME
+        // Unlike in KubernetesDockerRunner case, where docker_termination_logging is supported,
+        // here we are susceptible to Docker exit code bug, https://github.com/kubernetes/kubernetes/issues/41516.
+        final int exitCode = containerInfo.state().exitCode();
         final WorkflowInstance workflowInstance = inFlight.remove(containerId);
 
         // trigger started event if we didn't see the container in running before

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -135,7 +135,7 @@ public class KubernetesDockerRunnerTest {
 
   @Test
   public void shouldCompleteWithStatusCodeOnSucceeded() throws Exception {
-    createdPod.setStatus(terminated("Succeeded", 20));
+    createdPod.setStatus(terminated("Succeeded", 20, null));
     podWatcher.eventReceived(Watcher.Action.MODIFIED, createdPod);
 
     assertThat(stateManager.get(WORKFLOW_INSTANCE).data().lastExit(), hasValue(20));
@@ -216,7 +216,7 @@ public class KubernetesDockerRunnerTest {
   public void shouldDiscardChangesForOldExecutions() throws Exception {
     // simulate event from different pod, but still with the same workflow instance annotation
     createdPod.getMetadata().setName(POD_NAME + "-other");
-    createdPod.setStatus(terminated("Succeeded", 20));
+    createdPod.setStatus(terminated("Succeeded", 20, null));
 
     podWatcher.eventReceived(Watcher.Action.MODIFIED, createdPod);
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -127,7 +127,7 @@ public class KubernetesPodEventTranslatorTest {
   }
 
   @Test
-  public void terminateEvent_withTerminationLoggingButNoMessage_shouldHaveErrorExitCode() throws Exception {
+  public void errorExitCodeOnTerminationLoggingButNoMessage() throws Exception {
     Pod pod = podWithTerminationLogging();
     pod.setStatus(terminated("Succeeded", 0, null));
 
@@ -138,7 +138,7 @@ public class KubernetesPodEventTranslatorTest {
   }
 
   @Test
-  public void terminateEvent_withTerminationLoggingButInvalidJson_shouldHaveErrorExitCode() throws Exception {
+  public void errorExitCodeOnTerminationLoggingButInvalidJson() throws Exception {
     Pod pod = podWithTerminationLogging();
     pod.setStatus(terminated("Succeeded", 0, "SUCCESS"));
 
@@ -148,7 +148,7 @@ public class KubernetesPodEventTranslatorTest {
         Event.terminate(WFI, 127));
   }
   @Test
-  public void terminateEvent_withTerminationLoggingButPartialJson_shouldHaveErrorExitCode() throws Exception {
+  public void errorExitCodeOnTerminationLoggingButPartialJson() throws Exception {
     Pod pod = podWithTerminationLogging();
     pod.setStatus(terminated("Succeeded", 0, "{\"exit_code\":0}"));
 
@@ -159,7 +159,7 @@ public class KubernetesPodEventTranslatorTest {
   }
 
   @Test
-  public void terminateEvent_withTerminationLoggingAndZeroExitCode_shouldHaveExitCodeFromMessage() throws Exception {
+  public void exitCodeFromMessageOnTerminationLoggingAndZeroExitCode() throws Exception {
     Pod pod = podWithTerminationLogging();
     pod.setStatus(terminated("Succeeded", 0, String.format(MESSAGE_FORMAT, 1)));
 
@@ -170,7 +170,7 @@ public class KubernetesPodEventTranslatorTest {
   }
 
   @Test
-  public void terminateEvent_withTerminationLoggingAndNonzeroExitCode_shouldHaveExitCodeFromMessage() throws Exception {
+  public void exitCodeFromMessageOnTerminationLoggingAndNonzeroExitCode() throws Exception {
     Pod pod = podWithTerminationLogging();
     pod.setStatus(terminated("Failed", 2, String.format(MESSAGE_FORMAT, 3)));
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -50,12 +50,13 @@ public class KubernetesPodEventTranslatorTest {
       WorkflowInstance.create(TestData.WORKFLOW_ID, "foo");
   private static final DockerRunner.RunSpec RUN_SPEC =
       DockerRunner.RunSpec.create("busybox", ImmutableList.of(), false, Optional.empty());
+  private static String MESSAGE_FORMAT = "{\"rfu\":{\"dum\":\"my\"},\"component_id\":\"dummy\",\"workflow_id\":\"dummy\",\"parameter\":\"dummy\",\"execution_id\":\"dummy\",\"event\":\"dummy\",\"exit_code\":%d}\n";
 
   Pod pod = KubernetesDockerRunner.createPod(WFI, RUN_SPEC);
 
   @Test
   public void terminateOnSuccessfulTermination() throws Exception {
-    pod.setStatus(terminated("Succeeded", 20));
+    pod.setStatus(terminated("Succeeded", 20, null));
 
     assertGeneratesEventsAndTransitions(
         RunState.State.RUNNING, pod,
@@ -64,7 +65,7 @@ public class KubernetesPodEventTranslatorTest {
 
   @Test
   public void startedAndTerminatedOnFromSubmitted() throws Exception {
-    pod.setStatus(terminated("Succeeded", 0));
+    pod.setStatus(terminated("Succeeded", 0, null));
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -126,6 +127,69 @@ public class KubernetesPodEventTranslatorTest {
   }
 
   @Test
+  public void terminateEvent_withTerminationLoggingButNoMessage_shouldHaveErrorExitCode() throws Exception {
+    Pod pod = podWithTerminationLogging();
+    pod.setStatus(terminated("Succeeded", 0, null));
+
+    assertGeneratesEventsAndTransitions(
+        RunState.State.SUBMITTED, pod,
+        Event.started(WFI),
+        Event.terminate(WFI, 127));
+  }
+
+  @Test
+  public void terminateEvent_withTerminationLoggingButInvalidJson_shouldHaveErrorExitCode() throws Exception {
+    Pod pod = podWithTerminationLogging();
+    pod.setStatus(terminated("Succeeded", 0, "SUCCESS"));
+
+    assertGeneratesEventsAndTransitions(
+        RunState.State.SUBMITTED, pod,
+        Event.started(WFI),
+        Event.terminate(WFI, 127));
+  }
+  @Test
+  public void terminateEvent_withTerminationLoggingButPartialJson_shouldHaveErrorExitCode() throws Exception {
+    Pod pod = podWithTerminationLogging();
+    pod.setStatus(terminated("Succeeded", 0, "{\"exit_code\":0}"));
+
+    assertGeneratesEventsAndTransitions(
+        RunState.State.SUBMITTED, pod,
+        Event.started(WFI),
+        Event.terminate(WFI, 127));
+  }
+
+  @Test
+  public void terminateEvent_withTerminationLoggingAndZeroExitCode_shouldHaveExitCodeFromMessage() throws Exception {
+    Pod pod = podWithTerminationLogging();
+    pod.setStatus(terminated("Succeeded", 0, String.format(MESSAGE_FORMAT, 1)));
+
+    assertGeneratesEventsAndTransitions(
+        RunState.State.SUBMITTED, pod,
+        Event.started(WFI),
+        Event.terminate(WFI, 1));
+  }
+
+  @Test
+  public void terminateEvent_withTerminationLoggingAndNonzeroExitCode_shouldHaveExitCodeFromMessage() throws Exception {
+    Pod pod = podWithTerminationLogging();
+    pod.setStatus(terminated("Failed", 2, String.format(MESSAGE_FORMAT, 3)));
+
+    assertGeneratesEventsAndTransitions(
+        RunState.State.SUBMITTED, pod,
+        Event.started(WFI),
+        Event.terminate(WFI, 3));
+
+    // and even if the code from the message astonishingly signals success...
+    pod = podWithTerminationLogging();
+    pod.setStatus(terminated("Failed", 4, String.format(MESSAGE_FORMAT, 0)));
+
+    assertGeneratesEventsAndTransitions(
+        RunState.State.SUBMITTED, pod,
+        Event.started(WFI),
+        Event.terminate(WFI, 0));
+  }
+
+  @Test
   public void noEventsWhenStateInTerminated() throws Exception {
     pod.setStatus(podStatusNoContainer("Unknown"));
 
@@ -141,7 +205,7 @@ public class KubernetesPodEventTranslatorTest {
 
   @Test
   public void shouldIgnoreDeletedEvents() throws Exception {
-    pod.setStatus(terminated("Succeeded", 0));
+    pod.setStatus(terminated("Succeeded", 0, null));
     RunState state = RunState.create(WFI, RunState.State.TERMINATED);
 
     List<Event> events = translate(WFI, state, Watcher.Action.DELETED, pod);
@@ -180,10 +244,10 @@ public class KubernetesPodEventTranslatorTest {
         null));
   }
 
-  static PodStatus terminated(String phase, int exitCode) {
+  static PodStatus terminated(String phase, int exitCode, String message) {
     return podStatus(phase, true, new ContainerState(
         null,
-        new ContainerStateTerminated("", exitCode, "", "", "", 0, ""),
+        new ContainerStateTerminated("", exitCode, "", message, "", 0, ""),
         null));
   }
 
@@ -204,5 +268,11 @@ public class KubernetesPodEventTranslatorTest {
 
   static PodStatus podStatusNoContainer(String phase) {
     return new PodStatus(emptyList(), Lists.newArrayList(), "", "", phase, "", "", "");
+  }
+
+  private Pod podWithTerminationLogging() {
+    return KubernetesDockerRunner.createPod(
+        WFI,
+        DockerRunner.RunSpec.create("busybox", ImmutableList.of(), true, Optional.empty()));
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -150,7 +150,7 @@ public class KubernetesPodEventTranslatorTest {
   @Test
   public void errorExitCodeOnTerminationLoggingButPartialJson() throws Exception {
     Pod pod = podWithTerminationLogging();
-    pod.setStatus(terminated("Succeeded", 0, "{\"exit_code\":0}"));
+    pod.setStatus(terminated("Succeeded", 0, "{\"workflow_id\":\"dummy\"}"));
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,


### PR DESCRIPTION
This is a kludge to work around a Docker [exit code bug](https://github.com/kubernetes/kubernetes/issues/41516).

Now, when docker_termination_logging is set to "true" for the scheduled workflow at submission time, a message in the termination log will be expected for determination of the container exit status.