### PR TITLE
use the correct termination log file

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -152,7 +152,7 @@ class KubernetesDockerRunner implements DockerRunner {
         .build());
     env.add(new EnvVarBuilder()
         .withName(TERMINATION_LOG)
-        .withValue("/termination-log")
+        .withValue("/dev/termination-log")
         .build());
 
     PodBuilder podBuilder = new PodBuilder()

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
@@ -124,7 +124,7 @@ public class KubernetesDockerRunnerPodResourceTest {
     List<Container> containers = pod.getSpec().getContainers();
     Optional<EnvVar> terminationLogVar = containers.get(0).getEnv().stream()
         .filter(e -> TERMINATION_LOG.equals(e.getName())).findAny();
-    assertThat(terminationLogVar.get().getValue(), is("/termination-log"));
+    assertThat(terminationLogVar.get().getValue(), is("/dev/termination-log"));
   }
 
   @Test
@@ -140,7 +140,7 @@ public class KubernetesDockerRunnerPodResourceTest {
     List<Container> containers = pod.getSpec().getContainers();
     Optional<EnvVar> terminationLogVar = containers.get(0).getEnv().stream()
         .filter(e -> TERMINATION_LOG.equals(e.getName())).findAny();
-    assertThat(terminationLogVar.get().getValue(), is("/termination-log"));
+    assertThat(terminationLogVar.get().getValue(), is("/dev/termination-log"));
   }
 
   @Test


### PR DESCRIPTION
The default Kubernetes termination message path: https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#setting-the-termination-log-file