### PR TITLE
styx cli: workflow show

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliOutput.java
@@ -26,6 +26,8 @@ import com.spotify.styx.api.BackfillPayload;
 import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Resource;
+import com.spotify.styx.model.Workflow;
+import com.spotify.styx.model.WorkflowState;
 import java.util.List;
 
 /**
@@ -46,6 +48,8 @@ interface CliOutput {
   void printResources(List<Resource> resources);
 
   void printMessage(String message);
+
+  void printWorkflow(Workflow workflow, WorkflowState state);
 
   @AutoValue
   abstract class EventInfo {

--- a/styx-cli/src/main/java/com/spotify/styx/cli/JsonCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/JsonCliOutput.java
@@ -22,10 +22,13 @@ package com.spotify.styx.cli;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import com.spotify.styx.api.BackfillPayload;
 import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Resource;
+import com.spotify.styx.model.Workflow;
+import com.spotify.styx.model.WorkflowState;
 import com.spotify.styx.serialization.Json;
 import java.util.List;
 
@@ -75,5 +78,10 @@ class JsonCliOutput implements CliOutput {
   @Override
   public void printMessage(String message) {
     printJson(message);
+  }
+
+  @Override
+  public void printWorkflow(Workflow workflow, WorkflowState state) {
+    printJson(ImmutableMap.of("workflow", workflow, "state", state));
   }
 }

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
@@ -22,13 +22,17 @@ package com.spotify.styx.cli;
 
 import static com.spotify.styx.cli.CliUtil.formatTimestamp;
 
+import com.google.common.base.Joiner;
 import com.spotify.styx.api.BackfillPayload;
 import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Resource;
+import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
+import com.spotify.styx.model.WorkflowState;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.StateData;
+import java.util.Collections;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -120,5 +124,26 @@ class PlainCliOutput implements CliOutput {
   @Override
   public void printMessage(String message) {
     System.out.println(message);
+  }
+
+  @Override
+  public void printWorkflow(Workflow wf, WorkflowState state) {
+    final String image = state.dockerImage().orElseGet(() ->
+        wf.configuration().dockerImage().orElse(""));
+    System.out.println(Joiner.on(' ').join(
+        wf.componentId(),
+        wf.id(),
+        wf.componentUri(),
+        wf.configuration().schedule(),
+        wf.configuration().offset().orElse(""),
+        image,
+        wf.configuration().dockerArgs().orElse(Collections.emptyList()),
+        wf.configuration().dockerTerminationLogging(),
+        wf.configuration().secret().map(Object::toString).orElse(""),
+        wf.configuration().resources(),
+        state.commitSha().orElse(""),
+        state.enabled().map(Object::toString).orElse(""),
+        state.nextNaturalTrigger().map(Object::toString).orElse(""),
+        state.nextNaturalOffsetTrigger().map(Object::toString).orElse("")));
   }
 }

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -38,9 +38,12 @@ import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Schedule;
+import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
+import com.spotify.styx.model.WorkflowState;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.StateData;
+import java.util.Collections;
 import java.util.List;
 import org.fusesource.jansi.Ansi;
 
@@ -151,7 +154,6 @@ class PrettyCliOutput implements CliOutput {
     }
   }
 
-
   @Override
   public void printResources(List<Resource> resources) {
     final String format = "%50s %12s";
@@ -163,6 +165,19 @@ class PrettyCliOutput implements CliOutput {
   @Override
   public void printMessage(String message) {
     System.out.println(message);
+  }
+
+  @Override
+  public void printWorkflow(Workflow wf, WorkflowState state) {
+    final String image = state.dockerImage().orElseGet(() ->
+        wf.configuration().dockerImage().orElse(""));
+    System.out.println("Component: " + wf.componentId());
+    System.out.println(" Workflow: " + wf.id().id());
+    System.out.println("  Enabled: " + state.enabled().map(Object::toString).orElse(""));
+    System.out.println(" Schedule: " + wf.configuration().schedule());
+    System.out.println("   Commit: " + state.commitSha().orElse(""));
+    System.out.println("    Image: " + image);
+    System.out.println("     Args: " + wf.configuration().dockerArgs().orElse(Collections.emptyList()));
   }
 
   private Ansi getAnsiForState(RunStateDataPayload.RunStateData RunStateData) {


### PR DESCRIPTION
Add a `workflow show <component> <workflow>` command.

```
$ styx workflow show dano-test-pipeline dano-test
Component: dano-test-pipeline
 Workflow: dano-test
  Enabled: false
 Schedule: DAYS
   Commit: 79b49cdd161d3f17b43f005be22ead4095ca35c8
    Image: registry.spotify.net/spotify/dano-test-pipeline:1490015757-d811bbe@sha256:c666cbfb44ac1debc3bb709a0268d19e3cd4e45a4d204dcbb4c3455b70c7dff7
     Args: [bash, -c, echo hello digest world {}]
```

The output of the command is a `Workflow` with some fields from `WorkflowState` added / merged. Notably the `WorkflowState` takes precedence for the `Image` field value.