### PR TITLE
eagerly restore container execution state

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
         <version>19.0</version>
       </dependency>
       <dependency>
+        <groupId>com.github.rholder</groupId>
+        <artifactId>guava-retrying</artifactId>
+        <version>2.0.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.auto.value</groupId>
         <artifactId>auto-value</artifactId>
         <version>1.3</version>

--- a/styx-common/pom.xml
+++ b/styx-common/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.rholder</groupId>
+      <artifactId>guava-retrying</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.javaslang</groupId>
       <artifactId>javaslang</artifactId>
     </dependency>

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -47,6 +47,12 @@ public interface DockerRunner extends Closeable {
   Logger LOG = LoggerFactory.getLogger(DockerRunner.class);
 
   /**
+   * Fetch workflow instance state from execution engine and emit events as needed. For use when
+   * when booting in order to recover executions that completed while styx was offline.
+   */
+  void restore();
+
+  /**
    * Starts a workflow instance asynchronously.
    * @param workflowInstance The workflow instance that the run belongs to
    * @param runSpec          Specification of what to run

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
@@ -74,6 +74,13 @@ class LocalDockerRunner implements DockerRunner {
   }
 
   @Override
+  public void restore() {
+    // TODO: a meaningful implementation of this method needs LocalDockerRunner to list the
+    //       local docker containers using the docker api and emit events for them similar to
+    //       KubernetesDockerRunner.
+  }
+
+  @Override
   public String start(WorkflowInstance workflowInstance, RunSpec runSpec) {
     final String imageTag = runSpec.imageName().contains(":")
         ? runSpec.imageName()

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
@@ -47,6 +47,11 @@ class RoutingDockerRunner implements DockerRunner {
   }
 
   @Override
+  public void restore() {
+    runner().restore();
+  }
+
+  @Override
   public String start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException {
     return runner().start(workflowInstance, runSpec);
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -58,6 +58,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import javaslang.Tuple;
 import javaslang.Tuple2;
@@ -95,6 +96,7 @@ public class StyxSchedulerServiceFixture {
   // captured fields from fakes
   List<Tuple2<WorkflowInstance, DockerRunner.RunSpec>> dockerRuns = Lists.newArrayList();
   List<String> dockerCleans = Lists.newArrayList();
+  AtomicInteger dockerRestores = new AtomicInteger();
 
   // service and helper
   private StyxScheduler styxScheduler;
@@ -320,6 +322,7 @@ public class StyxSchedulerServiceFixture {
     return new DockerRunner() {
       @Override
       public void restore() {
+        dockerRestores.incrementAndGet();
       }
 
       @Override

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -319,6 +319,10 @@ public class StyxSchedulerServiceFixture {
   private DockerRunner fakeDockerRunner() {
     return new DockerRunner() {
       @Override
+      public void restore() {
+      }
+
+      @Override
       public String start(WorkflowInstance workflowInstance, RunSpec runSpec) {
         dockerRuns.add(Tuple.of(workflowInstance, runSpec));
         return TEST_EXECUTION_ID;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/RoutingDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/RoutingDockerRunnerTest.java
@@ -77,6 +77,15 @@ public class RoutingDockerRunnerTest {
   }
 
   @Test
+  public void testUsesDefaultRunnerOnRestore() throws Exception {
+    when(dockerId.get()).thenReturn("default");
+    dockerRunner.restore();
+
+    assertThat(createdRunners, hasKey("default"));
+    verify(createdRunners.get("default")).restore();
+  }
+
+  @Test
   public void testCreatesOnlyOneRunnerPerDockerId() throws Exception {
     when(dockerId.get()).thenReturn("default");
     dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/SyncStateManager.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/SyncStateManager.java
@@ -28,6 +28,7 @@ import com.spotify.styx.model.WorkflowInstance;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * An implementation of {@link StateManager} that process all events synchronously on the thread
@@ -37,7 +38,7 @@ import java.util.concurrent.CompletionStage;
  */
 public class SyncStateManager implements StateManager {
 
-  private final Map<WorkflowInstance, RunState> states = Maps.newHashMap();
+  private final Map<WorkflowInstance, RunState> states = new ConcurrentHashMap<>();
 
   @Override
   public void initialize(RunState runState) {


### PR DESCRIPTION
Before starting the scheduler, poll for execution container state in order to record the completion of any containers that succeeded while styx was offline.

This avoids styx unnecessarily failing successfully completed executions due to having artifically "timed out" when starting up after downtime.