### PR TITLE
v2 API and new model

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -31,8 +31,9 @@ import com.spotify.apollo.AppInit;
 import com.spotify.apollo.Environment;
 import com.spotify.apollo.route.Route;
 import com.spotify.styx.api.BackfillResource;
-import com.spotify.styx.api.CliResource;
 import com.spotify.styx.api.ResourceResource;
+import com.spotify.styx.api.SchedulerResource;
+import com.spotify.styx.api.StatusResource;
 import com.spotify.styx.api.StyxConfigResource;
 import com.spotify.styx.api.WorkflowResource;
 import com.spotify.styx.storage.AggregateStorage;
@@ -101,22 +102,41 @@ public class StyxApi implements AppInit {
     final Storage storage = storageFactory.apply(environment);
 
     final WorkflowResource workflowResource = new WorkflowResource(storage);
-    final ResourceResource resourceResource = new ResourceResource(storage);
     final BackfillResource backfillResource = new BackfillResource(schedulerServiceBaseUrl, storage);
+    final ResourceResource resourceResource = new ResourceResource(storage);
     final StyxConfigResource styxConfigResource = new StyxConfigResource(storage);
-    final CliResource cliResource = new CliResource(schedulerServiceBaseUrl, storage);
+    final StatusResource statusResource = new StatusResource(storage);
+    final SchedulerResource schedulerResource = new SchedulerResource(schedulerServiceBaseUrl);
+
+    final com.spotify.styx.api.deprecated.WorkflowResource
+        deprecatedWorkflowResource =
+        new com.spotify.styx.api.deprecated.WorkflowResource(workflowResource);
+    final com.spotify.styx.api.deprecated.BackfillResource
+        deprecatedBackfillResource =
+        new com.spotify.styx.api.deprecated.BackfillResource(backfillResource);
+    final com.spotify.styx.api.deprecated.CliResource
+        deprecatedCliResource =
+        new com.spotify.styx.api.deprecated.CliResource(statusResource, schedulerServiceBaseUrl);
 
     final Supplier<Optional<List<String>>> clientBlacklistSupplier =
         new CachedSupplier<>(storage::clientBlacklist, Instant::now);
 
     environment.routingEngine()
         .registerAutoRoute(Route.sync("GET", "/ping", rc -> "pong"))
+        // TODO remove deprecated resources
+        .registerRoutes(deprecatedWorkflowResource.routes())
+        .registerRoutes(deprecatedBackfillResource.routes()
+                            .map(r -> r.withMiddleware(clientValidator(clientBlacklistSupplier))))
+        .registerRoutes(deprecatedCliResource.routes()
+                            .map(r -> r.withMiddleware(clientValidator(clientBlacklistSupplier))))
         .registerRoutes(workflowResource.routes())
-        .registerRoutes(resourceResource.routes())
         .registerRoutes(backfillResource.routes()
                             .map(r -> r.withMiddleware(clientValidator(clientBlacklistSupplier))))
+        .registerRoutes(resourceResource.routes())
         .registerRoutes(styxConfigResource.routes())
-        .registerRoutes(cliResource.routes()
+        .registerRoutes(statusResource.routes()
+                            .map(r -> r.withMiddleware(clientValidator(clientBlacklistSupplier))))
+        .registerRoutes(schedulerResource.routes()
                             .map(r -> r.withMiddleware(clientValidator(clientBlacklistSupplier))));
   }
 

--- a/styx-api-service/src/main/java/com/spotify/styx/api/Api.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/Api.java
@@ -27,17 +27,17 @@ import java.util.Collection;
 import java.util.stream.Stream;
 import okio.ByteString;
 
-final class Api {
+public final class Api {
 
-  enum Version {
-    V0, V1;
+  public enum Version {
+    V0, V1, V2;
 
     public String prefix() {
       return "/api/v" + ordinal();
     }
   }
 
-  static Stream<Route<AsyncHandler<Response<ByteString>>>> prefixRoutes(
+  public static Stream<Route<AsyncHandler<Response<ByteString>>>> prefixRoutes(
       Collection<Route<AsyncHandler<Response<ByteString>>>> routes,
       Version... versions) {
     return Stream.of(versions)

--- a/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
@@ -2,7 +2,7 @@
  * -\-\-
  * Spotify Styx API Service
  * --
- * Copyright (C) 2016 Spotify AB
+ * Copyright (C) 2017 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 package com.spotify.styx.api;
 
 import static com.spotify.apollo.StatusType.Family.SUCCESSFUL;
-import static com.spotify.styx.api.Api.Version.V1;
+import static com.spotify.styx.api.Api.Version.V2;
 import static com.spotify.styx.serialization.Json.serialize;
 import static com.spotify.styx.util.ParameterUtil.rangeOfInstants;
 import static com.spotify.styx.util.ParameterUtil.toParameter;
@@ -42,8 +42,7 @@ import com.spotify.apollo.route.AsyncHandler;
 import com.spotify.apollo.route.Middleware;
 import com.spotify.apollo.route.Route;
 import com.spotify.futures.CompletableFutures;
-import com.spotify.styx.api.cli.RunStateDataPayload;
-import com.spotify.styx.api.cli.RunStateDataPayload.RunStateData;
+import com.spotify.styx.api.RunStateDataPayload.RunStateData;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.BackfillBuilder;
 import com.spotify.styx.model.BackfillInput;
@@ -119,12 +118,12 @@ public final class BackfillResource {
     );
 
     return cat(
-        Api.prefixRoutes(entityRoutes, V1),
-        Api.prefixRoutes(routes, V1)
+        Api.prefixRoutes(entityRoutes, V2),
+        Api.prefixRoutes(routes, V2)
     );
   }
 
-  private BackfillsPayload getBackfills(RequestContext rc) {
+  public BackfillsPayload getBackfills(RequestContext rc) {
     final Optional<String> componentOpt = rc.request().parameter("component");
     final Optional<String> workflowOpt = rc.request().parameter("workflow");
     final boolean includeStatuses = rc.request().parameter("status").orElse("false").equals("true");
@@ -159,7 +158,7 @@ public final class BackfillResource {
     return BackfillsPayload.create(backfillPayloads);
   }
 
-  private Response<BackfillPayload> getBackfill(String id) {
+  public Response<BackfillPayload> getBackfill(String id) {
     try {
       final Optional<Backfill> backfillOpt = storage.backfill(id);
       if (backfillOpt.isPresent()) {
@@ -178,7 +177,7 @@ public final class BackfillResource {
     return schedulerServiceBaseUrl + SCHEDULER_BASE_PATH + "/" + String.join("/", parts);
   }
 
-  private CompletionStage<Response<ByteString>> haltBackfill(String id, RequestContext rc) {
+  public CompletionStage<Response<ByteString>> haltBackfill(String id, RequestContext rc) {
     try {
       final Optional<Backfill> backfillOptional = storage.backfill(id);
       if (backfillOptional.isPresent()) {
@@ -216,7 +215,7 @@ public final class BackfillResource {
   }
 
   private CompletionStage<Boolean> haltActiveBackfillInstance(WorkflowInstance workflowInstance,
-                                                                Client client) {
+                                                              Client client) {
     try {
       final ByteString payload = serialize(Event.halt(workflowInstance));
       final Request request = Request.forUri(schedulerApiUrl("events"), "POST")
@@ -237,7 +236,7 @@ public final class BackfillResource {
     }
   }
 
-  private Response<Backfill> postBackfill(BackfillInput input) {
+  public Response<Backfill> postBackfill(BackfillInput input) {
     final BackfillBuilder builder = Backfill.newBuilder();
 
     final String id = RandomGenerator.DEFAULT.generateUniqueId("backfill");
@@ -303,7 +302,7 @@ public final class BackfillResource {
     return Response.forPayload(backfill);
   }
 
-  private Response<Backfill> updateBackfill(String id, Backfill backfill) {
+  public Response<Backfill> updateBackfill(String id, Backfill backfill) {
     if (!backfill.id().equals(id)) {
       return Response.forStatus(
           Status.BAD_REQUEST.withReasonPhrase("ID of payload does not match ID in uri."));

--- a/styx-api-service/src/main/java/com/spotify/styx/api/ResourceResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/ResourceResource.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.api;
 
 import static com.spotify.styx.api.Api.Version.V1;
+import static com.spotify.styx.api.Api.Version.V2;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.base.Throwables;
@@ -81,7 +82,7 @@ public final class ResourceResource {
         .map(r -> r.withMiddleware(Middleware::syncToAsync))
         .collect(toList());
 
-    return Api.prefixRoutes(routes, V1);
+    return Api.prefixRoutes(routes, V1, V2);
   }
 
   private ResourcesPayload getResources() {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
@@ -1,0 +1,76 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api;
+
+import static com.spotify.styx.api.Api.Version.V2;
+
+import com.spotify.apollo.RequestContext;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.route.AsyncHandler;
+import com.spotify.apollo.route.Route;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
+import okio.ByteString;
+
+/**
+ * API endpoints for scheduler
+ */
+public class SchedulerResource {
+
+  static final String BASE = "/scheduler";
+  private static final String SCHEDULER_BASE_PATH = "/api/v0";
+
+  private final String schedulerServiceBaseUrl;
+
+  public SchedulerResource(String schedulerServiceBaseUrl) {
+    this.schedulerServiceBaseUrl = Objects.requireNonNull(schedulerServiceBaseUrl);
+  }
+
+  public Stream<? extends Route<? extends AsyncHandler<? extends Response<ByteString>>>> routes() {
+    final List<Route<AsyncHandler<Response<ByteString>>>> schedulerProxies = Arrays.asList(
+        Route.async(
+            "GET", BASE + "/<endpoint:path>",
+            rc -> proxyToScheduler("/" + rc.pathArgs().get("endpoint"), rc)),
+        Route.async(
+            "POST", BASE + "/<endpoint:path>",
+            rc -> proxyToScheduler("/" + rc.pathArgs().get("endpoint"), rc)),
+        Route.async(
+            "DELETE", BASE + "/<endpoint:path>",
+            rc -> proxyToScheduler("/" + rc.pathArgs().get("endpoint"), rc)),
+        Route.async(
+            "PATCH", BASE + "/<endpoint:path>",
+            rc -> proxyToScheduler("/" + rc.pathArgs().get("endpoint"), rc)),
+        Route.async(
+            "PUT", BASE + "/<endpoint:path>",
+            rc -> proxyToScheduler("/" + rc.pathArgs().get("endpoint"), rc))
+    );
+
+    return Api.prefixRoutes(schedulerProxies, V2);
+  }
+
+  private CompletionStage<Response<ByteString>> proxyToScheduler(String path, RequestContext rc) {
+    return rc.requestScopedClient()
+        .send(rc.request().withUri(schedulerServiceBaseUrl + SCHEDULER_BASE_PATH + path));
+  }
+}

--- a/styx-api-service/src/main/java/com/spotify/styx/api/StyxConfigResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/StyxConfigResource.java
@@ -22,6 +22,7 @@ package com.spotify.styx.api;
 
 import static com.spotify.styx.api.Api.Version.V0;
 import static com.spotify.styx.api.Api.Version.V1;
+import static com.spotify.styx.api.Api.Version.V2;
 import static com.spotify.styx.api.Middlewares.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -43,7 +44,7 @@ import okio.ByteString;
 
 public class StyxConfigResource {
 
-  private static final String BASE = "/config";
+  static final String BASE = "/config";
 
   private final Storage storage;
 
@@ -52,7 +53,7 @@ public class StyxConfigResource {
   }
 
   public Stream<? extends Route<? extends AsyncHandler<? extends Response<ByteString>>>> routes() {
-    final List<Route<AsyncHandler<Response<ByteString>>>> v0 = Arrays.asList(
+    final List<Route<AsyncHandler<Response<ByteString>>>> routes = Arrays.asList(
         Route.with(
             json(), "GET", BASE,
             rc -> styxConfig()),
@@ -61,7 +62,7 @@ public class StyxConfigResource {
             rc -> patchStyxConfig(rc.request()))
     );
 
-    return Api.prefixRoutes(v0, V0, V1);
+    return Api.prefixRoutes(routes, V0, V1, V2);
   }
 
   private Response<StyxConfig> styxConfig() {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/deprecated/BackfillResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/deprecated/BackfillResource.java
@@ -1,0 +1,129 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Service
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api.deprecated;
+
+import static com.spotify.styx.api.Api.Version.V1;
+import static com.spotify.styx.util.StreamUtil.cat;
+import static java.util.stream.Collectors.toList;
+
+import com.spotify.apollo.RequestContext;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.entity.EntityMiddleware;
+import com.spotify.apollo.entity.JacksonEntityCodec;
+import com.spotify.apollo.route.AsyncHandler;
+import com.spotify.apollo.route.Middleware;
+import com.spotify.apollo.route.Route;
+import com.spotify.styx.api.Api;
+import com.spotify.styx.model.BackfillInput;
+import com.spotify.styx.model.deprecated.Backfill;
+import com.spotify.styx.serialization.Json;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
+import okio.ByteString;
+
+@Deprecated
+public final class BackfillResource {
+
+  static final String BASE = "/backfills";
+
+  private final com.spotify.styx.api.BackfillResource backfillResource;
+
+  public BackfillResource(com.spotify.styx.api.BackfillResource backfillResource) {
+    this.backfillResource = Objects.requireNonNull(backfillResource);
+  }
+
+  public Stream<? extends Route<? extends AsyncHandler<? extends Response<ByteString>>>> routes() {
+    final EntityMiddleware em =
+        EntityMiddleware.forCodec(JacksonEntityCodec.forMapper(Json.OBJECT_MAPPER));
+
+    final List<Route<AsyncHandler<Response<ByteString>>>> entityRoutes = Stream.of(
+        Route.with(
+            em.serializerDirect(BackfillsPayload.class),
+            "GET", BASE,
+            this::getBackfills),
+        Route.with(
+            em.response(BackfillInput.class, Backfill.class),
+            "POST", BASE,
+            rc -> this::postBackfill),
+        Route.with(
+            em.serializerResponse(BackfillPayload.class),
+            "GET", BASE + "/<bid>",
+            rc -> getBackfill(arg("bid", rc))),
+        Route.with(
+            em.response(Backfill.class),
+            "PUT", BASE + "/<bid>",
+            rc -> payload -> updateBackfill(arg("bid", rc), payload))
+    )
+        .map(r -> r.withMiddleware(Middleware::syncToAsync))
+        .collect(toList());
+
+    final List<Route<AsyncHandler<Response<ByteString>>>> routes = Collections.singletonList(
+        Route.async(
+            "DELETE", BASE + "/<bid>",
+            rc -> haltBackfill(arg("bid", rc), rc))
+    );
+
+    return cat(
+        Api.prefixRoutes(entityRoutes, V1),
+        Api.prefixRoutes(routes, V1)
+    );
+  }
+
+  private BackfillsPayload getBackfills(RequestContext requestContext) {
+    return BackfillsPayload.create(backfillResource.getBackfills(requestContext));
+  }
+
+  private Response<BackfillPayload> getBackfill(String id) {
+    final Response<com.spotify.styx.api.BackfillPayload> response = backfillResource.getBackfill(id);
+    return backfillResource.getBackfill(id).payload()
+        .map(BackfillPayload::create)
+        .map(Response::forPayload)
+        .orElse(Response.forStatus(response.status()));
+  }
+
+  private CompletionStage<Response<ByteString>> haltBackfill(String id, RequestContext rc) {
+    return backfillResource.haltBackfill(id, rc);
+  }
+
+  private Response<Backfill> postBackfill(BackfillInput input) {
+    final Response<com.spotify.styx.model.Backfill> response = backfillResource.postBackfill(input);
+    return response.payload()
+        .map(Backfill::create)
+        .map(Response::forPayload)
+        .orElse(Response.forStatus(response.status()));
+  }
+
+  private Response<Backfill> updateBackfill(String id, Backfill backfill) {
+    final Response<com.spotify.styx.model.Backfill> response =
+        backfillResource.updateBackfill(id, Backfill.create(backfill));
+    return response.payload()
+        .map(Backfill::create)
+        .map(Response::forPayload)
+        .orElse(Response.forStatus(response.status()));
+  }
+
+  private static String arg(String name, RequestContext rc) {
+    return rc.pathArgs().get(name);
+  }
+}

--- a/styx-api-service/src/main/java/com/spotify/styx/api/deprecated/CliResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/deprecated/CliResource.java
@@ -1,0 +1,144 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Service
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api.deprecated;
+
+import static com.spotify.styx.api.Api.Version.V0;
+import static com.spotify.styx.api.Api.Version.V1;
+import static com.spotify.styx.util.StreamUtil.cat;
+import static java.util.stream.Collectors.toList;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.api.client.repackaged.com.google.common.base.Throwables;
+import com.spotify.apollo.Request;
+import com.spotify.apollo.RequestContext;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.entity.EntityMiddleware;
+import com.spotify.apollo.entity.JacksonEntityCodec;
+import com.spotify.apollo.route.AsyncHandler;
+import com.spotify.apollo.route.Middleware;
+import com.spotify.apollo.route.Route;
+import com.spotify.styx.api.Api;
+import com.spotify.styx.api.EventsPayload;
+import com.spotify.styx.api.StatusResource;
+import com.spotify.styx.model.deprecated.WorkflowInstance;
+import com.spotify.styx.serialization.Json;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
+import okio.ByteString;
+
+/**
+ * API endpoints for the cli
+ */
+@Deprecated
+public class CliResource {
+
+  static final String BASE = "/cli";
+  private static final String SCHEDULER_BASE_PATH = "/api/v0";
+  private static final String EVENTS_PATH = "/events";
+  private static final String TRIGGER_PATH = "/trigger";
+
+  private final StatusResource statusResource;
+  private final String schedulerServiceBaseUrl;
+
+  public CliResource(StatusResource statusResource, String schedulerServiceBaseUrl) {
+    this.statusResource = Objects.requireNonNull(statusResource);
+    this.schedulerServiceBaseUrl = Objects.requireNonNull(schedulerServiceBaseUrl);
+  }
+
+  public Stream<? extends Route<? extends AsyncHandler<? extends Response<ByteString>>>> routes() {
+    final EntityMiddleware em =
+        EntityMiddleware.forCodec(JacksonEntityCodec.forMapper(Json.OBJECT_MAPPER));
+
+    final List<Route<AsyncHandler<Response<ByteString>>>> routes = Stream.of(
+        Route.with(
+            em.serializerDirect(RunStateDataPayload.class),
+            "GET", BASE + "/activeStates",
+            this::activeStates),
+        Route.with(
+            em.serializerDirect(EventsPayload.class),
+            "GET", BASE + "/events/<cid>/<eid>/<iid>",
+            rc -> eventsForWorkflowInstance(arg("cid", rc), arg("eid", rc), arg("iid", rc))))
+
+        .map(r -> r.withMiddleware(Middleware::syncToAsync))
+        .collect(toList());
+
+    final List<Route<AsyncHandler<Response<ByteString>>>> schedulerProxies = Stream.of(
+        Route.async(
+            "POST", BASE + EVENTS_PATH,
+            this::proxyEvent),
+        Route.with(
+            em.asyncResponse(WorkflowInstance.class),
+            "POST", BASE + TRIGGER_PATH,
+            rc -> workflowInstance -> proxyTrigger(workflowInstance, rc)))
+        .collect(toList());
+
+    return cat(
+        Api.prefixRoutes(routes, V0, V1),
+        Api.prefixRoutes(schedulerProxies, V0, V1)
+    );
+  }
+
+  private CompletionStage<Response<ByteString>> proxyEvent(RequestContext rc) {
+    return rc.requestScopedClient()
+        .send(rc.request().withUri(schedulerServiceBaseUrl + SCHEDULER_BASE_PATH + EVENTS_PATH));
+  }
+
+
+  private CompletionStage<Response<WorkflowInstance>> proxyTrigger(
+      WorkflowInstance workflowInstance, RequestContext rc) {
+    final ByteString payload;
+    try {
+      payload = Json.serialize(WorkflowInstance.create(workflowInstance));
+    } catch (JsonProcessingException e) {
+      throw Throwables.propagate(e);
+    }
+    final Request request =
+        Request.forUri(schedulerServiceBaseUrl + SCHEDULER_BASE_PATH + TRIGGER_PATH)
+            .withPayload(payload);
+    return rc.requestScopedClient().send(request).thenApply(response -> {
+      final com.spotify.styx.model.WorkflowInstance responsePayload;
+      try {
+        responsePayload = Json.deserialize(response.payload().get(),
+                             com.spotify.styx.model.WorkflowInstance.class);
+      } catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+      return Response.forStatus(response.status())
+          .withPayload(WorkflowInstance.create(responsePayload))
+          .withHeaders(response.headers());
+    });
+  }
+
+  private static String arg(String name, RequestContext rc) {
+    return rc.pathArgs().get(name);
+  }
+
+  private RunStateDataPayload activeStates(RequestContext requestContext) {
+    return RunStateDataPayload.create(statusResource.activeStates(requestContext));
+  }
+
+  private EventsPayload eventsForWorkflowInstance(String cid, String eid, String iid) {
+    return statusResource.eventsForWorkflowInstance(cid, eid, iid);
+  }
+}

--- a/styx-api-service/src/main/java/com/spotify/styx/api/deprecated/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/deprecated/WorkflowResource.java
@@ -1,0 +1,139 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Service
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api.deprecated;
+
+import static com.spotify.styx.api.Api.Version.V0;
+import static com.spotify.styx.api.Api.Version.V1;
+import static com.spotify.styx.api.Middlewares.json;
+import static com.spotify.styx.util.StreamUtil.cat;
+
+import com.spotify.apollo.Request;
+import com.spotify.apollo.RequestContext;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.Status;
+import com.spotify.apollo.route.AsyncHandler;
+import com.spotify.apollo.route.Route;
+import com.spotify.styx.api.Api;
+import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.data.deprecated.WorkflowInstanceExecutionData;
+import com.spotify.styx.model.deprecated.Workflow;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import okio.ByteString;
+
+@Deprecated
+public final class WorkflowResource {
+
+  static final String BASE = "/workflows";
+  private com.spotify.styx.api.WorkflowResource workflowResource;
+
+  public WorkflowResource(com.spotify.styx.api.WorkflowResource workflowResource) {
+    this.workflowResource = Objects.requireNonNull(workflowResource);
+  }
+
+  public Stream<? extends Route<? extends AsyncHandler<? extends Response<ByteString>>>> routes() {
+    final List<Route<AsyncHandler<Response<ByteString>>>> v0Routes = Arrays.asList(
+        Route.with(
+            json(), "GET", BASE + "/<cid>/<eid>",
+            rc -> workflow(arg("cid", rc), arg("eid", rc))),
+        Route.with(
+            json(), "GET", BASE + "/<cid>/<eid>/instances",
+            rc -> Response.forStatus(Status.NOT_FOUND.withReasonPhrase("Use v1 api"))),
+        Route.with(
+            json(), "GET", BASE + "/<cid>/<eid>/instances/<iid>",
+            rc -> Response.forStatus(Status.NOT_FOUND.withReasonPhrase("Use v1 api"))),
+        Route.with(
+            json(), "GET", BASE + "/<cid>/<eid>/state",
+            rc -> state(arg("cid", rc), arg("eid", rc))),
+        Route.with(
+            json(), "PATCH", BASE + "/<cid>/<eid>/state",
+            rc -> patchState(arg("cid", rc), arg("eid", rc), rc.request())),
+        Route.with(
+            json(), "PATCH", BASE + "/<cid>/state",
+            rc -> patchState(arg("cid", rc), rc.request()))
+    );
+
+    final List<Route<AsyncHandler<Response<ByteString>>>> v1Routes = Arrays.asList(
+        Route.with(
+            json(), "GET", BASE + "/<cid>/<eid>/instances",
+            rc -> instances(arg("cid", rc), arg("eid", rc), rc.request())),
+        Route.with(
+            json(), "GET", BASE + "/<cid>/<eid>/instances/<iid>",
+            rc -> instance(arg("cid", rc), arg("eid", rc), arg("iid", rc)))
+    );
+
+    return cat(
+        Api.prefixRoutes(v0Routes, V0, V1),
+        Api.prefixRoutes(v1Routes, V1)
+    );
+  }
+
+  private Response<WorkflowState> patchState(String componentId, String endpointId, Request request) {
+    return workflowResource.patchState(componentId, endpointId, request);
+  }
+
+  private Response<WorkflowState> patchState(String componentId, Request request) {
+    return workflowResource.patchState(componentId, request);
+  }
+
+  private Response<Workflow> workflow(String componentId, String endpointId) {
+    final Response<com.spotify.styx.model.Workflow> response = workflowResource.workflow(componentId, endpointId);
+    return response.payload()
+        .map(Workflow::create)
+        .map(Response::forPayload)
+        .orElse(Response.forStatus(response.status()));
+  }
+
+  private Response<WorkflowState> state(String componentId, String endpointId) {
+    return workflowResource.state(componentId, endpointId);
+  }
+
+  private Response<List<WorkflowInstanceExecutionData>> instances(
+      String componentId,
+      String endpointId,
+      Request request) {
+    final Response<List<com.spotify.styx.model.data.WorkflowInstanceExecutionData>>
+        response = workflowResource.instances(componentId, endpointId, request);
+    return response.payload()
+        .map(l -> l.stream().map(WorkflowInstanceExecutionData::create).collect(Collectors.toList()))
+        .map(Response::forPayload)
+        .orElse(Response.forStatus(response.status()));
+  }
+
+  private Response<WorkflowInstanceExecutionData> instance(
+      String componentId,
+      String endpointId,
+      String instanceId) {
+    final Response<com.spotify.styx.model.data.WorkflowInstanceExecutionData>
+        response = workflowResource.instance(componentId, endpointId, instanceId);
+    return response.payload()
+        .map(WorkflowInstanceExecutionData::create)
+        .map(Response::forPayload)
+        .orElse(Response.forStatus(response.status()));
+  }
+
+  private static String arg(String name, RequestContext rc) {
+    return rc.pathArgs().get(name);
+  }
+}

--- a/styx-api-service/src/test/java/com/spotify/styx/api/ApiVersionTestUtils.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/ApiVersionTestUtils.java
@@ -52,4 +52,48 @@ class ApiVersionTestUtils {
       }
     };
   }
+
+  /**
+   * A matcher that matches if the inspected {@link Api.Version} is at most as high as the given
+   * lower bound.
+   *
+   * @param upperBound  The upper bound to match against
+   * @return A hamcrest matcher as described above
+   */
+  static Matcher<Api.Version> isAtMost(Api.Version upperBound) {
+    return new TypeSafeMatcher<Api.Version>() {
+      @Override
+      protected boolean matchesSafely(Api.Version item) {
+        return item.ordinal() <= upperBound.ordinal();
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Version is at most");
+        description.appendValue(upperBound);
+      }
+    };
+  }
+
+  /**
+   * A matcher that matches if the inspected {@link Api.Version} is exactly the same as the given
+   * verwsion
+   *
+   * @param version  The version to match against
+   * @return A hamcrest matcher as described above
+   */
+  static Matcher<Api.Version> is(Api.Version version) {
+    return new TypeSafeMatcher<Api.Version>() {
+      @Override
+      protected boolean matchesSafely(Api.Version item) {
+        return item.ordinal() == version.ordinal();
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Version can only be");
+        description.appendValue(version);
+      }
+    };
+  }
 }

--- a/styx-api-service/src/test/java/com/spotify/styx/api/JsonMatchers.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/JsonMatchers.java
@@ -31,13 +31,14 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
-class JsonMatchers {
+public class JsonMatchers {
 
-  static <T> void assertJson(Response<ByteString> response, String jsonPath, Matcher<T> matcher) {
+  public static <T> void assertJson(Response<ByteString> response, String jsonPath,
+                                    Matcher<T> matcher) {
     assertThat(response, hasPayload(asByteString(hasJsonPath(jsonPath, matcher))));
   }
 
-  static <T> void assertNoJson(Response<ByteString> response, String jsonPath) {
+  public static <T> void assertNoJson(Response<ByteString> response, String jsonPath) {
     assertThat(response, hasPayload(asByteString(hasNoJsonPath(jsonPath))));
   }
 

--- a/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
@@ -70,7 +70,7 @@ public class ResourceResourceTest extends VersionedApiTest {
   }
 
   @Override
-  void init(Environment environment) {
+  protected void init(Environment environment) {
     ResourceResource resourceResource = new ResourceResource(storage);
 
     environment.routingEngine().registerRoutes(resourceResource.routes());

--- a/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
@@ -1,0 +1,75 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api;
+
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasStatus;
+import static com.spotify.apollo.test.unit.StatusTypeMatchers.withCode;
+import static org.junit.Assert.assertThat;
+
+import com.spotify.apollo.Environment;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.Status;
+import okio.ByteString;
+import org.junit.Test;
+
+public class SchedulerResourceTest extends VersionedApiTest {
+
+  private static final String SCHEDULER_BASE = "http://localhost:8080";
+
+  public SchedulerResourceTest(Api.Version version) {
+    super(SchedulerResource.BASE, version);
+  }
+
+  @Override
+  protected void init(Environment environment) {
+    final SchedulerResource schedulerResource = new SchedulerResource(SCHEDULER_BASE);
+
+    environment.routingEngine().registerRoutes(schedulerResource.routes());
+  }
+
+  @Test
+  public void testEventInjectionProxy() throws Exception {
+    sinceVersion(Api.Version.V2);
+
+    serviceHelper.stubClient()
+        .respond(Response.forStatus(Status.ACCEPTED))
+        .to(SCHEDULER_BASE + "/api/v0/events");
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("POST", path("/events")));
+
+    assertThat(response, hasStatus(withCode(Status.ACCEPTED)));
+  }
+
+  @Test
+  public void testTriggerWorkflowInstanceProxy() throws Exception {
+    sinceVersion(Api.Version.V2);
+
+    serviceHelper.stubClient()
+        .respond(Response.forStatus(Status.ACCEPTED))
+        .to(SCHEDULER_BASE + "/api/v0/trigger");
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("POST", path("/trigger")));
+
+    assertThat(response, hasStatus(withCode(Status.ACCEPTED)));
+  }
+}

--- a/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
@@ -1,0 +1,134 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api;
+
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasPayload;
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasStatus;
+import static com.spotify.apollo.test.unit.StatusTypeMatchers.withCode;
+import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.spotify.apollo.Environment;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.Status;
+import com.spotify.styx.model.Event;
+import com.spotify.styx.model.SequenceEvent;
+import com.spotify.styx.model.WorkflowId;
+import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.serialization.Json;
+import com.spotify.styx.state.Trigger;
+import com.spotify.styx.storage.InMemStorage;
+import com.spotify.styx.storage.Storage;
+import okio.ByteString;
+import org.junit.Test;
+
+public class StatusResourceTest extends VersionedApiTest {
+
+  private static final String COMPONENT_ID = "styx";
+  private static final String ID = "test";
+  private static final String PARAMETER = "1234";
+  private static final Trigger TRIGGER = Trigger.unknown("foobar");
+  private static final String OTHER_COMPONENT_ID = "styx-other";
+  private static final WorkflowInstance WFI =
+      WorkflowInstance.create(WorkflowId.create(COMPONENT_ID, ID), PARAMETER);
+  private static final WorkflowInstance OTHER_WFI =
+      WorkflowInstance.create(WorkflowId.create(OTHER_COMPONENT_ID, ID), PARAMETER);
+
+  private Storage storage = new InMemStorage();
+
+  public StatusResourceTest(Api.Version version) {
+    super(StatusResource.BASE, version);
+  }
+
+  @Override
+  protected void init(Environment environment) {
+    final StatusResource statusResource = new StatusResource(storage);
+
+    environment.routingEngine()
+        .registerRoutes(statusResource.routes());
+  }
+
+  @Test
+  public void testEventsRoundtrip() throws Exception {
+    sinceVersion(Api.Version.V2);
+
+    storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI, TRIGGER), 0L, 0L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI, "exec0", "img0"), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.started(WFI), 2L, 2L));
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("/events/styx/test/1234")));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertThat(response, hasPayload(any(ByteString.class)));
+
+    String json = response.payload().get().utf8();
+    EventsPayload parsed = Json.OBJECT_MAPPER.readValue(json, EventsPayload.class);
+
+    assertThat(parsed.events(), hasSize(3));
+  }
+
+  @Test
+  public void testGetAllActiveStates() throws Exception {
+    sinceVersion(Api.Version.V2);
+
+    storage.writeActiveState(WFI, 42L);
+    storage.writeActiveState(OTHER_WFI, 84L);
+    assertThat(storage.readActiveWorkflowInstances().entrySet(), hasSize(2));
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("/activeStates")));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+
+    String json = response.payload().get().utf8();
+    RunStateDataPayload
+        parsed = Json.OBJECT_MAPPER.readValue(json, RunStateDataPayload.class);
+
+    assertThat(parsed.activeStates(), hasSize(2));
+  }
+
+  @Test
+  public void testFilterActiveStatesOnComponent() throws Exception {
+    sinceVersion(Api.Version.V2);
+
+    WorkflowInstance OTHER_WFI =
+        WorkflowInstance.create(WorkflowId.create(COMPONENT_ID + "-other", ID), PARAMETER);
+
+    storage.writeActiveState(WFI, 42L);
+    storage.writeActiveState(OTHER_WFI, 84L);
+    assertThat(storage.readActiveWorkflowInstances().entrySet(), hasSize(2));
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("/activeStates?component=" + COMPONENT_ID)));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+
+    String json = response.payload().get().utf8();
+    RunStateDataPayload
+        parsed = Json.OBJECT_MAPPER.readValue(json, RunStateDataPayload.class);
+
+    assertThat(parsed.activeStates(), hasSize(1));
+    assertThat(parsed.activeStates().get(0).workflowInstance().workflowId().componentId(), is(COMPONENT_ID));
+  }
+}

--- a/styx-api-service/src/test/java/com/spotify/styx/api/VersionedApiTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/VersionedApiTest.java
@@ -21,7 +21,9 @@
 package com.spotify.styx.api;
 
 import static com.spotify.styx.api.ApiVersionTestUtils.ALL_VERSIONS;
+import static com.spotify.styx.api.ApiVersionTestUtils.is;
 import static com.spotify.styx.api.ApiVersionTestUtils.isAtLeast;
+import static com.spotify.styx.api.ApiVersionTestUtils.isAtMost;
 import static org.junit.Assume.assumeThat;
 
 import com.spotify.apollo.Environment;
@@ -80,7 +82,7 @@ public abstract class VersionedApiTest {
    *
    * @param environment The Apollo test environment
    */
-  abstract void init(Environment environment);
+  protected abstract void init(Environment environment);
 
   /**
    * Test precondition that only runs the calling test case if the version under test is equal or
@@ -90,6 +92,26 @@ public abstract class VersionedApiTest {
    */
   protected void sinceVersion(Api.Version version) {
     assumeThat(this.version, isAtLeast(version));
+  }
+
+  /**
+   * Test precondition that only runs the calling test case if the version under test is equal or
+   * lower than the given version.
+   *
+   * @param version The version from which the tests are valid
+   */
+  protected void tillVersion(Api.Version version) {
+    assumeThat(this.version, isAtMost(version));
+  }
+
+  /**
+   * Test precondition that only runs the calling test case if the version under test is exactly
+   * the same as the given version.
+   *
+   * @param version The version from which the tests are valid
+   */
+  protected void isVersion(Api.Version version) {
+    assumeThat(this.version, is(version));
   }
 
   /**

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -2,7 +2,7 @@
  * -\-\-
  * Spotify Styx API Service
  * --
- * Copyright (C) 2016 Spotify AB
+ * Copyright (C) 2017 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,9 +47,9 @@ import com.google.common.base.Throwables;
 import com.spotify.apollo.Environment;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.Status;
-import com.spotify.styx.model.DataEndpoint;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.Partitioning;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
@@ -84,11 +84,11 @@ public class WorkflowResourceTest extends VersionedApiTest {
     super(WorkflowResource.BASE, version, "workflow-test");
   }
 
-  private static final DataEndpoint DATA_ENDPOINT =
-      DataEndpoint.create("bar", Partitioning.DAYS, empty(), empty(), empty(), empty(), emptyList());
+  private static final Schedule SCHEDULE =
+      Schedule.create("bar", Partitioning.DAYS, empty(), empty(), empty(), empty(), emptyList());
 
   private static final Workflow WORKFLOW =
-      Workflow.create("foo", URI.create("/hejhej"), DATA_ENDPOINT);
+      Workflow.create("foo", URI.create("/hejhej"), SCHEDULE);
 
   private static final String VALID_SHA = "470a229b49a14e7682af2abfdac3b881a8aacdf9";
   private static final String INVALID_SHA = "XXXXXX9b49a14e7682af2abfdac3b881a8aacdf9";
@@ -119,7 +119,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
       ByteString.encodeUtf8("{\"enabled\":\"true\",\"other_field\":\"ignored\"}");
 
   @Override
-  void init(Environment environment) {
+  protected void init(Environment environment) {
     WorkflowResource workflowResource = new WorkflowResource(storage);
 
     environment.routingEngine().registerRoutes(workflowResource.routes());
@@ -156,6 +156,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldSucceedWithFullPatchStatePerWorkflow() throws Exception {
+    sinceVersion(Api.Version.V2);
+
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("GET", path("/foo/bar/state")));
 
@@ -181,6 +183,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldSucceedWithEnabledPatchStatePerWorkflow() throws Exception {
+    sinceVersion(Api.Version.V2);
+
     storage.patchState(WORKFLOW.id(), patchDockerImage("preset:image"));
 
     Response<ByteString> response =
@@ -198,6 +202,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldSucceedWhenStatePayloadWithOtherFieldsIsSent() throws Exception {
+    sinceVersion(Api.Version.V2);
+
     storage.patchState(WORKFLOW.id(), patchDockerImage("preset:image"));
 
     Response<ByteString> response =
@@ -213,6 +219,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldSucceedWithImagePatchStatePerWorkflow() throws Exception {
+    sinceVersion(Api.Version.V2);
+
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state"),
                                             STATEPAYLOAD_IMAGE));
@@ -228,6 +236,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldSucceedWithPatchStatePerComponent() throws Exception {
+    sinceVersion(Api.Version.V2);
+
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("PATCH", path("/foo/state"),
                                             STATEPAYLOAD_IMAGE));
@@ -243,6 +253,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldReturnCurrentWorkflowState() throws Exception {
+    sinceVersion(Api.Version.V2);
+
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("GET", path("/foo/bar/state")));
 
@@ -266,6 +278,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldAcceptPatchStateWithValidSHA1() throws Exception {
+    sinceVersion(Api.Version.V2);
+
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state"),
                                             STATEPAYLOAD_VALID_SHA));
@@ -279,6 +293,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldFailPatchStateWithInvalidSHA1() throws Exception {
+    sinceVersion(Api.Version.V2);
+
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state"),
                                             STATEPAYLOAD_INVALID_SHA));
@@ -306,6 +322,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldReturnBadRequestWhenMalformedStatePayloadIsSent() throws Exception {
+    sinceVersion(Api.Version.V2);
+
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state"),
                                             STATEPAYLOAD_BAD));
@@ -317,6 +335,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldReturnBadRequestWhenMalformedStatePayloadIsSentComponent() throws Exception {
+    sinceVersion(Api.Version.V2);
+
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("PATCH", path("/foo/state"),
                                             STATEPAYLOAD_BAD));
@@ -328,6 +348,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldReturnBadRequestWhenNoPayloadIsSent() throws Exception {
+    sinceVersion(Api.Version.V2);
+
     Response<ByteString> response =
     awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state")));
 
@@ -341,6 +363,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
    */
   @Test
   public void shouldReturnBadRequestSettingEnabledOnComponent() throws Exception {
+    sinceVersion(Api.Version.V2);
+
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("PATCH", path("/foo/state"),
                                             STATEPAYLOAD_FULL));
@@ -352,7 +376,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldReturnWorkflowInstancesData() throws Exception {
-    sinceVersion(Api.Version.V1);
+    sinceVersion(Api.Version.V2);
 
     WorkflowInstance wfi = WorkflowInstance.create(WORKFLOW.id(), "2016-08-10");
     storage.writeEvent(create(Event.triggerExecution(wfi, NATURAL_TRIGGER), 0L, ms("07:00:00")));
@@ -367,7 +391,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
     assertJson(response, "[*]", hasSize(1));
     assertJson(response, "[0].workflow_instance.parameter", is("2016-08-10"));
     assertJson(response, "[0].workflow_instance.workflow_id.component_id", is("foo"));
-    assertJson(response, "[0].workflow_instance.workflow_id.endpoint_id", is("bar"));
+    assertJson(response, "[0].workflow_instance.workflow_id.id", is("bar"));
     assertJson(response, "[0].triggers", hasSize(1));
     assertJson(response, "[0].triggers.[0].trigger_id", is(TriggerUtil.NATURAL_TRIGGER_ID));
     assertJson(response, "[0].triggers.[0].complete", is(false));
@@ -381,7 +405,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldReturnWorkflowInstanceData() throws Exception {
-    sinceVersion(Api.Version.V1);
+    sinceVersion(Api.Version.V2);
 
     WorkflowInstance wfi = WorkflowInstance.create(WORKFLOW.id(), "2016-08-10");
     storage.writeEvent(create(Event.triggerExecution(wfi, NATURAL_TRIGGER), 0L, ms("07:00:00")));
@@ -395,7 +419,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     assertJson(response, "workflow_instance.parameter", is("2016-08-10"));
     assertJson(response, "workflow_instance.workflow_id.component_id", is("foo"));
-    assertJson(response, "workflow_instance.workflow_id.endpoint_id", is("bar"));
+    assertJson(response, "workflow_instance.workflow_id.id", is("bar"));
     assertJson(response, "triggers", hasSize(1));
     assertJson(response, "triggers.[0].trigger_id", is(TriggerUtil.NATURAL_TRIGGER_ID));
     assertJson(response, "triggers.[0].timestamp", is("2016-08-10T07:00:00Z"));
@@ -412,7 +436,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldReturnWorkflowInstanceDataBackfill() throws Exception {
-    sinceVersion(Api.Version.V1);
+    sinceVersion(Api.Version.V2);
 
     WorkflowInstance wfi = WorkflowInstance.create(WORKFLOW.id(), "2016-08-10");
     storage.writeEvent(create(Event.triggerExecution(wfi, BACKFILL_TRIGGER), 0L, ms("07:00:00")));
@@ -424,7 +448,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     assertJson(response, "workflow_instance.parameter", is("2016-08-10"));
     assertJson(response, "workflow_instance.workflow_id.component_id", is("foo"));
-    assertJson(response, "workflow_instance.workflow_id.endpoint_id", is("bar"));
+    assertJson(response, "workflow_instance.workflow_id.id", is("bar"));
     assertJson(response, "triggers", hasSize(1));
     assertJson(response, "triggers.[0].trigger_id", is("backfill-1"));
     assertJson(response, "triggers.[0].timestamp", is("2016-08-10T07:00:00Z"));
@@ -433,7 +457,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldPaginateWorkflowInstancesData() throws Exception {
-    sinceVersion(Api.Version.V1);
+    sinceVersion(Api.Version.V2);
 
     WorkflowInstance wfi1 = WorkflowInstance.create(WORKFLOW.id(), "2016-08-11");
     WorkflowInstance wfi2 = WorkflowInstance.create(WORKFLOW.id(), "2016-08-12");

--- a/styx-api-service/src/test/java/com/spotify/styx/api/deprecated/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/deprecated/BackfillResourceTest.java
@@ -1,0 +1,473 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Service
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api.deprecated;
+
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasStatus;
+import static com.spotify.apollo.test.unit.StatusTypeMatchers.belongsToFamily;
+import static com.spotify.styx.api.JsonMatchers.assertJson;
+import static com.spotify.styx.api.JsonMatchers.assertNoJson;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyQuery;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.spotify.apollo.Environment;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.Status;
+import com.spotify.apollo.StatusType;
+import com.spotify.apollo.test.StubClient;
+import com.spotify.apollo.test.response.ResponseWithDelay;
+import com.spotify.apollo.test.response.Responses;
+import com.spotify.styx.api.Api;
+import com.spotify.styx.api.VersionedApiTest;
+import com.spotify.styx.model.Backfill;
+import com.spotify.styx.model.BackfillInput;
+import com.spotify.styx.model.Event;
+import com.spotify.styx.model.Partitioning;
+import com.spotify.styx.model.Schedule;
+import com.spotify.styx.model.SequenceEvent;
+import com.spotify.styx.model.Workflow;
+import com.spotify.styx.model.WorkflowId;
+import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.serialization.Json;
+import com.spotify.styx.state.Trigger;
+import com.spotify.styx.storage.AggregateStorage;
+import com.spotify.styx.storage.BigtableMocker;
+import com.spotify.styx.storage.BigtableStorage;
+import com.spotify.styx.testdata.TestData;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Optional;
+import okio.ByteString;
+import org.apache.hadoop.hbase.client.Connection;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@Deprecated
+public class BackfillResourceTest extends VersionedApiTest {
+
+  private static final String SCHEDULER_BASE = "http://localhost:8080";
+
+  private static LocalDatastoreHelper localDatastore;
+  private Connection bigtable = setupBigTableMockTable();
+
+  private AggregateStorage storage = new AggregateStorage(
+      bigtable,
+      localDatastore.options().service(),
+      Duration.ZERO);
+
+  private static final Backfill BACKFILL_1 = Backfill.newBuilder()
+      .id("backfill-1")
+      .start(Instant.parse("2017-01-01T00:00:00Z"))
+      .end(Instant.parse("2017-01-02T00:00:00Z"))
+      .workflowId(WorkflowId.create("component", "workflow1"))
+      .concurrency(1)
+      .nextTrigger(Instant.parse("2017-01-01T00:00:00Z"))
+      .partitioning(Partitioning.HOURS)
+      .build();
+
+  private static final Backfill BACKFILL_2 = Backfill.newBuilder()
+      .id("backfill-2")
+      .start(Instant.parse("2017-01-01T00:00:00Z"))
+      .end(Instant.parse("2017-01-02T00:00:00Z"))
+      .workflowId(WorkflowId.create("component", "workflow2"))
+      .concurrency(2)
+      .nextTrigger(Instant.parse("2017-01-01T00:00:00Z"))
+      .partitioning(Partitioning.DAYS)
+      .build();
+
+  private static final Backfill BACKFILL_3 = Backfill.newBuilder()
+      .id("backfill-3")
+      .start(Instant.parse("2017-01-01T00:00:00Z"))
+      .end(Instant.parse("2017-01-02T00:00:00Z"))
+      .workflowId(WorkflowId.create("other_component", "other_workflow"))
+      .concurrency(2)
+      .nextTrigger(Instant.parse("2017-01-01T00:00:00Z"))
+      .partitioning(Partitioning.DAYS)
+      .build();
+
+  public BackfillResourceTest(Api.Version version) {
+    super(BackfillResource.BASE, version, "backfill-test", spy(StubClient.class));
+  }
+
+  @Override
+  protected void init(Environment environment) {
+    environment.routingEngine()
+        .registerRoutes(
+            new BackfillResource(new com.spotify.styx.api.BackfillResource(SCHEDULER_BASE, storage))
+                .routes());
+  }
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency
+    localDatastore.start();
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+    if (localDatastore != null) {
+      localDatastore.stop();
+    }
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    storage.storeWorkflow(Workflow.create(
+        BACKFILL_1.workflowId().componentId(), URI.create("http://example.com"),
+        Schedule.create(BACKFILL_1.workflowId().id(), Partitioning.HOURS,
+                        Optional.empty(), Optional.empty(), Optional.empty(),
+                        Optional.empty(), Collections.emptyList())));
+    storage.storeWorkflow(Workflow.create(
+        BACKFILL_2.workflowId().componentId(), URI.create("http://example.com"),
+        Schedule.create(BACKFILL_2.workflowId().id(), Partitioning.HOURS,
+                        Optional.empty(), Optional.empty(), Optional.empty(),
+                        Optional.empty(), Collections.emptyList())));
+    storage.storeWorkflow(Workflow.create(
+        BACKFILL_3.workflowId().componentId(), URI.create("http://example.com"),
+        Schedule.create(BACKFILL_3.workflowId().id(), Partitioning.HOURS,
+                        Optional.empty(), Optional.empty(), Optional.empty(),
+                        Optional.empty(), Collections.emptyList())));
+    storage.storeBackfill(BACKFILL_1);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    // clear datastore after each test
+    Datastore datastore = localDatastore.options().service();
+    KeyQuery query = Query.keyQueryBuilder().build();
+    final QueryResults<Key> keys = datastore.run(query);
+    while (keys.hasNext()) {
+      datastore.delete(keys.next());
+    }
+  }
+
+  @Test
+  public void shouldListBackfillsNoStatus() throws Exception {
+    isVersion(Api.Version.V1);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("")));
+
+    assertThat(response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+    assertJson(response, "backfills[0].backfill.id", equalTo(BACKFILL_1.id()));
+    assertNoJson(response, "backfills[0].statuses.active_states");
+  }
+
+  @Test
+  public void shouldListBackfillsWithStatus() throws Exception {
+    isVersion(Api.Version.V1);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("?status=true")));
+
+    assertThat(response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+    assertJson(response, "backfills[0].backfill.id", equalTo(BACKFILL_1.id()));
+    assertJson(response, "backfills[0].statuses.active_states", hasSize(24));
+  }
+
+  @Test
+  public void shouldFilterBackfills() throws Exception {
+    isVersion(Api.Version.V1);
+
+    storage.storeBackfill(BACKFILL_2);
+    storage.storeBackfill(BACKFILL_3);
+
+    final String uri = path(String.format("?component=%s&workflow=%s",
+                                          BACKFILL_1.workflowId().componentId(),
+                                          BACKFILL_1.workflowId().id()));
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", uri));
+
+    assertThat(response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+    assertJson(response, "backfills", hasSize(1));
+    assertJson(response, "backfills[0].backfill.id", equalTo(BACKFILL_1.id()));
+  }
+
+  @Test
+  public void shouldListMultipleBackfills() throws Exception {
+    isVersion(Api.Version.V1);
+
+    storage.storeBackfill(BACKFILL_2);
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("")));
+
+    assertThat(response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+    assertJson(response, "backfills", hasSize(2));
+  }
+
+  @Test
+  public void shouldGetBackfillStatus() throws Exception {
+    isVersion(Api.Version.V1);
+
+    WorkflowInstance wfi = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T01");
+    storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T02:00:00Z")).build());
+    storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi, Trigger.backfill("backfill-1")), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi),                                          2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submitted(wfi, "exec-1"),                              4L, 4L));
+    storage.writeEvent(SequenceEvent.create(Event.started(wfi),                                          5L, 5L));
+    storage.writeActiveState(wfi, 5L);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("/" + BACKFILL_1.id())));
+
+    assertThat(response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+    assertJson(response, "backfill.id", equalTo(BACKFILL_1.id()));
+    assertJson(response, "statuses.active_states[0].state", equalTo("UNKNOWN"));
+    assertJson(response, "statuses.active_states[1].state", equalTo("RUNNING"));
+    assertJson(response, "statuses.active_states[2].state", equalTo("WAITING"));
+    assertJson(response, "statuses.active_states[23].state", equalTo("WAITING"));
+    assertJson(response, "statuses.active_states", hasSize(24));
+  }
+
+  @Test
+  public void shouldPostBackfill() throws Exception {
+    isVersion(Api.Version.V1);
+
+    final String json = "{\"start\":\"2017-01-01T00:00:00Z\"," +
+                        "\"end\":\"2017-02-01T00:00:00Z\"," +
+                        "\"component\":\"component\"," +
+                        "\"workflow\":\"workflow2\","+
+                        "\"concurrency\":1}";
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("POST", path(""), ByteString.encodeUtf8(json)));
+
+    assertThat(response.status().reasonPhrase(),
+               response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+    com.spotify.styx.model.deprecated.Backfill postedBackfill = Json.OBJECT_MAPPER.readValue(
+        response.payload().get().toByteArray(), com.spotify.styx.model.deprecated.Backfill.class);
+    assertThat(postedBackfill.id().matches("backfill-[\\d-]+"), is(true));
+    assertThat(postedBackfill.start(), equalTo(Instant.parse("2017-01-01T00:00:00Z")));
+    assertThat(postedBackfill.end(), equalTo(Instant.parse("2017-02-01T00:00:00Z")));
+    assertThat(postedBackfill.workflowId(), equalTo(
+        com.spotify.styx.model.deprecated.WorkflowId.create("component", "workflow2")));
+    assertThat(postedBackfill.concurrency(), equalTo(1));
+    assertThat(postedBackfill.nextTrigger(), equalTo(Instant.parse("2017-01-01T00:00:00Z")));
+    assertThat(postedBackfill.partitioning(), equalTo(Partitioning.HOURS));
+    assertThat(postedBackfill.allTriggered(), equalTo(false));
+    assertThat(postedBackfill.halted(), equalTo(false));
+  }
+
+  @Test
+  public void shouldFailOnMisalignedRange() throws Exception {
+    isVersion(Api.Version.V1);
+
+    final String json = "{\"start\":\"2017-01-01T00:00:01Z\"," +
+                        "\"end\":\"2017-02-01T00:00:00Z\"," +
+                        "\"component\":\"component\"," +
+                        "\"workflow\":\"workflow2\","+
+                        "\"concurrency\":1}";
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("POST", path(""), ByteString.encodeUtf8(json)));
+
+    assertThat(response.status().reasonPhrase(),
+               response, hasStatus(belongsToFamily(StatusType.Family.CLIENT_ERROR)));
+  }
+
+  @Test
+  public void shouldFailOnAlreadyActiveWithinRange() throws Exception {
+    isVersion(Api.Version.V1);
+
+    final BackfillInput backfillInput = BackfillInput.create(
+        BACKFILL_1.start(),
+        BACKFILL_1.end(),
+        BACKFILL_1.workflowId().componentId(),
+        BACKFILL_1.workflowId().id(),
+        BACKFILL_1.concurrency());
+
+    storage.writeActiveState(WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T01"), 0L);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("POST", path(""), Json.serialize(backfillInput)));
+
+    assertThat(response.status().reasonPhrase(),
+               response, hasStatus(belongsToFamily(StatusType.Family.CLIENT_ERROR)));
+  }
+
+  @Test
+  public void shouldUpdateBackfill() throws Exception {
+    isVersion(Api.Version.V1);
+
+    assertThat(storage.backfill(BACKFILL_1.id()).get().concurrency(), equalTo(1));
+
+    final com.spotify.styx.model.deprecated.Backfill
+        updatedBackfill = com.spotify.styx.model.deprecated.Backfill
+            .create(BACKFILL_1.builder().concurrency(4).build());
+    final String json = Json.OBJECT_MAPPER.writeValueAsString(updatedBackfill);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("PUT", path("/" + BACKFILL_1.id()),
+                                            ByteString.encodeUtf8(json)));
+
+    assertThat(response.status().reasonPhrase(),
+               response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+    assertJson(response, "id", equalTo(BACKFILL_1.id()));
+    assertJson(response, "concurrency", equalTo(4));
+
+    assertThat(storage.backfill(BACKFILL_1.id()).get().concurrency(), equalTo(4));
+  }
+
+  @Test
+  public void shouldHaltBackfill() throws Exception {
+    isVersion(Api.Version.V1);
+
+    serviceHelper.stubClient()
+        .respond(Response.forStatus(Status.ACCEPTED))
+        .to(SCHEDULER_BASE + "/api/v0/events");
+
+    WorkflowInstance wfi = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T01");
+    storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T02:00:00Z")).build());
+    storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi, Trigger.backfill("backfill-1")), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi),                                          2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submitted(wfi, "exec-1"),                              4L, 4L));
+    storage.writeEvent(SequenceEvent.create(Event.started(wfi),                                          5L, 5L));
+    storage.writeActiveState(wfi, 5L);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("DELETE", path("/" + BACKFILL_1.id())));
+    assertThat(response.status().reasonPhrase(),
+        response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+
+    assertThat(storage.backfill(BACKFILL_1.id()).get().halted(), equalTo(true));
+    verify(serviceHelper.stubClient(), times(1)).send(any());
+  }
+
+  @Test
+  public void shouldNotHaltWaitingInstanceInBackfill() throws Exception {
+    isVersion(Api.Version.V1);
+
+    serviceHelper.stubClient()
+        .respond(Response.forStatus(Status.ACCEPTED))
+        .to(SCHEDULER_BASE + "/api/v0/events");
+
+    WorkflowInstance wfi1 = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T01");
+    WorkflowInstance wfi2 = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T02");
+    storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T03:00:00Z")).build());
+    storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi1, Trigger.backfill("backfill-1")), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1),                                          2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submitted(wfi1, "exec-1"),                              4L, 4L));
+    storage.writeEvent(SequenceEvent.create(Event.started(wfi1),                                          5L, 5L));
+    storage.writeActiveState(wfi1, 5L);
+    storage.writeActiveState(wfi2, 5L);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("DELETE", path("/" + BACKFILL_1.id())));
+    assertThat(response.status().reasonPhrase(),
+               response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+
+    assertThat(storage.backfill(BACKFILL_1.id()).get().halted(), equalTo(true));
+    verify(serviceHelper.stubClient(), times(1)).send(any());
+  }
+
+  @Test
+  public void shouldReturnServerErrorIfFailedToSend() throws Exception {
+    isVersion(Api.Version.V1);
+
+    serviceHelper.stubClient().respond(Responses.sequence(ImmutableList.of(ResponseWithDelay
+                                                                               .forResponse(Response
+                                                                                                .forStatus(
+                                                                                                    Status.INTERNAL_SERVER_ERROR)),
+                                                                           ResponseWithDelay
+                                                                               .forResponse(Response
+                                                                                                .forStatus(
+                                                                                                    Status.ACCEPTED)))))
+        .to(SCHEDULER_BASE + "/api/v0/events");
+
+    WorkflowInstance wfi1 = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T01");
+    WorkflowInstance wfi2 = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T02");
+    storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T03:00:00Z")).build());
+
+    storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi1, Trigger.backfill("backfill-1")), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1),                                          2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submitted(wfi1, "exec-1"),                              4L, 4L));
+    storage.writeEvent(SequenceEvent.create(Event.started(wfi1),                                          5L, 5L));
+
+    storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi2, Trigger.backfill("backfill-1")), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi2),                                          2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi2, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submitted(wfi2, "exec-2"),                              4L, 4L));
+    storage.writeEvent(SequenceEvent.create(Event.started(wfi2),                                          5L, 5L));
+
+    storage.writeActiveState(wfi1, 5L);
+    storage.writeActiveState(wfi2, 5L);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("DELETE", path("/" + BACKFILL_1.id())));
+    assertThat(response.status().reasonPhrase(),
+               response, hasStatus(belongsToFamily(StatusType.Family.SERVER_ERROR)));
+
+    assertThat(storage.backfill(BACKFILL_1.id()).get().halted(), equalTo(true));
+    verify(serviceHelper.stubClient(), times(2)).send(any());
+  }
+
+  @Test
+  public void shouldOnlyUpdateBackfillIfSameId() throws Exception {
+    isVersion(Api.Version.V1);
+
+    final Backfill updatedBackfill = BACKFILL_1.builder().concurrency(4).build();
+    final String json = Json.OBJECT_MAPPER.writeValueAsString(updatedBackfill);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("PUT", path("/wrong-id"),
+                                            ByteString.encodeUtf8(json)));
+
+    assertThat(response.status().reasonPhrase(),
+               response, hasStatus(belongsToFamily(StatusType.Family.CLIENT_ERROR)));
+  }
+
+  private Connection setupBigTableMockTable() {
+    Connection bigtable = mock(Connection.class);
+    try {
+      new BigtableMocker(bigtable)
+          .setNumFailures(0)
+          .setupTable(BigtableStorage.EVENTS_TABLE_NAME)
+          .finalizeMocking();
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    return bigtable;
+  }
+}

--- a/styx-api-service/src/test/java/com/spotify/styx/api/deprecated/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/deprecated/WorkflowResourceTest.java
@@ -1,0 +1,499 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Service
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api.deprecated;
+
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasHeader;
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasNoPayload;
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasStatus;
+import static com.spotify.apollo.test.unit.StatusTypeMatchers.withCode;
+import static com.spotify.apollo.test.unit.StatusTypeMatchers.withReasonPhrase;
+import static com.spotify.styx.api.JsonMatchers.assertJson;
+import static com.spotify.styx.api.JsonMatchers.assertNoJson;
+import static com.spotify.styx.model.SequenceEvent.create;
+import static com.spotify.styx.model.WorkflowState.patchDockerImage;
+import static java.util.Collections.emptyList;
+import static java.util.Optional.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyQuery;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import com.google.common.base.Throwables;
+import com.spotify.apollo.Environment;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.Status;
+import com.spotify.styx.api.Api;
+import com.spotify.styx.api.VersionedApiTest;
+import com.spotify.styx.model.Event;
+import com.spotify.styx.model.Partitioning;
+import com.spotify.styx.model.Schedule;
+import com.spotify.styx.model.Workflow;
+import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.state.Trigger;
+import com.spotify.styx.storage.AggregateStorage;
+import com.spotify.styx.storage.BigtableMocker;
+import com.spotify.styx.storage.BigtableStorage;
+import com.spotify.styx.util.TriggerUtil;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import okio.ByteString;
+import org.apache.hadoop.hbase.client.Connection;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+@Deprecated
+public class WorkflowResourceTest extends VersionedApiTest {
+
+  private static LocalDatastoreHelper localDatastore;
+
+  private Datastore datastore = localDatastore.options().service();
+  private Connection bigtable = setupBigTableMockTable();
+  private AggregateStorage storage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
+
+  public WorkflowResourceTest(Api.Version version) {
+    super(WorkflowResource.BASE, version, "workflow-test");
+  }
+
+  private static final Schedule DATA_ENDPOINT =
+      Schedule.create("bar", Partitioning.DAYS, empty(), empty(), empty(), empty(), emptyList());
+
+  private static final Workflow WORKFLOW =
+      Workflow.create("foo", URI.create("/hejhej"), DATA_ENDPOINT);
+
+  private static final String VALID_SHA = "470a229b49a14e7682af2abfdac3b881a8aacdf9";
+  private static final String INVALID_SHA = "XXXXXX9b49a14e7682af2abfdac3b881a8aacdf9";
+
+  private static final Trigger NATURAL_TRIGGER = Trigger.natural();
+  private static final Trigger BACKFILL_TRIGGER = Trigger.backfill("backfill-1");
+
+  private static final ByteString STATEPAYLOAD_FULL =
+      ByteString.encodeUtf8("{\"enabled\":\"true\", \"docker_image\":\"cherry:image\", "
+                            + "\"commit_sha\":\"" + VALID_SHA + "\"}");
+
+  private static final ByteString STATEPAYLOAD_ENABLED =
+      ByteString.encodeUtf8("{\"enabled\":\"true\"}");
+
+  private static final ByteString STATEPAYLOAD_VALID_SHA =
+      ByteString.encodeUtf8("{\"commit_sha\":\"" + VALID_SHA + "\"}");
+
+  private static final ByteString STATEPAYLOAD_INVALID_SHA =
+      ByteString.encodeUtf8("{\"commit_sha\":\"" + INVALID_SHA + "\"}");
+
+  private static final ByteString STATEPAYLOAD_IMAGE =
+      ByteString.encodeUtf8("{\"docker_image\":\"berry:image\"}");
+
+  private static final ByteString STATEPAYLOAD_BAD =
+      ByteString.encodeUtf8("{\"The BAD\"}");
+
+  private static final ByteString STATEPAYLOAD_OTHER_FIELD =
+      ByteString.encodeUtf8("{\"enabled\":\"true\",\"other_field\":\"ignored\"}");
+
+  @Override
+  protected void init(Environment environment) {
+    WorkflowResource
+        workflowResource =
+        new WorkflowResource(new com.spotify.styx.api.WorkflowResource(storage));
+
+    environment.routingEngine().registerRoutes(workflowResource.routes());
+  }
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency
+    localDatastore.start();
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+    if (localDatastore != null) {
+      localDatastore.stop();
+    }
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    storage.storeWorkflow(WORKFLOW);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    // clear datastore after each test
+    Datastore datastore = localDatastore.options().service();
+    KeyQuery query = Query.keyQueryBuilder().build();
+    final QueryResults<Key> keys = datastore.run(query);
+    while (keys.hasNext()) {
+      datastore.delete(keys.next());
+    }
+  }
+
+  @Test
+  public void shouldSucceedWithFullPatchStatePerWorkflow() throws Exception {
+    tillVersion(Api.Version.V1);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("/foo/bar/state")));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertJson(response, "enabled", equalTo(false));
+    assertNoJson(response, "docker_image");
+    assertNoJson(response, "commit_sha");
+
+    response =
+        awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state"),
+                                            STATEPAYLOAD_FULL));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertThat(response, hasHeader("Content-Type", equalTo("application/json")));
+    assertJson(response, "enabled", equalTo(true));
+    assertJson(response, "docker_image", equalTo("cherry:image"));
+    assertJson(response, "commit_sha", equalTo(VALID_SHA));
+
+    assertThat(storage.enabled(WORKFLOW.id()), is(true));
+    assertThat(storage.workflowState(WORKFLOW.id()).dockerImage().get(), is("cherry:image"));
+    assertThat(storage.workflowState(WORKFLOW.id()).commitSha().get(), is(VALID_SHA));
+  }
+
+  @Test
+  public void shouldSucceedWithEnabledPatchStatePerWorkflow() throws Exception {
+    tillVersion(Api.Version.V1);
+
+    storage.patchState(WORKFLOW.id(), patchDockerImage("preset:image"));
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state"),
+                                            STATEPAYLOAD_ENABLED));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertThat(response, hasHeader("Content-Type", equalTo("application/json")));
+    assertJson(response, "enabled", equalTo(true));
+    assertJson(response, "docker_image", equalTo("preset:image"));
+
+    assertThat(storage.enabled(WORKFLOW.id()), is(true));
+    assertThat(storage.getDockerImage(WORKFLOW.id()), is(Optional.of("preset:image")));
+  }
+
+  @Test
+  public void shouldSucceedWhenStatePayloadWithOtherFieldsIsSent() throws Exception {
+    tillVersion(Api.Version.V1);
+
+    storage.patchState(WORKFLOW.id(), patchDockerImage("preset:image"));
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state"),
+                                            STATEPAYLOAD_OTHER_FIELD));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertThat(response, hasHeader("Content-Type", equalTo("application/json")));
+    assertJson(response, "enabled", equalTo(true));
+
+    assertThat(storage.enabled(WORKFLOW.id()), is(true));
+  }
+
+  @Test
+  public void shouldSucceedWithImagePatchStatePerWorkflow() throws Exception {
+    tillVersion(Api.Version.V1);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state"),
+                                            STATEPAYLOAD_IMAGE));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertThat(response, hasHeader("Content-Type", equalTo("application/json")));
+    assertJson(response, "enabled", equalTo(false));
+    assertJson(response, "docker_image", equalTo("berry:image"));
+
+    assertThat(storage.enabled(WORKFLOW.id()), is(false));
+    assertThat(storage.getDockerImage(WORKFLOW.id()), is(Optional.of("berry:image")));
+  }
+
+  @Test
+  public void shouldSucceedWithPatchStatePerComponent() throws Exception {
+    tillVersion(Api.Version.V1);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("PATCH", path("/foo/state"),
+                                            STATEPAYLOAD_IMAGE));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertThat(response, hasHeader("Content-Type", equalTo("application/json")));
+    assertNoJson(response, "enabled");
+    assertJson(response, "docker_image", equalTo("berry:image"));
+
+    assertThat(storage.enabled(WORKFLOW.id()), is(false));
+    assertThat(storage.getDockerImage(WORKFLOW.id()), is(Optional.of("berry:image")));
+  }
+
+  @Test
+  public void shouldReturnCurrentWorkflowState() throws Exception {
+    tillVersion(Api.Version.V1);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("/foo/bar/state")));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertJson(response, "enabled", equalTo(false));
+    assertNoJson(response, "docker_image");
+    assertNoJson(response, "commit_sha");
+
+    storage.patchState(WORKFLOW.id(),
+        WorkflowState.builder().enabled(true).dockerImage("tina:ranic")
+            .commitSha("470a229b49a14e7682af2abfdac3b881a8aacdf9").build());
+
+    response =
+        awaitResponse(serviceHelper.request("GET", path("/foo/bar/state")));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertJson(response, "enabled", equalTo(true));
+    assertJson(response, "docker_image", equalTo("tina:ranic"));
+    assertJson(response, "commit_sha", equalTo("470a229b49a14e7682af2abfdac3b881a8aacdf9"));
+  }
+
+  @Test
+  public void shouldAcceptPatchStateWithValidSHA1() throws Exception {
+    tillVersion(Api.Version.V1);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state"),
+                                            STATEPAYLOAD_VALID_SHA));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertJson(response, "commit_sha", equalTo(VALID_SHA));
+
+    assertThat(storage.workflowState(WORKFLOW.id()).commitSha().get(),
+               is(VALID_SHA));
+  }
+
+  @Test
+  public void shouldFailPatchStateWithInvalidSHA1() throws Exception {
+    tillVersion(Api.Version.V1);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state"),
+                                            STATEPAYLOAD_INVALID_SHA));
+
+    assertThat(response, hasStatus(withCode(Status.BAD_REQUEST)));
+    assertThat(response, hasStatus(withReasonPhrase(equalTo("Invalid SHA-1."))));
+
+    assertThat(storage.workflowState(WORKFLOW.id()).commitSha().isPresent(),
+               is(false));
+  }
+
+  @Test @Ignore
+  public void shouldReturnBadRequestOnEnableWhenWorkflowNotFound() throws Exception {
+    // can't implement
+    // this can't ever happen in the current bigtable storage implementation
+  }
+
+  @Test @Ignore
+  public void shouldReturnBadRequestOnImageWhenWorkflowNotFound() throws Exception {
+  }
+
+  @Test @Ignore
+  public void shouldReturnBadRequestOnImageWhenComponentNotFound() throws Exception {
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenMalformedStatePayloadIsSent() throws Exception {
+    tillVersion(Api.Version.V1);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state"),
+                                            STATEPAYLOAD_BAD));
+
+    assertThat(response, hasStatus(withCode(Status.BAD_REQUEST)));
+    assertThat(response, hasNoPayload());
+    assertThat(response, hasStatus(withReasonPhrase(equalTo("Invalid payload."))));
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenMalformedStatePayloadIsSentComponent() throws Exception {
+    tillVersion(Api.Version.V1);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("PATCH", path("/foo/state"),
+                                            STATEPAYLOAD_BAD));
+
+    assertThat(response, hasStatus(withCode(Status.BAD_REQUEST)));
+    assertThat(response, hasNoPayload());
+    assertThat(response, hasStatus(withReasonPhrase(equalTo("Invalid payload."))));
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenNoPayloadIsSent() throws Exception {
+    tillVersion(Api.Version.V1);
+
+    Response<ByteString> response =
+    awaitResponse(serviceHelper.request("PATCH", path("/foo/bar/state")));
+
+    assertThat(response, hasStatus(withCode(Status.BAD_REQUEST)));
+    assertThat(response, hasNoPayload());
+    assertThat(response, hasStatus(withReasonPhrase(equalTo("Missing payload."))));
+  }
+
+  /**
+   * This test should be removed when we actually support this
+   */
+  @Test
+  public void shouldReturnBadRequestSettingEnabledOnComponent() throws Exception {
+    tillVersion(Api.Version.V1);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("PATCH", path("/foo/state"),
+                                            STATEPAYLOAD_FULL));
+
+    assertThat(response, hasStatus(withCode(Status.BAD_REQUEST)));
+    assertThat(response, hasNoPayload());
+    assertThat(response, hasStatus(withReasonPhrase(equalTo("Enabled flag not supported for components."))));
+  }
+
+  @Test
+  public void shouldReturnWorkflowInstancesData() throws Exception {
+    isVersion(Api.Version.V1);
+
+    WorkflowInstance wfi = WorkflowInstance.create(WORKFLOW.id(), "2016-08-10");
+    storage.writeEvent(create(Event.triggerExecution(wfi, NATURAL_TRIGGER), 0L, ms("07:00:00")));
+    storage.writeEvent(create(Event.created(wfi, "exec", "img"), 1L, ms("07:00:01")));
+    storage.writeEvent(create(Event.started(wfi), 2L, ms("07:00:02")));
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("/foo/bar/instances")));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+
+    assertJson(response, "[*]", hasSize(1));
+    assertJson(response, "[0].workflow_instance.parameter", is("2016-08-10"));
+    assertJson(response, "[0].workflow_instance.workflow_id.component_id", is("foo"));
+    assertJson(response, "[0].workflow_instance.workflow_id.endpoint_id", is("bar"));
+    assertJson(response, "[0].triggers", hasSize(1));
+    assertJson(response, "[0].triggers.[0].trigger_id", is(TriggerUtil.NATURAL_TRIGGER_ID));
+    assertJson(response, "[0].triggers.[0].complete", is(false));
+    assertJson(response, "[0].triggers.[0].executions", hasSize(1));
+    assertJson(response, "[0].triggers.[0].executions.[0].execution_id", is("exec"));
+    assertJson(response, "[0].triggers.[0].executions.[0].docker_image", is("img"));
+    assertJson(response, "[0].triggers.[0].executions.[0].statuses", hasSize(2));
+    assertJson(response, "[0].triggers.[0].executions.[0].statuses.[0].status", is("SUBMITTED"));
+    assertJson(response, "[0].triggers.[0].executions.[0].statuses.[1].status", is("STARTED"));
+  }
+
+  @Test
+  public void shouldReturnWorkflowInstanceData() throws Exception {
+    isVersion(Api.Version.V1);
+
+    WorkflowInstance wfi = WorkflowInstance.create(WORKFLOW.id(), "2016-08-10");
+    storage.writeEvent(create(Event.triggerExecution(wfi, NATURAL_TRIGGER), 0L, ms("07:00:00")));
+    storage.writeEvent(create(Event.created(wfi, "exec", "img"), 1L, ms("07:00:01")));
+    storage.writeEvent(create(Event.started(wfi), 2L, ms("07:00:02")));
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("/foo/bar/instances/2016-08-10")));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+
+    assertJson(response, "workflow_instance.parameter", is("2016-08-10"));
+    assertJson(response, "workflow_instance.workflow_id.component_id", is("foo"));
+    assertJson(response, "workflow_instance.workflow_id.endpoint_id", is("bar"));
+    assertJson(response, "triggers", hasSize(1));
+    assertJson(response, "triggers.[0].trigger_id", is(TriggerUtil.NATURAL_TRIGGER_ID));
+    assertJson(response, "triggers.[0].timestamp", is("2016-08-10T07:00:00Z"));
+    assertJson(response, "triggers.[0].complete", is(false));
+    assertJson(response, "triggers.[0].executions", hasSize(1));
+    assertJson(response, "triggers.[0].executions.[0].execution_id", is("exec"));
+    assertJson(response, "triggers.[0].executions.[0].docker_image", is("img"));
+    assertJson(response, "triggers.[0].executions.[0].statuses", hasSize(2));
+    assertJson(response, "triggers.[0].executions.[0].statuses.[0].status", is("SUBMITTED"));
+    assertJson(response, "triggers.[0].executions.[0].statuses.[1].status", is("STARTED"));
+    assertJson(response, "triggers.[0].executions.[0].statuses.[0].timestamp", is("2016-08-10T07:00:01Z"));
+    assertJson(response, "triggers.[0].executions.[0].statuses.[1].timestamp", is("2016-08-10T07:00:02Z"));
+  }
+
+  @Test
+  public void shouldReturnWorkflowInstanceDataBackfill() throws Exception {
+    isVersion(Api.Version.V1);
+
+    WorkflowInstance wfi = WorkflowInstance.create(WORKFLOW.id(), "2016-08-10");
+    storage.writeEvent(create(Event.triggerExecution(wfi, BACKFILL_TRIGGER), 0L, ms("07:00:00")));
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("/foo/bar/instances/2016-08-10")));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+
+    assertJson(response, "workflow_instance.parameter", is("2016-08-10"));
+    assertJson(response, "workflow_instance.workflow_id.component_id", is("foo"));
+    assertJson(response, "workflow_instance.workflow_id.endpoint_id", is("bar"));
+    assertJson(response, "triggers", hasSize(1));
+    assertJson(response, "triggers.[0].trigger_id", is("backfill-1"));
+    assertJson(response, "triggers.[0].timestamp", is("2016-08-10T07:00:00Z"));
+    assertJson(response, "triggers.[0].complete", is(false));
+  }
+
+  @Test
+  public void shouldPaginateWorkflowInstancesData() throws Exception {
+    isVersion(Api.Version.V1);
+
+    WorkflowInstance wfi1 = WorkflowInstance.create(WORKFLOW.id(), "2016-08-11");
+    WorkflowInstance wfi2 = WorkflowInstance.create(WORKFLOW.id(), "2016-08-12");
+    WorkflowInstance wfi3 = WorkflowInstance.create(WORKFLOW.id(), "2016-08-13");
+    storage.writeEvent(create(Event.triggerExecution(wfi1, NATURAL_TRIGGER), 0L, ms("07:00:00")));
+    storage.writeEvent(create(Event.triggerExecution(wfi2, NATURAL_TRIGGER), 0L, ms("07:00:00")));
+    storage.writeEvent(create(Event.triggerExecution(wfi3, NATURAL_TRIGGER), 0L, ms("07:00:00")));
+
+    Response<ByteString> response = awaitResponse(
+        serviceHelper.request("GET", path("/foo/bar/instances?offset=2016-08-12&limit=1")));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+
+    assertJson(response, "[*]", hasSize(1));
+    assertJson(response, "[0].workflow_instance.parameter", is("2016-08-12"));
+  }
+
+  private long ms(String time) {
+    return Instant.parse("2016-08-10T" + time + "Z").toEpochMilli();
+  }
+
+  private Connection setupBigTableMockTable() {
+    Connection bigtable = mock(Connection.class);
+    try {
+      new BigtableMocker(bigtable)
+          .setNumFailures(0)
+          .setupTable(BigtableStorage.EVENTS_TABLE_NAME)
+          .finalizeMocking();
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    return bigtable;
+  }
+}

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliOutput.java
@@ -22,7 +22,7 @@ package com.spotify.styx.cli;
 
 import com.google.auto.value.AutoValue;
 import com.spotify.styx.api.BackfillPayload;
-import com.spotify.styx.api.cli.RunStateDataPayload;
+import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.model.Backfill;
 import java.util.List;
 

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliUtil.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliUtil.java
@@ -26,7 +26,7 @@ import static org.fusesource.jansi.Ansi.ansi;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.spotify.styx.api.cli.RunStateDataPayload.RunStateData;
+import com.spotify.styx.api.RunStateDataPayload.RunStateData;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.EventVisitor;
 import com.spotify.styx.model.ExecutionDescription;

--- a/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
@@ -38,7 +38,7 @@ import com.spotify.apollo.environment.ApolloEnvironmentModule;
 import com.spotify.apollo.http.client.HttpClientModule;
 import com.spotify.styx.api.BackfillPayload;
 import com.spotify.styx.api.BackfillsPayload;
-import com.spotify.styx.api.cli.RunStateDataPayload;
+import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.BackfillBuilder;
 import com.spotify.styx.model.BackfillInput;
@@ -296,7 +296,7 @@ public final class Main {
       throws ExecutionException, InterruptedException, IOException {
     final WorkflowInstance workflowInstance = getWorkflowInstance(namespace);
     final String component = workflowInstance.workflowId().componentId();
-    final String workflow = workflowInstance.workflowId().endpointId();
+    final String workflow = workflowInstance.workflowId().id();
     final String parameter = workflowInstance.parameter();
 
     final ByteString response = send(

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
@@ -23,7 +23,7 @@ package com.spotify.styx.cli;
 import static com.spotify.styx.cli.CliUtil.formatTimestamp;
 
 import com.spotify.styx.api.BackfillPayload;
-import com.spotify.styx.api.cli.RunStateDataPayload;
+import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.state.Message;
@@ -59,7 +59,7 @@ class PlainCliOutput implements CliOutput {
         System.out.println(String.format(
             "%s %s %s %s %s %d %s",
             workflowId.componentId(),
-            workflowId.endpointId(),
+            workflowId.id(),
             RunStateData.workflowInstance().parameter(),
             RunStateData.state(),
             stateData.executionId().orElse("<no-execution-id>"),
@@ -86,7 +86,7 @@ class PlainCliOutput implements CliOutput {
     System.out.println(String.format("%s %s %s %s %s %s %s %s %s",
                                      backfill.id(),
                                      backfill.workflowId().componentId(),
-                                     backfill.workflowId().endpointId(),
+                                     backfill.workflowId().id(),
                                      backfill.halted(),
                                      backfill.allTriggered(),
                                      backfill.concurrency(),

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -34,7 +34,7 @@ import static org.fusesource.jansi.Ansi.Color.YELLOW;
 
 import com.google.common.collect.Iterables;
 import com.spotify.styx.api.BackfillPayload;
-import com.spotify.styx.api.cli.RunStateDataPayload;
+import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Partitioning;
 import com.spotify.styx.model.WorkflowId;
@@ -60,7 +60,7 @@ class PrettyCliOutput implements CliOutput {
       System.out.println();
       System.out.println(String.format("%s %s",
                                        colored(CYAN, entry.getKey().componentId()),
-                                       colored(BLUE, entry.getKey().endpointId())));
+                                       colored(BLUE, entry.getKey().id())));
       entry.getValue().forEach(runStateData -> {
         final StateData stateData = runStateData.stateData();
         final Ansi ansiState = getAnsiForState(runStateData);
@@ -108,7 +108,7 @@ class PrettyCliOutput implements CliOutput {
                                      toParameter(partitioning, backfill.end()),
                                      toParameter(partitioning, backfill.nextTrigger()),
                                      workflowId.componentId(),
-                                     workflowId.endpointId()));
+                                     workflowId.id()));
   }
 
   private void printBackfillHeader() {

--- a/styx-common/src/main/java/com/spotify/styx/api/BackfillPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/BackfillPayload.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import com.spotify.styx.api.cli.RunStateDataPayload;
 import com.spotify.styx.model.Backfill;
 import java.util.Optional;
 

--- a/styx-common/src/main/java/com/spotify/styx/api/EventsPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/EventsPayload.java
@@ -1,0 +1,63 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.spotify.styx.model.Event;
+import java.util.List;
+
+/**
+ * convert Event to EventsPayload (with associated timestamps)
+ */
+@AutoValue
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class EventsPayload {
+
+  @JsonProperty
+  public abstract List<TimestampedEvent> events();
+
+  @AutoValue
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public abstract static class TimestampedEvent {
+
+    @JsonProperty
+    public abstract Event event();
+
+    @JsonProperty
+    public abstract long timestamp();
+
+    @JsonCreator
+    public static TimestampedEvent create(
+        @JsonProperty("event") Event event,
+        @JsonProperty("timestamp") long timestamp) {
+      return new AutoValue_EventsPayload_TimestampedEvent(event, timestamp);
+    }
+  }
+
+  @JsonCreator
+  public static EventsPayload create(
+      @JsonProperty("events") List<TimestampedEvent> events) {
+    return new AutoValue_EventsPayload(events);
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/api/RunStateDataPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/RunStateDataPayload.java
@@ -1,0 +1,73 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.state.StateData;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Value type for all current active states
+ */
+@AutoValue
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class RunStateDataPayload {
+
+  @JsonProperty
+  //todo change the name of this variable, remove 'active'
+  public abstract List<RunStateData> activeStates();
+
+  @AutoValue
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public abstract static class RunStateData {
+
+    public static final Comparator<RunStateData> PARAMETER_COMPARATOR =
+        Comparator.comparing(a -> a.workflowInstance().parameter());
+
+    @JsonProperty
+    public abstract WorkflowInstance workflowInstance();
+
+    @JsonProperty
+    public abstract String state();
+
+    @JsonProperty
+    public abstract StateData stateData();
+
+    @JsonCreator
+    public static RunStateData create(
+        @JsonProperty("workflow_instance") WorkflowInstance workflowInstance,
+        @JsonProperty("state") String state,
+        @JsonProperty("state_data") StateData stateData) {
+      return new AutoValue_RunStateDataPayload_RunStateData(workflowInstance, state, stateData);
+    }
+  }
+
+  @JsonCreator
+  public static RunStateDataPayload create(
+      @JsonProperty("active_states") List<RunStateData> runStateDataList) {
+    return new AutoValue_RunStateDataPayload(runStateDataList);
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/api/deprecated/BackfillPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/deprecated/BackfillPayload.java
@@ -1,0 +1,51 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api.deprecated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.spotify.styx.model.deprecated.Backfill;
+import java.util.Optional;
+
+@AutoValue
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated
+public abstract class BackfillPayload {
+
+  @JsonProperty
+  public abstract Backfill backfill();
+
+  @JsonProperty
+  public abstract Optional<RunStateDataPayload> statuses();
+
+  public static BackfillPayload create(
+      com.spotify.styx.api.BackfillPayload backfillPayload) {
+    final com.spotify.styx.model.Backfill backfill = backfillPayload.backfill();
+    final Optional<com.spotify.styx.api.RunStateDataPayload>
+        runStateDataPayload = backfillPayload.statuses();
+
+    final Backfill deprecatedBackfill = Backfill.create(backfill);
+    final Optional<RunStateDataPayload> deprecatedRunStateDataPayload =
+        runStateDataPayload.map(RunStateDataPayload::create);
+    return new AutoValue_BackfillPayload(deprecatedBackfill, deprecatedRunStateDataPayload);
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/api/deprecated/BackfillsPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/deprecated/BackfillsPayload.java
@@ -1,0 +1,43 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api.deprecated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@AutoValue
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated
+public abstract class BackfillsPayload {
+
+  @JsonProperty
+  public abstract List<BackfillPayload> backfills();
+
+  public static BackfillsPayload create(
+      com.spotify.styx.api.BackfillsPayload backfillsPayload) {
+    return new AutoValue_BackfillsPayload(
+        backfillsPayload.backfills().stream().map(BackfillPayload::create)
+            .collect(Collectors.toList()));
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/api/deprecated/RunStateDataPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/deprecated/RunStateDataPayload.java
@@ -18,22 +18,24 @@
  * -/-/-
  */
 
-package com.spotify.styx.api.cli;
+package com.spotify.styx.api.deprecated;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.model.deprecated.WorkflowInstance;
 import com.spotify.styx.state.StateData;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Value type for all current active states
  */
 @AutoValue
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated
 public abstract class RunStateDataPayload {
 
   @JsonProperty
@@ -42,6 +44,7 @@ public abstract class RunStateDataPayload {
 
   @AutoValue
   @JsonIgnoreProperties(ignoreUnknown = true)
+  @Deprecated
   public abstract static class RunStateData {
 
     public static final Comparator<RunStateData> PARAMETER_COMPARATOR =
@@ -63,11 +66,24 @@ public abstract class RunStateDataPayload {
         @JsonProperty("state_data") StateData stateData) {
       return new AutoValue_RunStateDataPayload_RunStateData(workflowInstance, state, stateData);
     }
+
+    public static RunStateData create(
+        com.spotify.styx.api.RunStateDataPayload.RunStateData runStateData) {
+      return new AutoValue_RunStateDataPayload_RunStateData(
+          WorkflowInstance.create(runStateData.workflowInstance()), runStateData.state(),
+          runStateData.stateData());
+    }
   }
 
   @JsonCreator
   public static RunStateDataPayload create(
       @JsonProperty("active_states") List<RunStateData> runStateDataList) {
     return new AutoValue_RunStateDataPayload(runStateDataList);
+  }
+
+  public static RunStateDataPayload create(
+      com.spotify.styx.api.RunStateDataPayload runStateDataPayload) {
+    return new AutoValue_RunStateDataPayload(runStateDataPayload.activeStates().stream().map(
+        RunStateData::create).collect(Collectors.toList()));
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/model/ExecutionDescription.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/ExecutionDescription.java
@@ -44,7 +44,7 @@ public abstract class ExecutionDescription {
   public abstract boolean dockerTerminationLogging();
 
   @JsonProperty
-  public abstract Optional<DataEndpoint.Secret> secret();
+  public abstract Optional<Schedule.Secret> secret();
 
   @JsonProperty
   public abstract Optional<String> commitSha();
@@ -54,7 +54,7 @@ public abstract class ExecutionDescription {
       @JsonProperty("docker_image") String dockerImage,
       @JsonProperty("docker_args") List<String> dockerArgs,
       @JsonProperty("docker_termination_logging") boolean dockerTerminationLogging,
-      @JsonProperty("secret") Optional<DataEndpoint.Secret> secret,
+      @JsonProperty("secret") Optional<Schedule.Secret> secret,
       @JsonProperty("commit_sha") Optional<String> commitSha) {
     return new AutoValue_ExecutionDescription(dockerImage, dockerArgs, dockerTerminationLogging, secret, commitSha);
   }

--- a/styx-common/src/main/java/com/spotify/styx/model/Schedule.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/Schedule.java
@@ -29,11 +29,11 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * A specification of a scheduled data endpoint
+ * A specification of a scheduled workflow
  */
 @AutoValue
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract class DataEndpoint {
+public abstract class Schedule {
 
   @JsonProperty
   public abstract String id();
@@ -64,7 +64,7 @@ public abstract class DataEndpoint {
   public abstract List<String> resources();
 
   @JsonCreator
-  public static DataEndpoint create(
+  public static Schedule create(
       @JsonProperty("id") String id,
       @JsonProperty("partitioning") Partitioning partitioning,
       @JsonProperty("docker_image") Optional<String> dockerImage,
@@ -73,7 +73,7 @@ public abstract class DataEndpoint {
       @JsonProperty("secret") Optional<Secret> secret,
       @JsonProperty("resources") List<String> resources) {
 
-    return new AutoValue_DataEndpoint(id, partitioning, dockerImage, dockerArgs,
+    return new AutoValue_Schedule(id, partitioning, dockerImage, dockerArgs,
         dockerTerminationLogging.orElse(false), secret,
         resources == null ? Collections.emptyList() : resources);
   }
@@ -92,7 +92,7 @@ public abstract class DataEndpoint {
     public static Secret create(
         @JsonProperty("name") String name,
         @JsonProperty("mount_path") String mountPath) {
-      return new AutoValue_DataEndpoint_Secret(name, mountPath);
+      return new AutoValue_Schedule_Secret(name, mountPath);
     }
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/model/Workflow.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/Workflow.java
@@ -2,7 +2,7 @@
  * -\-\-
  * Spotify Styx Common
  * --
- * Copyright (C) 2016 Spotify AB
+ * Copyright (C) 2017 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,13 +34,13 @@ public abstract class Workflow {
   public abstract String componentId();
 
   @JsonProperty
-  public abstract String endpointId();
+  public abstract String workflowId();
 
   @JsonProperty
   public abstract URI componentUri();
 
   @JsonProperty
-  public abstract DataEndpoint schedule();
+  public abstract Schedule schedule();
 
   public WorkflowId id() {
     return WorkflowId.ofWorkflow(this);
@@ -50,7 +50,7 @@ public abstract class Workflow {
   public static Workflow create(
       @JsonProperty("component_id") String componentId,
       @JsonProperty("component_uri") URI componentUri,
-      @JsonProperty("schedule") DataEndpoint schedule) {
+      @JsonProperty("schedule") Schedule schedule) {
     return new AutoValue_Workflow(componentId, schedule.id(), componentUri, schedule);
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowId.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowId.java
@@ -2,7 +2,7 @@
  * -\-\-
  * Spotify Styx Common
  * --
- * Copyright (C) 2016 Spotify AB
+ * Copyright (C) 2017 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,21 +41,21 @@ public abstract class WorkflowId {
   public abstract String componentId();
 
   @JsonProperty
-  public abstract String endpointId();
+  public abstract String id();
 
   public String toKey() {
-    return componentId() + "#" + endpointId();
+    return componentId() + "#" + id();
   }
 
   @JsonCreator
   public static WorkflowId create(
       @JsonProperty("component_id") String componentId,
-      @JsonProperty("endpoint_id") String endpointId) {
-    return new AutoValue_WorkflowId(componentId, endpointId);
+      @JsonProperty("id") String id) {
+    return new AutoValue_WorkflowId(componentId, id);
   }
 
   public static WorkflowId ofWorkflow(Workflow workflow) {
-    return new AutoValue_WorkflowId(workflow.componentId(), workflow.endpointId());
+    return new AutoValue_WorkflowId(workflow.componentId(), workflow.workflowId());
   }
 
   public static WorkflowId parseKey(String key) {

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowInstance.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowInstance.java
@@ -2,7 +2,7 @@
  * -\-\-
  * Spotify Styx Common
  * --
- * Copyright (C) 2016 Spotify AB
+ * Copyright (C) 2017 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public abstract class WorkflowInstance {
 
   /**
    * This property contains the thing needed to turn a general purpose Workflow into something
-   * that satisfies a specific data endpoint partition. Might be for example
+   * that satisfies a specific schedule partition. Might be for example
    * '-Pdatehour=2016-01-01T08'.
    */
   @JsonProperty

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WorkflowInstanceExecutionData.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WorkflowInstanceExecutionData.java
@@ -2,7 +2,7 @@
  * -\-\-
  * Spotify Styx Common
  * --
- * Copyright (C) 2016 Spotify AB
+ * Copyright (C) 2017 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/styx-common/src/main/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionData.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionData.java
@@ -1,0 +1,60 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.model.data.deprecated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.spotify.styx.model.data.Trigger;
+import com.spotify.styx.model.deprecated.WorkflowInstance;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Value representing all execution data for a {@link WorkflowInstance}
+ */
+@AutoValue
+@Deprecated
+public abstract class WorkflowInstanceExecutionData {
+
+  public static final Comparator<WorkflowInstanceExecutionData> COMPARATOR =
+      (a, b) -> WorkflowInstance.KEY_COMPARATOR.compare(a.workflowInstance(), b.workflowInstance());
+
+  @JsonProperty
+  public abstract WorkflowInstance workflowInstance();
+
+  @JsonProperty
+  public abstract List<Trigger> triggers();
+
+  @JsonCreator
+  public static WorkflowInstanceExecutionData create(
+      @JsonProperty("workflow_instance") WorkflowInstance workflowInstance,
+      @JsonProperty("triggers") List<Trigger> triggers) {
+    return new AutoValue_WorkflowInstanceExecutionData(workflowInstance, triggers);
+  }
+
+  public static WorkflowInstanceExecutionData create(
+      com.spotify.styx.model.data.WorkflowInstanceExecutionData workflowInstanceExecutionData) {
+    return new AutoValue_WorkflowInstanceExecutionData(
+        WorkflowInstance.create(workflowInstanceExecutionData.workflowInstance()),
+        workflowInstanceExecutionData.triggers());
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/model/deprecated/Backfill.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/deprecated/Backfill.java
@@ -1,0 +1,95 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.model.deprecated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.spotify.styx.model.Partitioning;
+import io.norberg.automatter.AutoMatter;
+import java.time.Instant;
+
+@AutoMatter
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated
+public interface Backfill {
+
+  @JsonProperty
+  String id();
+
+  @JsonProperty
+  Instant start();
+
+  @JsonProperty
+  Instant end();
+
+  @JsonProperty
+  WorkflowId workflowId();
+
+  @JsonProperty
+  int concurrency();
+
+  @JsonProperty
+  Instant nextTrigger();
+
+  @JsonProperty
+  Partitioning partitioning();
+
+  @JsonProperty
+  boolean allTriggered();
+
+  @JsonProperty
+  boolean halted();
+
+  BackfillBuilder builder();
+
+  static BackfillBuilder newBuilder() {
+    return new BackfillBuilder();
+  }
+
+  static Backfill create(com.spotify.styx.model.Backfill backfill) {
+    return Backfill.newBuilder()
+        .allTriggered(backfill.allTriggered())
+        .concurrency(backfill.concurrency())
+        .end(backfill.end())
+        .halted(backfill.halted())
+        .id(backfill.id())
+        .nextTrigger(backfill.nextTrigger())
+        .partitioning(backfill.partitioning())
+        .start(backfill.start())
+        .workflowId(WorkflowId.create(backfill.workflowId()))
+        .build();
+  }
+
+  static com.spotify.styx.model.Backfill create(Backfill backfill) {
+    return com.spotify.styx.model.Backfill.newBuilder()
+        .allTriggered(backfill.allTriggered())
+        .concurrency(backfill.concurrency())
+        .end(backfill.end())
+        .halted(backfill.halted())
+        .id(backfill.id())
+        .nextTrigger(backfill.nextTrigger())
+        .partitioning(backfill.partitioning())
+        .start(backfill.start())
+        .workflowId(com.spotify.styx.model.WorkflowId.create(backfill.workflowId().componentId(),
+                                                             backfill.workflowId().endpointId()))
+        .build();
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/model/deprecated/Workflow.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/deprecated/Workflow.java
@@ -1,0 +1,59 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.model.deprecated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.spotify.styx.model.Schedule;
+import java.net.URI;
+
+@AutoValue
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated
+public abstract class Workflow {
+
+  @JsonProperty
+  public abstract String componentId();
+
+  @JsonProperty
+  public abstract String endpointId();
+
+  @JsonProperty
+  public abstract URI componentUri();
+
+  @JsonProperty
+  public abstract Schedule schedule();
+
+  @JsonCreator
+  public static Workflow create(
+      @JsonProperty("component_id") String componentId,
+      @JsonProperty("component_uri") URI componentUri,
+      @JsonProperty("schedule") Schedule schedule) {
+    return new AutoValue_Workflow(componentId, schedule.id(), componentUri, schedule);
+  }
+
+  public static Workflow create(com.spotify.styx.model.Workflow workflow) {
+    return new AutoValue_Workflow(workflow.componentId(), workflow.workflowId(),
+                                  workflow.componentUri(), workflow.schedule());
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/model/deprecated/WorkflowId.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/deprecated/WorkflowId.java
@@ -1,0 +1,61 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.model.deprecated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import java.util.Comparator;
+
+/**
+ * A value for identifying a {@link Workflow}.
+ *
+ * <p>This should be used instead of instances of {@link Workflow} in order to make references
+ * independent of the current configuration of a {@link Workflow}.
+ */
+@AutoValue
+@Deprecated
+public abstract class WorkflowId {
+
+  public static final Comparator<WorkflowId> KEY_COMPARATOR =
+      (a, b) -> a.toKey().compareTo(b.toKey());
+
+  @JsonProperty
+  public abstract String componentId();
+
+  @JsonProperty
+  public abstract String endpointId();
+
+  public String toKey() {
+    return componentId() + "#" + endpointId();
+  }
+
+  @JsonCreator
+  public static WorkflowId create(
+      @JsonProperty("component_id") String componentId,
+      @JsonProperty("endpoint_id") String id) {
+    return new AutoValue_WorkflowId(componentId, id);
+  }
+
+  public static WorkflowId create(com.spotify.styx.model.WorkflowId workflowId) {
+    return new AutoValue_WorkflowId(workflowId.componentId(), workflowId.id());
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/model/deprecated/WorkflowInstance.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/deprecated/WorkflowInstance.java
@@ -1,0 +1,71 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.model.deprecated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import java.util.Comparator;
+
+/**
+ * An instantiation of a {@link Workflow}.
+ */
+@AutoValue
+@Deprecated
+public abstract class WorkflowInstance {
+
+  public static final Comparator<WorkflowInstance> KEY_COMPARATOR =
+      (a, b) -> a.toKey().compareTo(b.toKey());
+
+  @JsonProperty
+  public abstract WorkflowId workflowId();
+
+  /**
+   * This property contains the thing needed to turn a general purpose Workflow into something
+   * that satisfies a specific data endpoint partition. Might be for example
+   * '-Pdatehour=2016-01-01T08'.
+   */
+  @JsonProperty
+  public abstract String parameter();
+
+  public String toKey() {
+    return workflowId().toKey() + "#" + parameter();
+  }
+
+  @JsonCreator
+  public static WorkflowInstance create(
+      @JsonProperty("workflow_id") WorkflowId workflowId,
+      @JsonProperty("parameter") String parameter) {
+    return new AutoValue_WorkflowInstance(workflowId, parameter);
+  }
+
+  public static WorkflowInstance create(com.spotify.styx.model.WorkflowInstance workflowInstance) {
+    return new AutoValue_WorkflowInstance(WorkflowId.create(workflowInstance.workflowId()),
+                                          workflowInstance.parameter());
+  }
+
+  public static com.spotify.styx.model.WorkflowInstance create(WorkflowInstance workflowInstance) {
+    return com.spotify.styx.model.WorkflowInstance.create(
+        com.spotify.styx.model.WorkflowId.create(workflowInstance.workflowId().componentId(),
+                                                 workflowInstance.workflowId().endpointId()),
+        workflowInstance.parameter());
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -225,7 +225,7 @@ class DatastoreStorage {
             return Json.OBJECT_MAPPER
                 .readValue(e.getString(PROPERTY_WORKFLOW_JSON), Workflow.class);
           } catch (IOException e1) {
-            LOG.info("Failed to read workflow for {}, {}", workflowId.componentId(), workflowId.endpointId());
+            LOG.info("Failed to read workflow for {}, {}", workflowId.componentId(), workflowId.id());
           }
           return null;
         });
@@ -244,7 +244,7 @@ class DatastoreStorage {
       final Optional<Entity> workflowOpt = getOpt(transaction, workflowKey);
       if (!workflowOpt.isPresent()) {
         throw new ResourceNotFoundException(
-            String.format("%s:%s doesn't exist.", workflowId.componentId(), workflowId.endpointId()));
+            String.format("%s:%s doesn't exist.", workflowId.componentId(), workflowId.id()));
       }
 
       final Entity.Builder builder = Entity
@@ -314,7 +314,7 @@ class DatastoreStorage {
       final Key key = activeWorkflowInstanceKey(workflowInstance);
       final Entity entity = Entity.builder(key)
           .set(PROPERTY_COMPONENT, workflowInstance.workflowId().componentId())
-          .set(PROPERTY_WORKFLOW, workflowInstance.workflowId().endpointId())
+          .set(PROPERTY_WORKFLOW, workflowInstance.workflowId().id())
           .set(PROPERTY_PARAMETER, workflowInstance.parameter())
           .set(PROPERTY_COUNTER, counter)
           .build();
@@ -336,7 +336,7 @@ class DatastoreStorage {
       final Optional<Entity> workflowOpt = getOpt(transaction, workflowKey);
       if (!workflowOpt.isPresent()) {
         throw new ResourceNotFoundException(
-            String.format("%s:%s doesn't exist.", workflowId.componentId(), workflowId.endpointId()));
+            String.format("%s:%s doesn't exist.", workflowId.componentId(), workflowId.id()));
       }
 
       final Entity.Builder builder = Entity.builder(workflowOpt.get());
@@ -433,7 +433,7 @@ class DatastoreStorage {
     return datastore.newKeyFactory()
         .ancestors(PathElement.of(KIND_COMPONENT, workflowId.componentId()))
         .kind(KIND_WORKFLOW)
-        .newKey(workflowId.endpointId());
+        .newKey(workflowId.id());
   }
 
   private Key activeWorkflowInstanceKey(WorkflowInstance workflowInstance) {
@@ -452,9 +452,9 @@ class DatastoreStorage {
 
   private WorkflowId parseWorkflowId(Entity workflow) {
     final String componentId = workflow.key().ancestors().get(0).name();
-    final String endpointId = workflow.key().name();
+    final String id = workflow.key().name();
 
-    return WorkflowId.create(componentId, endpointId);
+    return WorkflowId.create(componentId, id);
   }
 
   /**
@@ -604,7 +604,7 @@ class DatastoreStorage {
     final EntityQuery query = backfillQueryBuilder(
         showAll,
         PropertyFilter.eq(PROPERTY_COMPONENT, workflowId.componentId()),
-        PropertyFilter.eq(PROPERTY_WORKFLOW, workflowId.endpointId()))
+        PropertyFilter.eq(PROPERTY_WORKFLOW, workflowId.id()))
         .build();
 
     return backfillsForQuery(query);
@@ -639,7 +639,7 @@ class DatastoreStorage {
         .set(PROPERTY_START, instantToDatetime(backfill.start()))
         .set(PROPERTY_END, instantToDatetime(backfill.end()))
         .set(PROPERTY_COMPONENT, backfill.workflowId().componentId())
-        .set(PROPERTY_WORKFLOW, backfill.workflowId().endpointId())
+        .set(PROPERTY_WORKFLOW, backfill.workflowId().id())
         .set(PROPERTY_PARTITIONING, backfill.partitioning().name())
         .set(PROPERTY_NEXT_TRIGGER, instantToDatetime(backfill.nextTrigger()))
         .set(PROPERTY_ALL_TRIGGERED, backfill.allTriggered())

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -252,7 +252,7 @@ public class InMemStorage implements Storage {
   @Override
   public List<Backfill> backfillsForWorkflow(boolean showAll, String workflow) throws IOException {
     Stream<Backfill> backfillStream = backfillStore.values().stream()
-        .filter(backfill -> backfill.workflowId().endpointId().equals(workflow));
+        .filter(backfill -> backfill.workflowId().id().equals(workflow));
 
     if (!showAll) {
       backfillStream = backfillStream.filter(backfill -> backfill.halted() && backfill.allTriggered());

--- a/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
+++ b/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
@@ -29,9 +29,9 @@ import static java.util.Collections.emptyList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 
-import com.spotify.styx.model.DataEndpoint;
-import com.spotify.styx.model.DataEndpoint.Secret;
 import com.spotify.styx.model.ExecutionDescription;
+import com.spotify.styx.model.Schedule;
+import com.spotify.styx.model.Schedule.Secret;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import java.net.URI;
@@ -55,24 +55,24 @@ public final class TestData {
   public static final WorkflowInstance WORKFLOW_INSTANCE =
       WorkflowInstance.create(WORKFLOW_ID, "2016-09-01");
 
-  public static final DataEndpoint HOURLY_DATA_ENDPOINT =
-      DataEndpoint.create(
+  public static final Schedule HOURLY_SCHEDULE =
+      Schedule.create(
           "styx.TestEndpoint", HOURS, empty(), empty(), empty(), empty(), emptyList());
 
-  public static final DataEndpoint DAILY_DATA_ENDPOINT =
-      DataEndpoint.create(
+  public static final Schedule DAILY_SCHEDULE =
+      Schedule.create(
           "styx.TestEndpoint", DAYS, empty(), empty(), empty(), empty(), emptyList());
 
-  public static final DataEndpoint WEEKLY_DATA_ENDPOINT =
-      DataEndpoint.create(
+  public static final Schedule WEEKLY_SCHEDULE =
+      Schedule.create(
           "styx.TestEndpoint", WEEKS, empty(), empty(), empty(), empty(), emptyList());
 
-  public static final DataEndpoint MONTHLY_DATA_ENDPOINT =
-      DataEndpoint.create(
+  public static final Schedule MONTHLY_SCHEDULE =
+      Schedule.create(
           "styx.TestEndpoint", MONTHS, empty(), empty(), empty(), empty(), emptyList());
 
-  public static final DataEndpoint FULL_DATA_ENDPOINT =
-      DataEndpoint.create(
+  public static final Schedule FULL_DATA_SCHEDULE =
+      Schedule.create(
           "styx.TestEndpoint", DAYS, of("busybox"), of(asList("x", "y")), of(false),
           of(Secret.create("name", "/path")), emptyList());
 
@@ -81,6 +81,6 @@ public final class TestData {
           "busybox:1.1",
           Arrays.asList("foo", "bar"),
           false,
-          Optional.of(DataEndpoint.Secret.create("secret", "/dev/null")),
+          Optional.of(Schedule.Secret.create("secret", "/dev/null")),
           Optional.of("00000ef508c1cb905e360590ce3e7e9193f6b370"));
 }

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
@@ -2,7 +2,7 @@
  * -\-\-
  * Spotify Styx Common
  * --
- * Copyright (C) 2016 Spotify AB
+ * Copyright (C) 2017 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
@@ -131,7 +131,7 @@ public class WorkflowInstanceExecutionDataTest {
         + "\"workflow_instance\":{"
           + "\"workflow_id\":{"
             + "\"component_id\":\"component1\","
-            + "\"endpoint_id\":\"endpoint1\""
+            + "\"id\":\"endpoint1\""
           + "},"
           + "\"parameter\":\"2016-08-03T06\""
         + "},"

--- a/styx-common/src/test/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionDataTest.java
@@ -1,0 +1,230 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.model.data.deprecated;
+
+import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.model.data.ExecStatus;
+import com.spotify.styx.model.data.Execution;
+import com.spotify.styx.model.data.Trigger;
+import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
+import java.time.Instant;
+import java.util.Arrays;
+import org.junit.Test;
+
+@Deprecated
+public class WorkflowInstanceExecutionDataTest {
+
+  @Test
+  public void shouldDeserializeExecStatus() throws Exception {
+    String json = statusJson("09:56", "STARTED");
+    ExecStatus executionStatus = OBJECT_MAPPER.readValue(json, ExecStatus.class);
+
+    assertThat(executionStatus.timestamp(), is(Instant.parse("2016-08-03T09:56:03.607Z")));
+    assertThat(executionStatus.status(), is("STARTED"));
+  }
+
+  @Test
+  public void shouldDeserializeExecution() throws Exception {
+    String json = executionJson("exec-id", "busybox:1.0", "09", "SUCCESS");
+
+    Execution execution = OBJECT_MAPPER.readValue(json, Execution.class);
+    Execution expected = Execution.create(
+        "exec-id",
+        "busybox:1.0",
+        Arrays.asList(
+            ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
+            ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
+            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "SUCCESS")
+        )
+    );
+    assertThat(execution, is(expected));
+  }
+
+  @Test
+  public void shouldDeserializeTrigger() throws Exception {
+    String jsonExec0 = executionJson("exec-id-0", "busybox:1.0", "09", "FAILED");
+    String jsonExec1 = executionJson("exec-id-1", "busybox:1.1", "10", "SUCCESS");
+
+    String json =
+        "{"
+        + "\"trigger_id\":\"trig-0\","
+        + "\"timestamp\":\"" + time("07:55") + "\","
+        + "\"complete\":true,"
+        + "\"executions\":["
+        + jsonExec0 + "," + jsonExec1
+        + "]}";
+
+    Trigger trigger = OBJECT_MAPPER.readValue(json, Trigger.class);
+    Trigger expected = Trigger.create(
+        "trig-0",
+        time("07:55"),
+        true,
+        Arrays.asList(
+            Execution.create(
+                "exec-id-0",
+                "busybox:1.0",
+                Arrays.asList(
+                    ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
+                    ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
+                    ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED")
+                )
+            ),
+            Execution.create(
+                "exec-id-1",
+                "busybox:1.1",
+                Arrays.asList(
+                    ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),
+                    ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING"),
+                    ExecStatus.create(Instant.parse("2016-08-03T10:58:03.607Z"), "SUCCESS")
+                )
+            )
+        )
+    );
+    assertThat(trigger, is(expected));
+  }
+
+  @Test
+  public void shouldDeserializeExecutionData() throws Exception {
+    String jsonExec00 = executionJson("exec-id-00", "busybox:1.0", "07", "FAILED");
+    String jsonExec01 = executionJson("exec-id-01", "busybox:1.1", "08", "SUCCESS");
+
+    String jsonTrigger0 =
+        "{"
+        + "\"trigger_id\":\"trig-0\","
+        + "\"timestamp\":\"" + time("07:55") + "\","
+        + "\"complete\":true,"
+        + "\"executions\":["
+        + jsonExec00 + "," + jsonExec01
+        + "]}";
+
+    String jsonExec10 = executionJson("exec-id-10", "busybox:1.2", "09", "FAILED");
+    String jsonExec11 = executionJson("exec-id-11", "busybox:1.3", "10", "SUCCESS");
+
+    String jsonTrigger1 =
+        "{"
+        + "\"trigger_id\":\"trig-1\","
+        + "\"timestamp\":\"" + time("09:55") + "\","
+        + "\"complete\":false,"
+        + "\"executions\":["
+        + jsonExec10 + "," + jsonExec11
+        + "]}";
+
+    String json =
+        "{"
+        + "\"workflow_instance\":{"
+          + "\"workflow_id\":{"
+            + "\"component_id\":\"component1\","
+            + "\"id\":\"endpoint1\""
+          + "},"
+          + "\"parameter\":\"2016-08-03T06\""
+        + "},"
+        + "\"triggers\":["
+        + jsonTrigger0 + "," + jsonTrigger1
+        + "]}";
+
+    com.spotify.styx.model.data.WorkflowInstanceExecutionData
+        executionData = OBJECT_MAPPER.readValue(json, WorkflowInstanceExecutionData.class);
+    com.spotify.styx.model.data.WorkflowInstanceExecutionData
+        expected = WorkflowInstanceExecutionData.create(
+        WorkflowInstance.parseKey("component1#endpoint1#2016-08-03T06"),
+        Arrays.asList(
+            Trigger.create(
+                "trig-0",
+                time("07:55"),
+                true,
+                Arrays.asList(
+                    Execution.create(
+                        "exec-id-00",
+                        "busybox:1.0",
+                        Arrays.asList(
+                            ExecStatus.create(Instant.parse("2016-08-03T07:56:03.607Z"), "STARTED"),
+                            ExecStatus.create(Instant.parse("2016-08-03T07:57:03.607Z"), "RUNNING"),
+                            ExecStatus.create(Instant.parse("2016-08-03T07:58:03.607Z"), "FAILED")
+                        )
+                    ),
+                    Execution.create(
+                        "exec-id-01",
+                        "busybox:1.1",
+                        Arrays.asList(
+                            ExecStatus.create(Instant.parse("2016-08-03T08:56:03.607Z"), "STARTED"),
+                            ExecStatus.create(Instant.parse("2016-08-03T08:57:03.607Z"), "RUNNING"),
+                            ExecStatus.create(Instant.parse("2016-08-03T08:58:03.607Z"), "SUCCESS")
+                        )
+                    )
+                )
+            ),
+            Trigger.create(
+                "trig-1",
+                time("09:55"),
+                false,
+                Arrays.asList(
+                    Execution.create(
+                        "exec-id-10",
+                        "busybox:1.2",
+                        Arrays.asList(
+                            ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
+                            ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
+                            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED")
+                        )
+                    ),
+                    Execution.create(
+                        "exec-id-11",
+                        "busybox:1.3",
+                        Arrays.asList(
+                            ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),
+                            ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING"),
+                            ExecStatus.create(Instant.parse("2016-08-03T10:58:03.607Z"), "SUCCESS")
+                        )
+                    )
+                )
+            )
+        )
+    );
+
+    assertThat(executionData, is(expected));
+  }
+
+  private String statusJson(String time, String status) {
+    return "{\"timestamp\":\"2016-08-03T" + time + ":03.607Z\", \"status\":\"" + status + "\"}";
+  }
+
+  private String executionJson(String id, String image, String hour, String endStatus) {
+    String jsonStatus1 = statusJson(hour + ":56", "STARTED");
+    String jsonStatus2 = statusJson(hour + ":57", "RUNNING");
+    String jsonStatus3 = statusJson(hour + ":58", endStatus);
+
+    return
+        "{"
+        + "\"execution_id\":\"" + id + "\","
+        + "\"docker_image\":\"" + image + "\","
+        + "\"statuses\":["
+        + jsonStatus1 + "," + jsonStatus2 + "," + jsonStatus3
+        + "]}";
+  }
+
+  private static Instant time(String time) {
+    return Instant.parse("2016-08-03T" + time + ":03.607Z");
+  }
+}

--- a/styx-common/src/test/java/com/spotify/styx/serialization/JsonRoundtripTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/JsonRoundtripTest.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Partitioning;
 import com.spotify.styx.testdata.TestData;
 import java.io.IOException;
@@ -41,9 +41,9 @@ public class JsonRoundtripTest {
   private static final Logger LOG = LoggerFactory.getLogger(JsonRoundtripTest.class);
 
   @Test
-  public void testRoundtripDataEndpoint() throws Exception {
-    DataEndpoint before = TestData.FULL_DATA_ENDPOINT;
-    DataEndpoint after = roundtrip(before, DataEndpoint.class);
+  public void testRoundtripSchedule() throws Exception {
+    Schedule before = TestData.FULL_DATA_SCHEDULE;
+    Schedule after = roundtrip(before, Schedule.class);
     assertThat(after, is(before));
   }
 
@@ -64,7 +64,7 @@ public class JsonRoundtripTest {
   public void testLegacyPartitioningSupport() throws Exception {
     for (Map.Entry<String, Partitioning> testCase : LEGACY_PARTITIONING_TESTS.entrySet()) {
       String json = "{\"id\":\"styx.TestWeekly\",\"partitioning\":\"" + testCase.getKey() + "\"}";
-      DataEndpoint after = roundtrip(json, DataEndpoint.class);
+      Schedule after = roundtrip(json, Schedule.class);
       assertThat(after.partitioning(), is(testCase.getValue()));
     }
   }

--- a/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
@@ -25,7 +25,7 @@ import static com.spotify.styx.serialization.Json.serialize;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.WorkflowId;
@@ -55,7 +55,7 @@ public class PersistentEventTest {
       DOCKER_IMAGE,
       Arrays.asList("foo", "bar"),
       false,
-      Optional.of(DataEndpoint.Secret.create("secret", "/dev/null")),
+      Optional.of(Schedule.Secret.create("secret", "/dev/null")),
       Optional.of(COMMIT_SHA));
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/state/StateDataSerializationTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/StateDataSerializationTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.serialization.Json;
 import com.spotify.styx.util.TriggerUtil;
@@ -108,7 +108,7 @@ public class StateDataSerializationTest {
               "pipeline-core:474339e",
               Arrays.asList("echo", "hello", "world"),
               false,
-              Optional.of(DataEndpoint.Secret.create("pipeline-core-secret", "/etc/keys")),
+              Optional.of(Schedule.Secret.create("pipeline-core-secret", "/etc/keys")),
               Optional.of("474339ec18d3d04d5d513856bc8ca1d4f1aed03f")
           )
       )

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -24,7 +24,7 @@ import static com.github.npathai.hamcrestopt.OptionalMatchers.hasValue;
 import static com.spotify.styx.model.Partitioning.DAYS;
 import static com.spotify.styx.model.Partitioning.HOURS;
 import static com.spotify.styx.model.WorkflowState.patchDockerImage;
-import static com.spotify.styx.testdata.TestData.FULL_DATA_ENDPOINT;
+import static com.spotify.styx.testdata.TestData.FULL_DATA_SCHEDULE;
 import static com.spotify.styx.testdata.TestData.WORKFLOW_INSTANCE;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.empty;
@@ -47,7 +47,7 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StringValue;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
@@ -80,28 +80,28 @@ public class DatastoreStorageTest {
   private static final WorkflowId WORKFLOW_ID_NO_STATE = WorkflowId.create("noStateComp", "NoStateEndpoint");
   private static final WorkflowId WORKFLOW_ID_WITH_DOCKER_IMG = WorkflowId.create("dockerComp", "dockerEndpoint");
 
-  private static final DataEndpoint DATA_ENDPOINT_EMPTY_CONF =
-      DataEndpoint.create(
-          WORKFLOW_ID_NO_DOCKER_IMG.endpointId(), DAYS, empty(), empty(), empty(), empty(), emptyList());
+  private static final Schedule SCHEDULE_EMPTY_CONF =
+      Schedule.create(
+          WORKFLOW_ID_NO_DOCKER_IMG.id(), DAYS, empty(), empty(), empty(), empty(), emptyList());
   private static final Optional<String> DOCKER_IMAGE = of("busybox");
   private static final String DOCKER_IMAGE_COMPONENT = "busybox:component";
   private static final String DOCKER_IMAGE_WORKFLOW = "busybox:workflow";
   private static final String COMMIT_SHA = "dcee675978b4d89e291bb695d0ca7deaf05d2a32";
-  private static final DataEndpoint DATA_ENDPOINT_WITH_DOCKER_IMAGE =
-      DataEndpoint.create(
-          WORKFLOW_ID_WITH_DOCKER_IMG.endpointId(), DAYS, DOCKER_IMAGE, empty(), empty(), empty(), emptyList());
+  private static final Schedule SCHEDULE_WITH_DOCKER_IMAGE =
+      Schedule.create(
+          WORKFLOW_ID_WITH_DOCKER_IMG.id(), DAYS, DOCKER_IMAGE, empty(), empty(), empty(), emptyList());
   private static final Workflow
       WORKFLOW_NO_DOCKER_IMAGE =
       Workflow.create(WORKFLOW_ID_NO_DOCKER_IMG.componentId(), URI.create("http://foo"),
-          DATA_ENDPOINT_EMPTY_CONF);
+                      SCHEDULE_EMPTY_CONF);
   private static final Workflow
       WORKFLOW_NO_STATE =
       Workflow.create(WORKFLOW_ID_NO_STATE.componentId(), URI.create("http://foo"),
-          DATA_ENDPOINT_EMPTY_CONF);
+                      SCHEDULE_EMPTY_CONF);
   private static final Workflow
       WORKFLOW_WITH_DOCKER_IMAGE =
       Workflow.create(WORKFLOW_ID_WITH_DOCKER_IMG.componentId(), URI.create("http://foo"),
-          DATA_ENDPOINT_WITH_DOCKER_IMAGE);
+                      SCHEDULE_WITH_DOCKER_IMAGE);
 
   private static final Instant NEXT_EXECUTION = Instant.parse("2016-03-14T14:00:00Z");
 
@@ -140,7 +140,7 @@ public class DatastoreStorageTest {
 
   @Test
   public void shouldPersistWorkflows() throws Exception {
-    Workflow workflow = Workflow.create("test", URI.create("http://foo"), FULL_DATA_ENDPOINT);
+    Workflow workflow = Workflow.create("test", URI.create("http://foo"), FULL_DATA_SCHEDULE);
     storage.store(workflow);
     Optional<Workflow> retrieved = storage.workflow(workflow.id());
 
@@ -172,15 +172,15 @@ public class DatastoreStorageTest {
 
   @Test
   public void shouldNotRemoveWorkflowWhenSettingDockerImage() throws Exception {
-    Workflow workflow = Workflow.create("test", URI.create("http://foo"), FULL_DATA_ENDPOINT);
+    Workflow workflow = Workflow.create("test", URI.create("http://foo"), FULL_DATA_SCHEDULE);
     storage.store(workflow);
     Optional<Workflow> retrieved = storage.workflow(workflow.id());
     assertThat(retrieved, is(Optional.of(workflow)));
 
-    storage.patchState(workflow.id(), patchDockerImage(FULL_DATA_ENDPOINT.dockerImage().get()));
+    storage.patchState(workflow.id(), patchDockerImage(FULL_DATA_SCHEDULE.dockerImage().get()));
     Optional<String> dockerImg = storage.getDockerImage(workflow.id());
     retrieved = storage.workflow(workflow.id());
-    assertThat(dockerImg, is(FULL_DATA_ENDPOINT.dockerImage()));
+    assertThat(dockerImg, is(FULL_DATA_SCHEDULE.dockerImage()));
     assertThat(retrieved, is(Optional.of(workflow)));
   }
 
@@ -203,7 +203,8 @@ public class DatastoreStorageTest {
   public void shouldPersistDockerImagePerComponent() throws Exception {
     WorkflowState state = patchDockerImage(DOCKER_IMAGE_COMPONENT);
 
-    storage.store(Workflow.create(WORKFLOW_ID1.componentId(), URI.create("http://foo"), DATA_ENDPOINT_EMPTY_CONF));
+    storage.store(Workflow.create(WORKFLOW_ID1.componentId(), URI.create("http://foo"),
+                                  SCHEDULE_EMPTY_CONF));
     storage.patchState(WORKFLOW_ID1.componentId(), state);
     Optional<String> retrieved = storage.getDockerImage(WORKFLOW_ID1);
 
@@ -214,7 +215,8 @@ public class DatastoreStorageTest {
   public void shouldPersistCommitShaPerComponent() throws Exception {
     WorkflowState state = WorkflowState.builder().commitSha(COMMIT_SHA).build();
 
-    storage.store(Workflow.create(WORKFLOW_ID1.componentId(), URI.create("http://foo"), DATA_ENDPOINT_EMPTY_CONF));
+    storage.store(Workflow.create(WORKFLOW_ID1.componentId(), URI.create("http://foo"),
+                                  SCHEDULE_EMPTY_CONF));
     storage.patchState(WORKFLOW_ID1.componentId(), state);
     WorkflowState retrieved = storage.workflowState(WORKFLOW_ID1);
 
@@ -226,7 +228,8 @@ public class DatastoreStorageTest {
     storage.store(Workflow.create(
         WORKFLOW_ID1.componentId(),
         URI.create("http://foo"),
-        DataEndpoint.create(WORKFLOW_ID1.endpointId(), DAYS, empty(), empty(), empty(), empty(), emptyList())));
+        Schedule
+            .create(WORKFLOW_ID1.id(), DAYS, empty(), empty(), empty(), empty(), emptyList())));
     storage.patchState(WORKFLOW_ID1, patchDockerImage(DOCKER_IMAGE_WORKFLOW));
     Optional<String> retrieved = storage.getDockerImage(WORKFLOW_ID1);
 
@@ -238,7 +241,8 @@ public class DatastoreStorageTest {
     storage.store(Workflow.create(
         WORKFLOW_ID1.componentId(),
         URI.create("http://foo"),
-        DataEndpoint.create(WORKFLOW_ID1.endpointId(), DAYS, empty(), empty(), empty(), empty(), emptyList())));
+        Schedule
+            .create(WORKFLOW_ID1.id(), DAYS, empty(), empty(), empty(), empty(), emptyList())));
     storage.patchState(WORKFLOW_ID1, WorkflowState.builder().commitSha(COMMIT_SHA).build());
     WorkflowState retrieved = storage.workflowState(WORKFLOW_ID1);
 
@@ -427,7 +431,7 @@ public class DatastoreStorageTest {
     Entity instance = activeInstances.get(0);
     assertThat(instance.getLong(DatastoreStorage.PROPERTY_COUNTER), is(42L));
     assertThat(instance.getString(DatastoreStorage.PROPERTY_COMPONENT), is(WORKFLOW_INSTANCE.workflowId().componentId()));
-    assertThat(instance.getString(DatastoreStorage.PROPERTY_WORKFLOW), is(WORKFLOW_INSTANCE.workflowId().endpointId()));
+    assertThat(instance.getString(DatastoreStorage.PROPERTY_WORKFLOW), is(WORKFLOW_INSTANCE.workflowId().id()));
     assertThat(instance.getString(DatastoreStorage.PROPERTY_PARAMETER), is(WORKFLOW_INSTANCE.parameter()));
   }
 
@@ -489,7 +493,8 @@ public class DatastoreStorageTest {
     storage.store(Workflow.create(
         WORKFLOW_ID1.componentId(),
         URI.create("http://not/important"),
-        DataEndpoint.create(WORKFLOW_ID1.endpointId(), DAYS, empty(), empty(), empty(), empty(), emptyList())));
+        Schedule
+            .create(WORKFLOW_ID1.id(), DAYS, empty(), empty(), empty(), empty(), emptyList())));
     WorkflowState state = WorkflowState.builder()
         .enabled(true)
         .dockerImage(DOCKER_IMAGE.get())
@@ -549,6 +554,7 @@ public class DatastoreStorageTest {
     return Workflow.create(
         workflowId.componentId(),
         URI.create("http://foo"),
-        DataEndpoint.create(workflowId.endpointId(), HOURS, empty(), empty(), empty(), empty(), emptyList()));
+        Schedule
+            .create(workflowId.id(), HOURS, empty(), empty(), empty(), empty(), emptyList()));
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/storage/InMemoryStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/InMemoryStorageTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowState;
@@ -78,6 +78,7 @@ public class InMemoryStorageTest {
     return Workflow.create(
         workflowId.componentId(),
         URI.create("http://foo"),
-        DataEndpoint.create(workflowId.endpointId(), HOURS, empty(), empty(), empty(), empty(), emptyList()));
+        Schedule
+            .create(workflowId.id(), HOURS, empty(), empty(), empty(), empty(), emptyList()));
   }
 }

--- a/styx-local-files-source/src/main/java/com/spotify/styx/YamlScheduleDefinition.java
+++ b/styx-local-files-source/src/main/java/com/spotify/styx/YamlScheduleDefinition.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -34,11 +34,11 @@ import javax.annotation.Nullable;
 abstract class YamlScheduleDefinition {
 
   @JsonProperty
-  public abstract List<DataEndpoint> schedules();
+  public abstract List<Schedule> schedules();
 
   @JsonCreator
   public static YamlScheduleDefinition create(
-      @JsonProperty("schedules") @Nullable List<DataEndpoint> schedules) {
+      @JsonProperty("schedules") @Nullable List<Schedule> schedules) {
     if (schedules == null) {
       schedules = Collections.emptyList();
     }

--- a/styx-local-files-source/src/test/java/com/spotify/styx/LocalFileScheduleSourceTest.java
+++ b/styx-local-files-source/src/test/java/com/spotify/styx/LocalFileScheduleSourceTest.java
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 import com.google.common.io.Resources;
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Partitioning;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.schedule.ScheduleSource;
@@ -182,11 +182,11 @@ public class LocalFileScheduleSourceTest {
   }
 
   private void changeListener(Workflow workflow) {
-    workflows.put(workflow.endpointId(), workflow);
+    workflows.put(workflow.workflowId(), workflow);
   }
 
   private void removeListener(Workflow workflow) {
-    workflows.remove(workflow.endpointId());
+    workflows.remove(workflow.workflowId());
   }
 
   private byte[] readResource(String filename) throws IOException, URISyntaxException {
@@ -199,7 +199,7 @@ public class LocalFileScheduleSourceTest {
     return Workflow.create(
         "test-file.yaml",
         testPath.toUri(),
-        DataEndpoint.create(
+        Schedule.create(
             "foo",
             Partitioning.HOURS,
             empty(),
@@ -214,7 +214,7 @@ public class LocalFileScheduleSourceTest {
     return Workflow.create(
         "test-file.yaml",
         testPath.toUri(),
-        DataEndpoint.create(
+        Schedule.create(
             "foo",
             Partitioning.DAYS,
             empty(),
@@ -229,7 +229,7 @@ public class LocalFileScheduleSourceTest {
     return Workflow.create(
         "test-file.yaml",
         testPath.toUri(),
-        DataEndpoint.create(
+        Schedule.create(
             "foo",
             Partitioning.HOURS,
             empty(),
@@ -244,7 +244,7 @@ public class LocalFileScheduleSourceTest {
     return Workflow.create(
         "test-file.yaml",
         testPath.toUri(),
-        DataEndpoint.create(
+        Schedule.create(
             "bar",
             Partitioning.DAYS,
             empty(),

--- a/styx-schedule-source/src/main/java/com/spotify/styx/schedule/model/ScheduleDefinition.java
+++ b/styx-schedule-source/src/main/java/com/spotify/styx/schedule/model/ScheduleDefinition.java
@@ -24,27 +24,27 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
 /**
- * Mainly a list of {@link DataEndpoint}s
+ * Mainly a list of {@link Schedule}s
  */
 @AutoValue
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class ScheduleDefinition {
 
   @JsonProperty
-  public abstract List<DataEndpoint> dataEndpoints();
+  public abstract List<Schedule> schedules();
 
   @JsonCreator
   public static ScheduleDefinition create(
-      @JsonProperty("data_endpoints") @Nullable List<DataEndpoint> dataEndpoints) {
-    if (dataEndpoints == null) {
-      dataEndpoints = Collections.emptyList();
+      @JsonProperty("workflows") @Nullable List<Schedule> schedules) {
+    if (schedules == null) {
+      schedules = Collections.emptyList();
     }
-    return new AutoValue_ScheduleDefinition(dataEndpoints);
+    return new AutoValue_ScheduleDefinition(schedules);
   }
 }

--- a/styx-schedule-source/src/main/java/com/spotify/styx/schedule/model/deprecated/ScheduleDefinition.java
+++ b/styx-schedule-source/src/main/java/com/spotify/styx/schedule/model/deprecated/ScheduleDefinition.java
@@ -1,6 +1,6 @@
 /*-
  * -\-\-
- * Spotify Styx Common
+ * Spotify Styx Schedule Source API
  * --
  * Copyright (C) 2016 Spotify AB
  * --
@@ -18,46 +18,39 @@
  * -/-/-
  */
 
-package com.spotify.styx.api.cli;
+package com.spotify.styx.schedule.model.deprecated;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import com.spotify.styx.model.Event;
+import com.spotify.styx.model.Schedule;
+import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
- * convert Event to EventsPayload (with associated timestamps)
+ * Mainly a list of {@link Schedule}s
  */
 @AutoValue
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract class EventsPayload {
+@Deprecated
+public abstract class ScheduleDefinition {
 
   @JsonProperty
-  public abstract List<TimestampedEvent> events();
-
-  @AutoValue
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  public abstract static class TimestampedEvent {
-
-    @JsonProperty
-    public abstract Event event();
-
-    @JsonProperty
-    public abstract long timestamp();
-
-    @JsonCreator
-    public static TimestampedEvent create(
-        @JsonProperty("event") Event event,
-        @JsonProperty("timestamp") long timestamp) {
-      return new AutoValue_EventsPayload_TimestampedEvent(event, timestamp);
-    }
-  }
+  public abstract List<Schedule> schedules();
 
   @JsonCreator
-  public static EventsPayload create(
-      @JsonProperty("events") List<TimestampedEvent> events) {
-    return new AutoValue_EventsPayload(events);
+  public static ScheduleDefinition create(
+      @JsonProperty("data_endpoints") @Nullable List<Schedule> schedules) {
+    if (schedules == null) {
+      schedules = Collections.emptyList();
+    }
+    return new AutoValue_ScheduleDefinition(schedules);
+  }
+
+  public static com.spotify.styx.schedule.model.ScheduleDefinition create(
+      ScheduleDefinition scheduleDefinition) {
+    return com.spotify.styx.schedule.model.ScheduleDefinition.create(scheduleDefinition.schedules());
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -24,7 +24,7 @@ import static java.util.Optional.empty;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.StateManager;
@@ -68,13 +68,13 @@ public interface DockerRunner extends Closeable {
 
     public abstract boolean terminationLogging();
 
-    public abstract Optional<DataEndpoint.Secret> secret();
+    public abstract Optional<Schedule.Secret> secret();
 
     public static RunSpec create(
         String imageName,
         ImmutableList<String> args,
         boolean terminationLogging,
-        Optional<DataEndpoint.Secret> secret) {
+        Optional<Schedule.Secret> secret) {
       return new AutoValue_DockerRunner_RunSpec(imageName, args, terminationLogging, secret);
     }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -30,10 +30,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.spotify.styx.model.DataEndpoint;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.EventVisitor;
 import com.spotify.styx.model.ExecutionDescription;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.Message;
@@ -75,6 +75,7 @@ class KubernetesDockerRunner implements DockerRunner {
   static final String STYX_WORKFLOW_INSTANCE_ANNOTATION = "styx-workflow-instance";
   static final String DOCKER_TERMINATION_LOGGING_ANNOTATION = "styx-docker-termination-logging";
   static final String COMPONENT_ID = "STYX_COMPONENT_ID";
+  // TODO: for backward compatibility, delete later
   static final String ENDPOINT_ID = "STYX_ENDPOINT_ID";
   static final String WORKFLOW_ID = "STYX_WORKFLOW_ID";
   static final String PARAMETER = "STYX_PARAMETER";
@@ -133,13 +134,14 @@ class KubernetesDockerRunner implements DockerRunner {
         .withName(COMPONENT_ID)
         .withValue(workflowInstance.workflowId().componentId())
         .build());
+    // TODO: for backward compatibility, delete later
     env.add(new EnvVarBuilder()
         .withName(ENDPOINT_ID)
-        .withValue(workflowInstance.workflowId().endpointId())
+        .withValue(workflowInstance.workflowId().id())
         .build());
     env.add(new EnvVarBuilder()
         .withName(WORKFLOW_ID)
-        .withValue(workflowInstance.workflowId().endpointId())
+        .withValue(workflowInstance.workflowId().id())
         .build());
     env.add(new EnvVarBuilder()
         .withName(PARAMETER)
@@ -170,7 +172,7 @@ class KubernetesDockerRunner implements DockerRunner {
             .withEnv(env);
 
     if (runSpec.secret().isPresent()) {
-      final DataEndpoint.Secret secret = runSpec.secret().get();
+      final Schedule.Secret secret = runSpec.secret().get();
       spec = spec.addNewVolume()
           .withName(secret.name())
           .withNewSecret()

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
@@ -161,7 +161,7 @@ public final class MetricsStats implements Stats {
     activeStatesPerWorkflowGauges.computeIfAbsent(
         workflowId, (ignoreKey) -> registry.register(
             ACTIVE_STATES_PER_WORKFLOW.tagged(
-                "component-id", workflowId.componentId(), "endpoint-id", workflowId.endpointId()),
+                "component-id", workflowId.componentId(), "workflow-id", workflowId.id()),
             activeStatesCount));
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.repackaged.com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.spotify.styx.model.Backfill;
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.Partitioning;
 import com.spotify.styx.model.Resource;
@@ -160,8 +160,8 @@ public class SchedulerTest {
     return Workflow.create(
         id.componentId(),
         URI.create("http://example.com"),
-        DataEndpoint.create(
-            id.endpointId(), Partitioning.HOURS, empty(), empty(), empty(), empty(),
+        Schedule.create(
+            id.id(), Partitioning.HOURS, empty(), empty(), empty(), empty(),
             Arrays.asList(resources)));
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StateInitializingTriggerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StateInitializingTriggerTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Partitioning;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
@@ -74,8 +74,8 @@ public class StateInitializingTriggerTest {
 
   @Test
   public void shouldInitializeWorkflowInstance() throws Exception {
-    DataEndpoint endpoint = dataEndpoint(HOURS);
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, endpoint);
+    Schedule schedule = schedule(HOURS);
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule);
     setDockerImage(workflow.id(), workflow.schedule());
     trigger.event(workflow, NATURAL_TRIGGER, TIME);
 
@@ -84,8 +84,8 @@ public class StateInitializingTriggerTest {
 
   @Test
   public void shouldInjectTriggerExecutionEventWithNaturalTrigger() throws Exception {
-    DataEndpoint endpoint = dataEndpoint(HOURS);
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, endpoint);
+    Schedule schedule = schedule(HOURS);
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule);
     setDockerImage(workflow.id(), workflow.schedule());
     trigger.event(workflow, NATURAL_TRIGGER, TIME);
 
@@ -99,8 +99,8 @@ public class StateInitializingTriggerTest {
 
   @Test
   public void shouldInjectTriggerExecutionEventWithBackfillTrigger() throws Exception {
-    DataEndpoint endpoint = dataEndpoint(HOURS);
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, endpoint);
+    Schedule schedule = schedule(HOURS);
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule);
     setDockerImage(workflow.id(), workflow.schedule());
     trigger.event(workflow, BACKFILL_TRIGGER, TIME);
 
@@ -114,7 +114,7 @@ public class StateInitializingTriggerTest {
 
   @Test
   public void shouldDoNothingIfDockerInfoMissing() throws Exception {
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, TestData.DAILY_DATA_ENDPOINT);
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, TestData.DAILY_SCHEDULE);
     setDockerImage(workflow.id(), workflow.schedule());
     trigger.event(workflow, NATURAL_TRIGGER, TIME);
 
@@ -124,8 +124,8 @@ public class StateInitializingTriggerTest {
   @Test
   public void shouldCreateWorkflowInstanceParameter() throws Exception {
     for (Map.Entry<Partitioning, String> partitioningCase : PARTITIONING_ARG_EXPECTS.entrySet()) {
-      DataEndpoint endpoint = dataEndpoint(partitioningCase.getKey(), "--date", "{}", "--bar");
-      Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, endpoint);
+      Schedule schedule = schedule(partitioningCase.getKey(), "--date", "{}", "--bar");
+      Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule);
       setDockerImage(workflow.id(), workflow.schedule());
       trigger.event(workflow, NATURAL_TRIGGER, TIME);
 
@@ -142,8 +142,8 @@ public class StateInitializingTriggerTest {
     assertThat(PARTITIONING_ARG_EXPECTS.keySet(), is(Sets.newHashSet(Partitioning.values())));
   }
 
-  private DataEndpoint dataEndpoint(Partitioning partitioning, String... args) {
-    return DataEndpoint.create(
+  private Schedule schedule(Partitioning partitioning, String... args) {
+    return Schedule.create(
         "styx.TestEndpoint",
         partitioning,
         Optional.of("busybox"),
@@ -154,7 +154,7 @@ public class StateInitializingTriggerTest {
   }
 
   // todo: do not use deprecated getDockerImage method
-  private void setDockerImage(WorkflowId workflowId, DataEndpoint schedule) throws IOException {
+  private void setDockerImage(WorkflowId workflowId, Schedule schedule) throws IOException {
     when(storage.getDockerImage(workflowId)).thenReturn(schedule.dockerImage());
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertThat;
 
 import com.spotify.styx.docker.DockerRunner.RunSpec;
 import com.spotify.styx.model.Backfill;
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.Partitioning;
@@ -55,10 +55,10 @@ import org.junit.Test;
 
 public class SystemTest extends StyxSchedulerServiceFixture {
 
-  private static final DataEndpoint DATA_ENDPOINT_HOURLY = DataEndpoint.create(
+  private static final Schedule SCHEDULE_HOURLY = Schedule.create(
       "styx.TestEndpoint", Partitioning.HOURS, of("busybox"), of(asList("--hour", "{}")),
       empty(), empty(), emptyList());
-  private static final DataEndpoint DATA_ENDPOINT_DAILY = DataEndpoint.create(
+  private static final Schedule SCHEDULE_DAILY = Schedule.create(
       "styx.TestEndpoint", Partitioning.DAYS, of("busybox"), of(asList("--hour", "{}")),
       empty(), empty(), emptyList());
   private static final String TEST_EXECUTION_ID_1 = "execution_1";
@@ -66,14 +66,14 @@ public class SystemTest extends StyxSchedulerServiceFixture {
   private static final Workflow HOURLY_WORKFLOW = Workflow.create(
       "styx",
       TestData.WORKFLOW_URI,
-      DATA_ENDPOINT_HOURLY);
+      SCHEDULE_HOURLY);
   private static final ExecutionDescription TEST_EXECUTION_DESCRIPTION =
       ExecutionDescription.create(
           TEST_DOCKER_IMAGE, Arrays.asList("--date", "{}", "--bar"), false, empty(), empty());
   private static final Workflow DAILY_WORKFLOW = Workflow.create(
       "styx",
       TestData.WORKFLOW_URI,
-      DATA_ENDPOINT_DAILY);
+      SCHEDULE_DAILY);
   private static final Trigger TRIGGER1 = Trigger.unknown("trig1");
   private static final Trigger TRIGGER2 = Trigger.unknown("trig2");
   private static final Backfill ONE_DAY_HOURLY_BACKFILL = Backfill.newBuilder()
@@ -300,10 +300,10 @@ public class SystemTest extends StyxSchedulerServiceFixture {
     awaitWorkflowInstanceCompletion(workflowInstance);
 
     workflowChanges(Workflow.create(DAILY_WORKFLOW.componentId(),
-        DAILY_WORKFLOW.componentUri(),
-        DataEndpoint.create(DATA_ENDPOINT_DAILY.id(), DATA_ENDPOINT_DAILY.partitioning(),
-            Optional.of("freebox"), DATA_ENDPOINT_DAILY.dockerArgs(), empty(),
-            DATA_ENDPOINT_DAILY.secret(), emptyList())));
+                                    DAILY_WORKFLOW.componentUri(),
+                                    Schedule.create(SCHEDULE_DAILY.id(), SCHEDULE_DAILY.partitioning(),
+                                                    Optional.of("freebox"), SCHEDULE_DAILY.dockerArgs(), empty(),
+                                                    SCHEDULE_DAILY.secret(), emptyList())));
     timePasses(StyxScheduler.SCHEDULER_TICK_INTERVAL_SECONDS, SECONDS);
     awaitNumberOfDockerRunsWontChange(1);
 
@@ -349,14 +349,14 @@ public class SystemTest extends StyxSchedulerServiceFixture {
     injectEvent(Event.terminate(workflowInstance, Optional.of(20)));
     awaitWorkflowInstanceState(workflowInstance, RunState.State.QUEUED);
 
-    DataEndpoint changedDataEndpoint = DataEndpoint.create(
-        DATA_ENDPOINT_HOURLY.id(), Partitioning.HOURS, of("busybox:v777"),
+    Schedule changedSchedule = Schedule.create(
+        SCHEDULE_HOURLY.id(), Partitioning.HOURS, of("busybox:v777"),
         of(asList("other", "args")), empty(), empty(), emptyList());
 
     Workflow changedWorkflow = Workflow.create(
         HOURLY_WORKFLOW.componentId(),
         TestData.WORKFLOW_URI,
-        changedDataEndpoint);
+        changedSchedule);
 
     workflowChanges(changedWorkflow);
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
@@ -20,12 +20,8 @@
 
 package com.spotify.styx;
 
-import static com.spotify.styx.testdata.TestData.FULL_DATA_ENDPOINT;
+import static com.spotify.styx.testdata.TestData.FULL_DATA_SCHEDULE;
 import static java.time.temporal.ChronoUnit.DAYS;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -33,7 +29,6 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.repackaged.com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.spotify.styx.model.Workflow;
@@ -51,7 +46,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -73,7 +67,7 @@ public class TriggerManagerTest {
   private static final Instant MANAGER_TIME_PLUS_DAY_TRUNCATED = Instant.parse("2016-10-11T00:00:00Z");
 
   private static Workflow WORKFLOW_DAILY =
-      Workflow.create("comp", URI.create("http:/foo"), FULL_DATA_ENDPOINT);
+      Workflow.create("comp", URI.create("http:/foo"), FULL_DATA_SCHEDULE);
 
   @Mock
   Storage storage;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
@@ -73,16 +73,16 @@ public class SchedulerResourceTest {
 
   private final Workflow HOURLY_WORKFLOW = Workflow.create("styx",
                                                     TestData.WORKFLOW_URI,
-                                                    TestData.HOURLY_DATA_ENDPOINT);
+                                                    TestData.HOURLY_SCHEDULE);
   private final Workflow DAILY_WORKFLOW = Workflow.create("styx",
                                                            TestData.WORKFLOW_URI,
-                                                           TestData.DAILY_DATA_ENDPOINT);
+                                                           TestData.DAILY_SCHEDULE);
   private final Workflow WEEKLY_WORKFLOW = Workflow.create("styx",
                                                           TestData.WORKFLOW_URI,
-                                                          TestData.WEEKLY_DATA_ENDPOINT);
+                                                          TestData.WEEKLY_SCHEDULE);
   private final Workflow MONTHLY_WORKFLOW = Workflow.create("styx",
                                                             TestData.WORKFLOW_URI,
-                                                            TestData.MONTHLY_DATA_ENDPOINT);
+                                                            TestData.MONTHLY_SCHEDULE);
   private Optional<Workflow> triggeredWorkflow = Optional.empty();
   private Optional<Trigger> trigger = Optional.empty();
   private Optional<Instant> triggeredInstant = Optional.empty();

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.testdata.TestData;
 import io.fabric8.kubernetes.api.model.Container;
@@ -171,7 +171,7 @@ public class KubernetesDockerRunnerPodResourceTest {
 
   @Test
   public void shouldConfigureSecretsMount() throws Exception {
-    DataEndpoint.Secret secret = DataEndpoint.Secret.create("my-secret", "/etc/secrets");
+    Schedule.Secret secret = Schedule.Secret.create("my-secret", "/etc/secrets");
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
         DockerRunner.RunSpec.create(
@@ -203,12 +203,9 @@ public class KubernetesDockerRunnerPodResourceTest {
         DockerRunner.RunSpec.create("busybox", ImmutableList.of(), false, empty()));
     List<EnvVar> envVars = pod.getSpec().getContainers().get(0).getEnv();
 
-    EnvVar endpoint = new EnvVar();
-    endpoint.setName(KubernetesDockerRunner.ENDPOINT_ID);
-    endpoint.setValue(WORKFLOW_INSTANCE.workflowId().endpointId());
     EnvVar workflow = new EnvVar();
     workflow.setName(KubernetesDockerRunner.WORKFLOW_ID);
-    workflow.setValue(WORKFLOW_INSTANCE.workflowId().endpointId());
+    workflow.setValue(WORKFLOW_INSTANCE.workflowId().id());
     EnvVar component = new EnvVar();
     component.setName(KubernetesDockerRunner.COMPONENT_ID);
     component.setValue(WORKFLOW_INSTANCE.workflowId().componentId());
@@ -220,7 +217,6 @@ public class KubernetesDockerRunnerPodResourceTest {
     assertThat(envVars.size(), is(6));
     assertThat(envVars, hasItem(component));
     assertThat(envVars, hasItem(workflow));
-    assertThat(envVars, hasItem(endpoint));
     assertThat(envVars, hasItem(parameter));
     assertThat(execution.getName(),is(KubernetesDockerRunner.EXECUTION_ID));
     assertThat(execution.getValue(),

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
@@ -40,7 +40,7 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.RateLimiter;
 import com.spotify.styx.docker.DockerRunner;
 import com.spotify.styx.docker.DockerRunner.RunSpec;
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.Workflow;
@@ -138,7 +138,7 @@ public class DockerRunnerHandlerTest {
   }
 
   private WorkflowInstance startWorkflowInstance(String parameter) throws Exception {
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, dataEndpoint());
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule());
     ExecutionDescription desc = ExecutionDescription.forImage(TEST_DOCKER_IMAGE);
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), parameter);
     StateData stateData = StateData.newBuilder().executionDescription(desc).build();
@@ -150,7 +150,7 @@ public class DockerRunnerHandlerTest {
 
   @Test
   public void shouldPassInArguments() throws Exception {
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, dataEndpoint());
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule());
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14");
     ExecutionDescription desc = ExecutionDescription.forImage(TEST_DOCKER_IMAGE);
     RunState runState = RunState.create(workflowInstance, RunState.State.SUBMITTING,
@@ -167,7 +167,7 @@ public class DockerRunnerHandlerTest {
 
   @Test
   public void shouldInterpolatePartitioningArgument() throws Exception {
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, dataEndpoint());
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule());
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
     RunState runState = RunState.create(workflowInstance, RunState.State.SUBMITTING,
         StateData.newBuilder().executionDescription(EXECUTION_DESCRIPTION).build());
@@ -185,7 +185,7 @@ public class DockerRunnerHandlerTest {
     when(dockerRunner.start(any(WorkflowInstance.class), any(RunSpec.class)))
         .thenThrow(new IOException("Testing exception."));
 
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, dataEndpoint());
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule());
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
     RunState runState = RunState.create(workflowInstance, RunState.State.SUBMITTING,
         StateData.newBuilder().executionDescription(EXECUTION_DESCRIPTION).build());
@@ -200,7 +200,7 @@ public class DockerRunnerHandlerTest {
 
   @Test
   public void shouldHaltIfMissingExecutionDescription() throws Exception {
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, dataEndpoint());
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule());
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
     RunState runState = RunState.create(workflowInstance, RunState.State.SUBMITTING);
 
@@ -214,8 +214,8 @@ public class DockerRunnerHandlerTest {
 
   @Test
   public void shouldPerformCleanupOnFailed() throws Exception {
-    DataEndpoint endpoint = dataEndpoint("--date", "{}", "--bar");
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, endpoint);
+    Schedule schedule = schedule("--date", "{}", "--bar");
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule);
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
     RunState runState = RunState.create(workflowInstance, RunState.State.FAILED,
         StateData.newBuilder().executionId(TEST_EXECUTION_ID).build());
@@ -228,8 +228,8 @@ public class DockerRunnerHandlerTest {
 
   @Test
   public void shouldPerformCleanupOnFailedThroughTransitions() throws Exception {
-    DataEndpoint endpoint = dataEndpoint("--date", "{}", "--bar");
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, endpoint);
+    Schedule schedule = schedule("--date", "{}", "--bar");
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule);
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
     RunState runState = RunState.create(workflowInstance, RunState.State.NEW, dockerRunnerHandler);
 
@@ -242,8 +242,8 @@ public class DockerRunnerHandlerTest {
     verify(dockerRunner).cleanup(TEST_EXECUTION_ID);
   }
 
-  private DataEndpoint dataEndpoint(String... args) {
-    return DataEndpoint.create(
+  private Schedule schedule(String... args) {
+    return Schedule.create(
         "styx.TestEndpoint",
         HOURS,
         Optional.of(TEST_DOCKER_IMAGE),

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Lists;
-import com.spotify.styx.model.DataEndpoint;
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
@@ -72,7 +72,7 @@ public class ExecutionDescriptionHandlerTest {
 
   @Test
   public void shouldTransitionIntoSubmitting() throws Exception {
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, dataEndpoint("--date", "{}", "--bar"));
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule("--date", "{}", "--bar"));
     WorkflowState workflowState = WorkflowState.builder()
         .enabled(true)
         .dockerImage(DOCKER_IMAGE)
@@ -99,7 +99,7 @@ public class ExecutionDescriptionHandlerTest {
 
   @Test
   public void shouldTransitionIntoFailedIfStorageError() throws Exception {
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, dataEndpoint("--date", "{}", "--bar"));
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule("--date", "{}", "--bar"));
     WorkflowState workflowState = WorkflowState.builder()
         .enabled(true)
         .dockerImage(DOCKER_IMAGE)
@@ -139,8 +139,8 @@ public class ExecutionDescriptionHandlerTest {
 
   @Test
   public void shouldHaltIfMissingDockerArgs() throws Exception {
-    DataEndpoint dataEndpoint = TestData.DAILY_DATA_ENDPOINT;
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, dataEndpoint);
+    Schedule schedule = TestData.DAILY_SCHEDULE;
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule);
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
     RunState runState = RunState.create(workflowInstance, RunState.State.PREPARE);
 
@@ -154,8 +154,8 @@ public class ExecutionDescriptionHandlerTest {
 
   @Test
   public void shouldHaltIfMissingDockerImage() throws Exception {
-    DataEndpoint dataEndpoint = dataEndpoint("foo", "bar");
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, dataEndpoint);
+    Schedule schedule = schedule("foo", "bar");
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule);
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
     RunState runState = RunState.create(workflowInstance, RunState.State.PREPARE);
 
@@ -168,8 +168,8 @@ public class ExecutionDescriptionHandlerTest {
   }
 
   @Test
-  public void shouldFallbackToDockerImageInEndpointDefinition() throws Exception {
-    DataEndpoint dataEndpoint = DataEndpoint.create(
+  public void shouldFallbackToDockerImageInScheduleDefinition() throws Exception {
+    Schedule schedule = Schedule.create(
         "styx.TestEndpoint",
         HOURS,
         Optional.of("legacy-docker-image"),
@@ -177,7 +177,7 @@ public class ExecutionDescriptionHandlerTest {
         empty(),
         empty(),
         emptyList());
-    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, dataEndpoint);
+    Workflow workflow = Workflow.create("id", TestData.WORKFLOW_URI, schedule);
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
     RunState runState = RunState.create(workflowInstance, RunState.State.PREPARE);
 
@@ -193,8 +193,8 @@ public class ExecutionDescriptionHandlerTest {
     assertThat(data.executionDescription().get().dockerImage(), is("legacy-docker-image"));
   }
 
-  private DataEndpoint dataEndpoint(String... args) {
-    return DataEndpoint.create(
+  private Schedule schedule(String... args) {
+    return Schedule.create(
         "styx.TestEndpoint",
         HOURS,
         Optional.empty(),


### PR DESCRIPTION
New model wll be used to do scheduling on workflow instead of data
endpoints.

v0 and v1 APIs are deprecated now.