### PR TITLE
Add styx-client module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <module>styx-schedule-source</module>
     <module>styx-local-files-source</module>
     <module>styx-cli</module>
+    <module>styx-client</module>
     <module>styx-common</module>
     <module>styx-test</module>
     <module>styx-standalone-service</module>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,14 @@
         <version>0.7.0</version>
       </dependency>
 
-      <!-- client libs -->
+      <!-- styx client libs -->
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>3.7.0</version>
+      </dependency>
+
+      <!-- external clients libs -->
       <dependency>
         <groupId>com.spotify</groupId>
         <artifactId>docker-client</artifactId>
@@ -342,6 +349,11 @@
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>3.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>1.12.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/styx-cli/pom.xml
+++ b/styx-cli/pom.xml
@@ -16,6 +16,11 @@
       <artifactId>styx-common</artifactId>
       <version>1.0.8-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>styx-client</artifactId>
+      <version>1.0.8-SNAPSHOT</version>
+    </dependency>
 
     <dependency>
       <groupId>com.spotify</groupId>
@@ -69,6 +74,7 @@
       <artifactId>jackson-annotations</artifactId>
       <version>${jackson.version}</version>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/styx-cli/pom.xml
+++ b/styx-cli/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>net.sourceforge.argparse4j</groupId>
       <artifactId>argparse4j</artifactId>
-      <version>0.7.0</version>
     </dependency>
 
     <dependency>
@@ -72,7 +71,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
 
   </dependencies>

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliOutput.java
@@ -20,14 +20,13 @@
 
 package com.spotify.styx.cli;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.auto.value.AutoValue;
 import com.spotify.styx.api.BackfillPayload;
 import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.data.EventInfo;
 import java.util.List;
 
 /**
@@ -50,18 +49,4 @@ interface CliOutput {
   void printMessage(String message);
 
   void printWorkflow(Workflow workflow, WorkflowState state);
-
-  @AutoValue
-  abstract class EventInfo {
-    @JsonProperty
-    abstract long timestamp();
-    @JsonProperty
-    abstract String name();
-    @JsonProperty
-    abstract String info();
-
-    public static EventInfo create(long ts, String eventName, String eventInfo) {
-      return new AutoValue_CliOutput_EventInfo(ts, eventName, eventInfo);
-    }
-  }
 }

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliUtil.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliUtil.java
@@ -27,24 +27,15 @@ import static org.fusesource.jansi.Ansi.ansi;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.spotify.styx.api.RunStateDataPayload.RunStateData;
-import com.spotify.styx.model.Event;
-import com.spotify.styx.model.EventVisitor;
-import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.WorkflowId;
-import com.spotify.styx.model.WorkflowInstance;
-import com.spotify.styx.state.Message;
-import com.spotify.styx.state.Trigger;
-import com.spotify.styx.util.TriggerUtil;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Optional;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 import org.fusesource.jansi.Ansi;
 
 class CliUtil {
@@ -84,93 +75,5 @@ class CliUtil {
         .atZone(ZoneId.of("UTC"))
         .toLocalDateTime()
         .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
-  }
-
-  public static String info(Event event) {
-    return event.accept(EventInfoVisitor.INSTANCE);
-  }
-
-  private enum EventInfoVisitor implements EventVisitor<String> {
-    INSTANCE;
-
-    @Override
-    public String timeTrigger(WorkflowInstance workflowInstance) {
-      return "";
-    }
-
-    @Override
-    public String triggerExecution(WorkflowInstance workflowInstance, Trigger trigger) {
-      return String.format("Trigger id: %s", TriggerUtil.triggerId(trigger));
-    }
-
-    @Override
-    public String info(WorkflowInstance workflowInstance, Message message) {
-      return message.line();
-    }
-
-    @Override
-    public String created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
-      return String.format("Execution id: %s, Docker image: %s", executionId, dockerImage);
-    }
-
-    @Override
-    public String dequeue(WorkflowInstance workflowInstance) {
-      return "";
-    }
-
-    @Override
-    public String started(WorkflowInstance workflowInstance) {
-      return "";
-    }
-
-    @Override
-    public String terminate(WorkflowInstance workflowInstance, Optional<Integer> exitCode) {
-      return "Exit code: " + exitCode.map(String::valueOf).orElse("-");
-    }
-
-    @Override
-    public String runError(WorkflowInstance workflowInstance, String message) {
-      return "Error message: " + message;
-    }
-
-    @Override
-    public String success(WorkflowInstance workflowInstance) {
-      return "";
-    }
-
-    @Override
-    public String retryAfter(WorkflowInstance workflowInstance, long delayMillis) {
-      return String.format("Delay (seconds): %d", TimeUnit.MILLISECONDS.toSeconds(delayMillis));
-    }
-
-    @Override
-    public String retry(WorkflowInstance workflowInstance) {
-      return "";
-    }
-
-    @Override
-    public String stop(WorkflowInstance workflowInstance) {
-      return "";
-    }
-
-    @Override
-    public String timeout(WorkflowInstance workflowInstance) {
-      return "";
-    }
-
-    @Override
-    public String halt(WorkflowInstance workflowInstance) {
-      return "";
-    }
-
-    @Override
-    public String submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription) {
-      return String.format("Execution description: %s", executionDescription);
-    }
-
-    @Override
-    public String submitted(WorkflowInstance workflowInstance, String executionId) {
-      return String.format("Execution id: %s", executionId);
-    }
   }
 }

--- a/styx-cli/src/main/java/com/spotify/styx/cli/JsonCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/JsonCliOutput.java
@@ -29,6 +29,7 @@ import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.data.EventInfo;
 import com.spotify.styx.serialization.Json;
 import java.util.List;
 

--- a/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
@@ -49,6 +49,7 @@ import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.data.EventInfo;
 import com.spotify.styx.util.EventUtil;
 import com.spotify.styx.util.ParameterUtil;
 import java.io.IOException;
@@ -429,7 +430,7 @@ public final class Main {
 
     final ObjectNode json = (ObjectNode) jsonNode;
     final ArrayNode events = json.withArray("events");
-    final ImmutableList.Builder<CliOutput.EventInfo> eventInfos = ImmutableList.builder();
+    final ImmutableList.Builder<EventInfo> eventInfos = ImmutableList.builder();
     for (JsonNode eventWithTimestamp : events) {
       final long ts = eventWithTimestamp.get("timestamp").asLong();
       final JsonNode event = eventWithTimestamp.get("event");
@@ -439,14 +440,14 @@ public final class Main {
       try {
         Event typedEvent = OBJECT_MAPPER.convertValue(event, Event.class);
         eventName = EventUtil.name(typedEvent);
-        eventInfo = CliUtil.info(typedEvent);
+        eventInfo = EventUtil.info(typedEvent);
       } catch (IllegalArgumentException e) {
         // fall back to just inspecting the json
         eventName = event.get("@type").asText();
         eventInfo = "";
       }
 
-      eventInfos.add(CliOutput.EventInfo.create(ts, eventName, eventInfo));
+      eventInfos.add(EventInfo.create(ts, eventName, eventInfo));
     }
 
     cliOutput.printEvents(eventInfos.build());

--- a/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
@@ -20,51 +20,24 @@
 
 package com.spotify.styx.cli;
 
-import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
-import static com.spotify.styx.serialization.Json.deserialize;
-import static com.spotify.styx.serialization.Json.serialize;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableList;
 import com.spotify.apollo.Client;
-import com.spotify.apollo.Request;
-import com.spotify.apollo.Response;
 import com.spotify.apollo.core.Service;
 import com.spotify.apollo.core.Services;
 import com.spotify.apollo.environment.ApolloEnvironmentModule;
 import com.spotify.apollo.http.client.HttpClientModule;
-import com.spotify.styx.api.BackfillPayload;
-import com.spotify.styx.api.BackfillsPayload;
-import com.spotify.styx.api.ResourcesPayload;
-import com.spotify.styx.api.RunStateDataPayload;
-import com.spotify.styx.model.Backfill;
-import com.spotify.styx.model.BackfillBuilder;
-import com.spotify.styx.model.BackfillInput;
-import com.spotify.styx.model.Event;
-import com.spotify.styx.model.Resource;
+import com.spotify.styx.client.StyxApolloClient;
 import com.spotify.styx.model.Workflow;
-import com.spotify.styx.model.WorkflowId;
-import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
-import com.spotify.styx.model.data.EventInfo;
-import com.spotify.styx.util.EventUtil;
 import com.spotify.styx.util.ParameterUtil;
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.time.Duration;
-import java.time.Instant;
 import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
+import java.util.function.BiConsumer;
+import javaslang.Tuple;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Argument;
@@ -75,14 +48,10 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.Subparsers;
 import net.sourceforge.argparse4j.internal.HelpScreenException;
-import okio.ByteString;
 
 public final class Main {
 
-  private static final String UTF_8 = "UTF-8";
   private static final String ENV_VAR_PREFIX = "STYX_CLI";
-  private static final String STYX_API_ENDPOINT = "/api/v2";
-  private static final int TTL_REQUEST = 90;
 
   private static final String COMMAND_DEST = "command";
   private static final String SUBCOMMAND_DEST = "subcommand";
@@ -93,7 +62,7 @@ public final class Main {
   private static final int EXIT_CODE_SUCCESS = 0;
   private static final int EXIT_CODE_UNKNOWN_ERROR = 1;
   private static final int EXIT_CODE_ARGUMENT_ERROR = 2;
-  private static final int EXIT_CODE_API_ERROR = 3;
+  private static final int EXIT_CODE_CLIENT_ERROR = 3;
   private static final String STYX_CLI_VERSION =
       "Styx CLI " + Main.class.getPackage().getImplementationVersion();
 
@@ -102,7 +71,17 @@ public final class Main {
   private final String apiHost;
   private final Service cliService;
   private final CliOutput cliOutput;
-  private Client client;
+  private StyxApolloClient styxClient;
+  private final BiConsumer<Object, Throwable> throwableChecker = (response, throwable) -> {
+    if (throwable != null) {
+      if (throwable.getCause() == null) {
+        System.err.println(throwable.toString());
+      } else {
+        System.err.println(throwable.getCause().getMessage());
+      }
+      System.exit(EXIT_CODE_CLIENT_ERROR);
+    }
+  };
 
   private Main(
       StyxCliParser parser,
@@ -161,7 +140,9 @@ public final class Main {
     final Command command = namespace.get(COMMAND_DEST);
 
     try (Service.Instance instance = cliService.start()) {
-      client = ApolloEnvironmentModule.environment(instance).environment().client();
+      final Service.Signaller signaller = instance.getSignaller();
+      final Client client = ApolloEnvironmentModule.environment(instance).environment().client();
+      styxClient = new StyxApolloClient(client, apiHost);
 
       switch (command) {
         case LIST:
@@ -251,265 +232,167 @@ public final class Main {
           // parsing unknown command will fail so this would only catch non-exhaustive switches
           throw new ArgumentParserException("Unrecognized command: " + command, parser.parser);
       }
+      signaller.signalShutdown();
     } catch (ArgumentParserException e) {
       parser.parser.handleError(e);
       System.exit(EXIT_CODE_ARGUMENT_ERROR);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (IOException e) {
       e.printStackTrace();
       System.exit(EXIT_CODE_UNKNOWN_ERROR);
-    } catch (Exception e) {
-      System.err.println(e.getClass().getSimpleName() + ": " + e.getMessage());
-      System.exit(EXIT_CODE_API_ERROR);
     }
   }
 
-  private void backfillCreate() throws ExecutionException, InterruptedException, IOException {
+  private void backfillCreate() {
     final String component = namespace.getString(parser.backfillCreateComponent.getDest());
     final String workflow = namespace.getString(parser.backfillCreateWorkflow.getDest());
     final String start = namespace.getString(parser.backfillCreateStart.getDest());
     final String end = namespace.getString(parser.backfillCreateEnd.getDest());
     final int concurrency = namespace.getInt(parser.backfillCreateConcurrency.getDest());
 
-    final BackfillInput backfillInput = BackfillInput.create(
-        Instant.parse(start), Instant.parse(end), component, workflow, concurrency);
-
-    final ByteString payload = serialize(backfillInput);
-    final ByteString response = send(
-        Request.forUri(apiUrl("backfills"), "POST").withPayload(payload));
-    final Backfill backfill = deserialize(response, Backfill.class);
-    cliOutput.printBackfill(backfill);
+    styxClient.backfillCreate(component, workflow, start, end, concurrency)
+        .whenComplete(throwableChecker)
+        .whenComplete((backfill, throwable) -> cliOutput.printBackfill(backfill));
   }
 
-  private void backfillEdit() throws ExecutionException, InterruptedException, IOException {
+  private void backfillEdit() {
     final Integer concurrency = namespace.getInt(parser.backfillEditConcurrency.getDest());
     final String id = namespace.getString(parser.backfillEditId.getDest());
 
-    final ByteString getResponse = send(Request.forUri(apiUrl("backfills", id)));
-    final BackfillPayload backfillPayload = deserialize(getResponse, BackfillPayload.class);
-    final BackfillBuilder editedBackfillBuilder = backfillPayload.backfill().builder();
     if (concurrency != null) {
-      editedBackfillBuilder.concurrency(concurrency);
+      styxClient.backfillEditConcurrency(id, concurrency)
+          .whenComplete(throwableChecker)
+          .whenComplete((backfill, throwable) -> cliOutput.printBackfill(backfill));
     }
-    final ByteString putPayload = serialize(editedBackfillBuilder.build());
-    final ByteString putResponse = send(
-        Request.forUri(apiUrl("backfills", id), "PUT").withPayload(putPayload));
-
-    final Backfill newBackfill = deserialize(putResponse, Backfill.class);
-    cliOutput.printBackfill(newBackfill);
   }
 
-  private void backfillHalt() throws ExecutionException, InterruptedException {
+  private void backfillHalt() {
     final String id = namespace.getString(parser.backfillHaltId.getDest());
-    send(Request.forUri(apiUrl("backfills", id), "DELETE"));
+
+    styxClient.backfillHalt(id)
+        .whenComplete(throwableChecker)
+        .whenComplete((none, throwable) -> cliOutput.printMessage(
+            "Backfill halted! Use `styx backfill show " + id + "` to check the backfill status."));
   }
 
-  private void backfillShow() throws ExecutionException, InterruptedException, IOException {
+  private void backfillShow() {
     final String id = namespace.getString(parser.backfillShowId.getDest());
-    final ByteString response = send(Request.forUri(apiUrl("backfills", id)));
-    final BackfillPayload backfillStatus = deserialize(response, BackfillPayload.class);
-    cliOutput.printBackfillPayload(backfillStatus);
+
+    styxClient.backfill(id)
+        .whenComplete(throwableChecker)
+        .whenComplete((backfillPayload, throwable) -> cliOutput.printBackfillPayload(backfillPayload));
   }
 
-  private void backfillList()
-      throws IOException, ExecutionException, InterruptedException {
-    String uri = apiUrl("backfills");
-    final List<String> queries = new ArrayList<>();
-    if (namespace.getBoolean(parser.backfillListShowAll.getDest())) {
-      queries.add("showAll=true");
-    }
-    final String component = namespace.getString(parser.backfillListComponent.getDest());
-    if (component != null) {
-      queries.add("component=" + URLEncoder.encode(component, UTF_8));
-    }
-    final String workflow = namespace.getString(parser.backfillListWorkflow.getDest());
-    if (workflow != null) {
-      queries.add("workflow=" + URLEncoder.encode(workflow, UTF_8));
-    }
-    if (!queries.isEmpty()) {
-      uri += "?" + String.join("&", queries);
-    }
-    final ByteString response = send(Request.forUri(uri));
-    final BackfillsPayload backfills = deserialize(response, BackfillsPayload.class);
-    cliOutput.printBackfills(backfills.backfills());
+  private void backfillList() {
+    final Optional<String> component =
+        Optional.ofNullable(namespace.getString(parser.backfillListComponent.getDest()));
+    final Optional<String> workflow =
+        Optional.ofNullable(namespace.getString(parser.backfillListWorkflow.getDest()));
+    final boolean showAll = namespace.getBoolean(parser.backfillListShowAll.getDest());
+
+    styxClient.backfillList(component, workflow, showAll, false)
+        .whenComplete(throwableChecker)
+        .whenComplete((backfillsPayload, throwable) -> cliOutput.printBackfills(backfillsPayload.backfills()));
   }
 
-  private void resourceCreate() throws ExecutionException, InterruptedException, IOException {
+  private void resourceCreate() {
     final String id = namespace.getString(parser.resourceCreateId.getDest());
     final int concurrency = namespace.getInt(parser.resourceCreateConcurrency.getDest());
 
-    final ByteString payload = serialize(Resource.create(id, concurrency));
-    final ByteString response = send(
-        Request.forUri(apiUrl("resources"), "POST").withPayload(payload));
-    final Resource resource = deserialize(response, Resource.class);
-    cliOutput.printResources(Collections.singletonList(resource));
+    styxClient.resourceCreate(id, concurrency)
+        .whenComplete(throwableChecker)
+        .whenComplete((resource, throwable) -> cliOutput.printResources(Collections.singletonList(resource)));
   }
 
-  private void resourceEdit() throws ExecutionException, InterruptedException, IOException {
+  private void resourceEdit() {
     final String id = namespace.getString(parser.resourceEditId.getDest());
     final Integer concurrency = namespace.getInt(parser.resourceEditConcurrency.getDest());
 
-    final ByteString getResponse = send(Request.forUri(apiUrl("resources", id)));
-    Resource resource = deserialize(getResponse, Resource.class);
     if (concurrency != null) {
-      resource = Resource.create(resource.id(), concurrency);
+      styxClient.resourceEdit(id, concurrency)
+          .whenComplete(throwableChecker)
+          .whenComplete((resource, throwable) -> cliOutput.printResources(Collections.singletonList(resource)));
     }
-    final ByteString putPayload = serialize(resource);
-    final ByteString putResponse = send(
-        Request.forUri(apiUrl("resources", id), "PUT").withPayload(putPayload));
-
-    final Resource newResource = deserialize(putResponse, Resource.class);
-    cliOutput.printResources(Collections.singletonList(newResource));
   }
 
-  private void resourceShow() throws ExecutionException, InterruptedException, IOException {
+  private void resourceShow() {
     final String id = namespace.getString(parser.resourceShowId.getDest());
-    final ByteString response = send(Request.forUri(apiUrl("resources", id)));
-    final Resource resource = deserialize(response, Resource.class);
-    cliOutput.printResources(Collections.singletonList(resource));
+
+    styxClient.resource(id)
+        .whenComplete(throwableChecker)
+        .whenComplete((resource, throwable) -> cliOutput.printResources(Collections.singletonList(resource)));
   }
 
-  private void resourceList()
-      throws IOException, ExecutionException, InterruptedException {
-    final ByteString response = send(Request.forUri(apiUrl("resources")));
-    final ResourcesPayload resources = deserialize(response, ResourcesPayload.class);
-    cliOutput.printResources(resources.resources());
+  private void resourceList() {
+    styxClient.resourceList()
+        .whenComplete(throwableChecker)
+        .whenComplete((resourcesPayload, throwable) -> cliOutput.printResources(resourcesPayload.resources()));
   }
 
-  private void workflowShow() throws ExecutionException, InterruptedException, IOException {
-    final String cid = namespace.getString(parser.workflowShowComponentId.getDest());
-    final String wid = namespace.getString(parser.workflowShowWorkflowId.getDest());
+  private void workflowShow() {
+    final String component = namespace.getString(parser.workflowShowComponentId.getDest());
+    final String workflow = namespace.getString(parser.workflowShowWorkflowId.getDest());
 
-    // Fetch config and state in parallel
-    final CompletableFuture<Response<ByteString>> workflowResponse =
-        sendAsync(Request.forUri(apiUrl("workflows", cid, wid))).toCompletableFuture();
-    final CompletableFuture<Response<ByteString>> stateResponse =
-        sendAsync(Request.forUri(apiUrl("workflows", cid, wid, "state"))).toCompletableFuture();
+    final CompletableFuture<Workflow> workflowFuture =
+        styxClient.workflow(component, workflow).toCompletableFuture();
+    final CompletableFuture<WorkflowState> workflowStateFuture =
+        styxClient.workflowState(component, workflow).toCompletableFuture();
 
-    // Wait for both responses
-    CompletableFuture.allOf(workflowResponse, stateResponse).get();
-
-    final ByteString workflowPayload = requireSuccess(workflowResponse.get())
-        .payload().orElse(ByteString.EMPTY);
-    final ByteString statePayload = requireSuccess(stateResponse.get())
-        .payload().orElse(ByteString.EMPTY);
-
-    final Workflow workflow = deserialize(workflowPayload, Workflow.class);
-    final WorkflowState workflowState = deserialize(statePayload, WorkflowState.class);
-
-    cliOutput.printWorkflow(workflow, workflowState);
+    workflowFuture.thenCombine(workflowStateFuture, Tuple::of)
+        .whenComplete(throwableChecker)
+        .whenComplete((tuple, throwable) -> cliOutput.printWorkflow(tuple._1, tuple._2));
   }
 
-  private void activeStates() throws IOException, ExecutionException, InterruptedException {
-    String uri = apiUrl("status", "activeStates");
-    final String component = namespace.getString(parser.listComponent.getDest());
-    if (component != null) {
-      uri += "?component=" + URLEncoder.encode(component, UTF_8);
-    }
+  private void activeStates() {
+    final Optional<String> component =
+        Optional.ofNullable(namespace.getString(parser.listComponent.getDest()));
 
-    final ByteString response = send(Request.forUri(uri).withTtl(Duration.ofSeconds(TTL_REQUEST)));
-    final RunStateDataPayload runStateDataPayload = deserialize(response, RunStateDataPayload.class);
-    cliOutput.printStates(runStateDataPayload);
+    styxClient.activeStates(component)
+        .whenComplete(throwableChecker)
+        .whenComplete((runStateDataPayload, throwable) -> cliOutput.printStates(runStateDataPayload));
   }
 
-  private void eventsForWorkflowInstance()
-      throws ExecutionException, InterruptedException, IOException {
-    final WorkflowInstance workflowInstance = getWorkflowInstance(namespace);
-    final String component = workflowInstance.workflowId().componentId();
-    final String workflow = workflowInstance.workflowId().id();
-    final String parameter = workflowInstance.parameter();
+  private void eventsForWorkflowInstance() {
+    final String component = namespace.getString(COMPONENT_DEST);
+    final String workflow = namespace.getString(WORKFLOW_DEST);
+    final String parameter = namespace.getString(PARAMETER_DEST);
 
-    final ByteString response = send(
-        Request.forUri(apiUrl("status", "events", component, workflow, parameter))
-            .withTtl(Duration.ofSeconds(TTL_REQUEST)));
-
-    final JsonNode jsonNode = OBJECT_MAPPER.readTree(response.toByteArray());
-
-    if (!jsonNode.isObject()) {
-      throw new RuntimeException("Invalid json returned from API");
-    }
-
-    final ObjectNode json = (ObjectNode) jsonNode;
-    final ArrayNode events = json.withArray("events");
-    final ImmutableList.Builder<EventInfo> eventInfos = ImmutableList.builder();
-    for (JsonNode eventWithTimestamp : events) {
-      final long ts = eventWithTimestamp.get("timestamp").asLong();
-      final JsonNode event = eventWithTimestamp.get("event");
-
-      String eventName;
-      String eventInfo;
-      try {
-        Event typedEvent = OBJECT_MAPPER.convertValue(event, Event.class);
-        eventName = EventUtil.name(typedEvent);
-        eventInfo = EventUtil.info(typedEvent);
-      } catch (IllegalArgumentException e) {
-        // fall back to just inspecting the json
-        eventName = event.get("@type").asText();
-        eventInfo = "";
-      }
-
-      eventInfos.add(EventInfo.create(ts, eventName, eventInfo));
-    }
-
-    cliOutput.printEvents(eventInfos.build());
+    styxClient.eventsForWorkflowInstance(component, workflow, parameter)
+        .whenComplete(throwableChecker)
+        .whenComplete((list, throwable) -> cliOutput.printEvents(list));
   }
 
-  private void triggerWorkflowInstance()
-      throws ExecutionException, InterruptedException, JsonProcessingException {
-    final WorkflowInstance workflowInstance = getWorkflowInstance(namespace);
-    final ByteString payload = serialize(workflowInstance);
-    send(Request.forUri(apiUrl("scheduler", "trigger"), "POST").withPayload(payload));
-    cliOutput.printMessage(
-        "Triggered! Use `styx ls -c " + workflowInstance.workflowId().componentId()
-        + "` to check active workflow instances.");
+  private void triggerWorkflowInstance() {
+    final String component = namespace.getString(COMPONENT_DEST);
+    final String workflow = namespace.getString(WORKFLOW_DEST);
+    final String parameter = namespace.getString(PARAMETER_DEST);
+
+    styxClient.triggerWorkflowInstance(component, workflow, parameter)
+        .whenComplete(throwableChecker)
+        .whenComplete((none, throwable) -> cliOutput.printMessage(
+            "Triggered! Use `styx ls -c " + component + "` to check active workflow instances."));
   }
 
-  private void haltWorkflowInstance()
-      throws ExecutionException, InterruptedException, JsonProcessingException {
-    final WorkflowInstance workflowInstance = getWorkflowInstance(namespace);
-    final ByteString payload = serialize(Event.halt(workflowInstance));
-    send(Request.forUri(apiUrl("scheduler", "events"), "POST").withPayload(payload));
+  private void haltWorkflowInstance() {
+    final String component = namespace.getString(COMPONENT_DEST);
+    final String workflow = namespace.getString(WORKFLOW_DEST);
+    final String parameter = namespace.getString(PARAMETER_DEST);
+
+    styxClient.haltWorkflowInstance(component, workflow, parameter)
+        .whenComplete(throwableChecker)
+        .whenComplete((none, throwable) -> cliOutput.printMessage(
+            "Halted! Use `styx events " + component + " " + workflow + " " + parameter + "` "
+            + "to verify."));
   }
 
-  private void retryWorkflowInstance()
-      throws ExecutionException, InterruptedException, JsonProcessingException {
-    final WorkflowInstance workflowInstance = getWorkflowInstance(namespace);
-    final ByteString payload = serialize(Event.dequeue(workflowInstance));
-    send(Request.forUri(apiUrl("scheduler", "events"), "POST").withPayload(payload));
-  }
+  private void retryWorkflowInstance() {
+    final String component = namespace.getString(COMPONENT_DEST);
+    final String workflow = namespace.getString(WORKFLOW_DEST);
+    final String parameter = namespace.getString(PARAMETER_DEST);
 
-  private static WorkflowInstance getWorkflowInstance(Namespace namespace) {
-    return WorkflowInstance.create(
-        WorkflowId.create(
-            namespace.getString(COMPONENT_DEST),
-            namespace.getString(WORKFLOW_DEST)),
-        namespace.getString(PARAMETER_DEST));
-  }
-
-  private String apiUrl(CharSequence... parts) {
-    return "http://" + apiHost + STYX_API_ENDPOINT + "/" + String.join("/", parts);
-  }
-
-  private ByteString send(Request request) throws ExecutionException, InterruptedException {
-    // TODO: Move requireSuccess use into callers of send()
-    return requireSuccess(sendAsync(request).toCompletableFuture().get())
-        .payload().orElse(ByteString.EMPTY);
-  }
-
-  private static <T> Response<T> requireSuccess(Response<T> response) {
-    switch (response.status().family()) {
-      case SUCCESSFUL:
-        return response;
-      default:
-        throw new RuntimeException(
-            String.format("API error: %d %s",
-                response.status().code(),
-                response.status().reasonPhrase()));
-    }
-  }
-
-  private CompletionStage<Response<ByteString>> sendAsync(Request request)
-      throws ExecutionException, InterruptedException {
-    return client.send(request.withHeader("User-Agent", STYX_CLI_VERSION));
+    styxClient.retryWorkflowInstance(component, workflow, parameter)
+        .whenComplete(throwableChecker)
+        .whenComplete((none, throwable) -> cliOutput.printMessage(
+            "Retrying! Use `styx ls -c " + component + "` to check active workflow instances."));
   }
 
   private static class StyxCliParser {

--- a/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
@@ -26,6 +26,7 @@ import com.spotify.apollo.core.Services;
 import com.spotify.apollo.environment.ApolloEnvironmentModule;
 import com.spotify.apollo.http.client.HttpClientModule;
 import com.spotify.styx.client.StyxApolloClient;
+import com.spotify.styx.client.util.ApiErrorException;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowState;
 import com.spotify.styx.util.ParameterUtil;
@@ -74,7 +75,9 @@ public final class Main {
   private StyxApolloClient styxClient;
   private final BiConsumer<Object, Throwable> throwableChecker = (response, throwable) -> {
     if (throwable != null) {
-      if (throwable.getCause() == null) {
+      if (throwable instanceof ApiErrorException) {
+        System.err.println("API error: " + throwable.getMessage());
+      } else if (throwable.getCause() == null) {
         System.err.println(throwable.toString());
       } else {
         System.err.println(throwable.getCause().getMessage());

--- a/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
@@ -30,7 +30,8 @@ import com.spotify.styx.api.BackfillsPayload;
 import com.spotify.styx.api.ResourcesPayload;
 import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.client.ApiErrorException;
-import com.spotify.styx.client.StyxApolloClient;
+import com.spotify.styx.client.StyxClient;
+import com.spotify.styx.client.StyxClientFactory;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Workflow;
@@ -81,7 +82,7 @@ public final class Main {
   private final String apiHost;
   private final Service cliService;
   private final CliOutput cliOutput;
-  private StyxApolloClient styxClient;
+  private StyxClient styxClient;
 
   private Main(
       StyxCliParser parser,
@@ -141,7 +142,7 @@ public final class Main {
 
     try (Service.Instance instance = cliService.start()) {
       final Client client = ApolloEnvironmentModule.environment(instance).environment().client();
-      styxClient = new StyxApolloClient(client, apiHost);
+      styxClient = StyxClientFactory.create(client, apiHost);
 
       switch (command) {
         case LIST:

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
@@ -30,6 +30,7 @@ import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.data.EventInfo;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.StateData;
 import java.util.Collections;

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -41,6 +41,7 @@ import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.data.EventInfo;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.StateData;
 import java.util.Collections;

--- a/styx-client/pom.xml
+++ b/styx-client/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>styx</artifactId>
+    <groupId>com.spotify</groupId>
+    <version>1.0.8-SNAPSHOT</version>
+  </parent>
+
+  <name>Spotify Styx API Client</name>
+  <artifactId>styx-client</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>styx-common</artifactId>
+      <version>1.0.8-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>completable-futures</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/styx-client/pom.xml
+++ b/styx-client/pom.xml
@@ -18,6 +18,12 @@
       <artifactId>styx-common</artifactId>
       <version>1.0.8-SNAPSHOT</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>completable-futures</artifactId>

--- a/styx-client/src/main/java/com/spotify/styx/client/ApiErrorException.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/ApiErrorException.java
@@ -1,0 +1,39 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.client;
+
+/**
+ * Exception used in case of API errors, i.e. API requests whose response has status code
+ * different than 2xx.
+ */
+public class ApiErrorException extends RuntimeException {
+
+  private final int code;
+
+  ApiErrorException(String message, int code) {
+    super(message);
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+}

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
@@ -1,0 +1,349 @@
+/*-
+ * -\-\-
+ * styx-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.client;
+
+import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
+import static com.spotify.styx.serialization.Json.serialize;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.spotify.apollo.Client;
+import com.spotify.apollo.Request;
+import com.spotify.apollo.Response;
+import com.spotify.futures.CompletableFutures;
+import com.spotify.styx.api.BackfillPayload;
+import com.spotify.styx.api.BackfillsPayload;
+import com.spotify.styx.api.ResourcesPayload;
+import com.spotify.styx.api.RunStateDataPayload;
+import com.spotify.styx.model.Backfill;
+import com.spotify.styx.model.BackfillInput;
+import com.spotify.styx.model.Event;
+import com.spotify.styx.model.Resource;
+import com.spotify.styx.model.Workflow;
+import com.spotify.styx.model.WorkflowId;
+import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.data.EventInfo;
+import com.spotify.styx.util.EventUtil;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import okio.ByteString;
+
+/**
+ * Styx Apollo Client Implementation
+ */
+public class StyxApolloClient
+    implements StyxWorkflowClient, StyxBackfillClient, StyxResourceClient,
+               StyxSchedulerClient, StyxStatusClient {
+  private static final String STYX_API_ENDPOINT = "/api/v2";
+  private static final String UTF_8 = "UTF-8";
+  private static final String STYX_CLIENT_VERSION =
+      "Styx Client " + StyxApolloClient.class.getPackage().getImplementationVersion();
+  private static final int TTL_SECONDS = 90;
+
+  private final String apiHost;
+  private final Client client;
+
+  public StyxApolloClient(final Client client,
+                          final String apiHost) {
+    this.apiHost = apiHost;
+    this.client = client;
+  }
+
+  @Override
+  public CompletionStage<RunStateDataPayload> activeStates(Optional<String> componentId) {
+    String url = apiUrl("status", "activeStates");
+    if (componentId.isPresent()) {
+      url = addQueryToApiUrl(url, "component=" + componentId.get());
+    }
+    return executeRequest(
+        Request.forUri(url).withTtl(Duration.ofSeconds(TTL_SECONDS)),
+        RunStateDataPayload.class);
+  }
+
+  @Override
+  public CompletionStage<List<EventInfo>> eventsForWorkflowInstance(String componentId,
+                                                                    String workflowId,
+                                                                    String parameter) {
+    final String url = apiUrl("status", "events", componentId, workflowId, parameter);
+    return executeRequest(Request.forUri(url).withTtl(Duration.ofSeconds(TTL_SECONDS)))
+        .thenApply(response -> {
+          final JsonNode jsonNode;
+          try {
+            if (!response.payload().isPresent()) {
+              throw new RuntimeException("No json returned from API");
+            }
+            jsonNode = OBJECT_MAPPER.readTree(response.payload().get().toByteArray());
+          } catch (IOException e) {
+            throw new RuntimeException("Invalid json returned from API");
+          }
+
+          if (!jsonNode.isObject()) {
+            throw new RuntimeException("Unexpected json returned from API");
+          }
+
+          final ObjectNode json = (ObjectNode) jsonNode;
+          final ArrayNode events = json.withArray("events");
+          final ImmutableList.Builder<EventInfo> eventInfos = ImmutableList.builder();
+          for (JsonNode eventWithTimestamp : events) {
+            final long ts = eventWithTimestamp.get("timestamp").asLong();
+            final JsonNode event = eventWithTimestamp.get("event");
+
+            String eventName;
+            String eventInfo;
+            try {
+              Event typedEvent = OBJECT_MAPPER.convertValue(event, Event.class);
+              eventName = EventUtil.name(typedEvent);
+              eventInfo = EventUtil.info(typedEvent);
+            } catch (IllegalArgumentException e) {
+              // fall back to just inspecting the json
+              eventName = event.get("@type").asText();
+              eventInfo = "";
+            }
+
+            eventInfos.add(EventInfo.create(ts, eventName, eventInfo));
+          }
+          return eventInfos.build();
+        });
+  }
+
+  @Override
+  public CompletionStage<Workflow> workflow(String componentId, String workflowId) {
+    final String url = apiUrl("workflows", componentId, workflowId);
+    return executeRequest(Request.forUri(url), Workflow.class);
+  }
+
+  @Override
+  public CompletionStage<WorkflowState> workflowState(String componentId, String workflowId) {
+    final String url = apiUrl("workflows", componentId, workflowId, "state");
+    return executeRequest(Request.forUri(url), WorkflowState.class);
+  }
+
+  @Override
+  public CompletionStage<Void> triggerWorkflowInstance(String componentId,
+                                                       String workflowId,
+                                                       String parameter) {
+    final String url = apiUrl("scheduler", "trigger");
+    final WorkflowInstance workflowInstance = WorkflowInstance.create(
+        WorkflowId.create(componentId, workflowId),
+        parameter);
+    try {
+      final ByteString payload = serialize(workflowInstance);
+      return executeRequest(
+          Request.forUri(url, "POST").withPayload(payload))
+          .thenApply(response -> (Void) null);
+    } catch (JsonProcessingException e) {
+      return CompletableFutures.exceptionallyCompletedFuture(e);
+    }
+  }
+
+  @Override
+  public CompletionStage<Void> haltWorkflowInstance(String componentId,
+                                                    String workflowId,
+                                                    String parameter) {
+    final String url = apiUrl("scheduler", "events");
+    final WorkflowInstance workflowInstance = WorkflowInstance.create(
+        WorkflowId.create(componentId, workflowId),
+        parameter);
+    try {
+      final ByteString payload = serialize(Event.halt(workflowInstance));
+      return executeRequest(
+          Request.forUri(url, "POST").withPayload(payload))
+          .thenApply(response -> (Void) null);
+    } catch (JsonProcessingException e) {
+      return CompletableFutures.exceptionallyCompletedFuture(e);
+    }
+  }
+
+  @Override
+  public CompletionStage<Void> retryWorkflowInstance(String componentId,
+                                                     String workflowId,
+                                                     String parameter) {
+    final String url = apiUrl("scheduler", "events");
+    final WorkflowInstance workflowInstance = WorkflowInstance.create(
+        WorkflowId.create(componentId, workflowId),
+        parameter);
+    try {
+      final ByteString payload = serialize(Event.dequeue(workflowInstance));
+      return executeRequest(
+          Request.forUri(url, "POST").withPayload(payload))
+          .thenApply(response -> (Void) null);
+    } catch (JsonProcessingException e) {
+      return CompletableFutures.exceptionallyCompletedFuture(e);
+    }
+  }
+
+  @Override
+  public CompletionStage<Resource> resourceCreate(String resourceId, int concurrency) {
+    final String url = apiUrl("resources");
+    try {
+      final ByteString payload = serialize(Resource.create(resourceId, concurrency));
+      return executeRequest(Request.forUri(url, "POST").withPayload(payload), Resource.class);
+    } catch (JsonProcessingException e) {
+      return CompletableFutures.exceptionallyCompletedFuture(e);
+    }
+  }
+
+  @Override
+  public CompletionStage<Resource> resourceEdit(String resourceId, int concurrency) {
+    final String url = apiUrl("resources", resourceId);
+    try {
+      final ByteString payload = serialize(Resource.create(resourceId, concurrency));
+      return executeRequest(Request.forUri(url, "PUT").withPayload(payload), Resource.class);
+    } catch (JsonProcessingException e) {
+      return CompletableFutures.exceptionallyCompletedFuture(e);
+    }
+  }
+
+  @Override
+  public CompletionStage<Resource> resource(String resourceId) {
+    final String url = apiUrl("resources", resourceId);
+    return executeRequest(Request.forUri(url), Resource.class);
+  }
+
+  @Override
+  public CompletionStage<ResourcesPayload> resourceList() {
+    final String url = apiUrl("resources");
+    return executeRequest(Request.forUri(url), ResourcesPayload.class);
+  }
+
+  @Override
+  public CompletionStage<Backfill> backfillCreate(String componentId, String workflowId,
+                                                  String start, String end,
+                                                  int concurrency) {
+    final String url = apiUrl("backfills");
+    try {
+      final ByteString payload = serialize(BackfillInput.create(
+          Instant.parse(start), Instant.parse(end), componentId, workflowId, concurrency));
+      return executeRequest(Request.forUri(url, "POST").withPayload(payload), Backfill.class);
+    } catch (JsonProcessingException e) {
+      return CompletableFutures.exceptionallyCompletedFuture(e);
+    }
+  }
+
+  @Override
+  public CompletionStage<Backfill> backfillEditConcurrency(String backfillId, int concurrency) {
+    return backfill(backfillId).thenCompose(backfillPayload -> {
+      final Backfill editedBackfill = backfillPayload.backfill().builder().concurrency(concurrency).build();
+      final String url = apiUrl("backfills", backfillId);
+      try {
+        final ByteString payload = serialize(editedBackfill);
+        return executeRequest(Request.forUri(url, "PUT").withPayload(payload), Backfill.class);
+      } catch (JsonProcessingException e) {
+        return CompletableFutures.exceptionallyCompletedFuture(e);
+      }
+    });
+  }
+
+  @Override
+  public CompletionStage<Void> backfillHalt(String backfillId) {
+    final String url = apiUrl("backfills", backfillId);
+    return executeRequest(Request.forUri(url, "DELETE")).thenApply(response -> (Void) null);
+  }
+
+  @Override
+  public CompletionStage<BackfillPayload> backfill(String backfillId) {
+    final String url = apiUrl("backfills", backfillId);
+    return executeRequest(Request.forUri(url), BackfillPayload.class);
+  }
+
+  @Override
+  public CompletionStage<BackfillsPayload> backfillList(Optional<String> componentId,
+                                                        Optional<String> workflowId,
+                                                        boolean showAll,
+                                                        boolean status) {
+    final List<String> queries = new ArrayList<>();
+    componentId.ifPresent(c -> queries.add("component=" + c));
+    workflowId.ifPresent(w -> queries.add("workflow=" + w));
+    queries.add("showAll=" + showAll);
+    queries.add("status=" + status);
+
+    String url = apiUrl("backfills");
+    url = addQueryToApiUrl(url, queries);
+
+    return executeRequest(Request.forUri(url), BackfillsPayload.class);
+  }
+
+  private <T> CompletionStage<T> executeRequest(final Request request,
+                                                final Class<T> tClass) {
+    return executeRequest(request).thenApply(response -> {
+      if (!response.payload().isPresent()) {
+        throw new RuntimeException("Expected payload not found");
+      } else {
+        try {
+          return OBJECT_MAPPER.readValue(response.payload().get().toByteArray(), tClass);
+        } catch (IOException e) {
+          throw new RuntimeException("Error while reading the received payload: " + e);
+        }
+      }
+    });
+  }
+
+  private CompletionStage<Response<ByteString>> executeRequest(final Request request) {
+    return client.send(request.withHeader("User-Agent", STYX_CLIENT_VERSION)).thenApply(response -> {
+      switch (response.status().family()) {
+        case SUCCESSFUL:
+          return response;
+        default:
+          final String status = response.status().code() + " " + response.status().reasonPhrase();
+          throw new RuntimeException("API error: " + status);
+      }
+    });
+  }
+
+  private String apiUrl(String... parts) {
+    final List<String> encodedPartsList = Arrays.stream(parts).map(part -> {
+      try {
+        return URLEncoder.encode(part, UTF_8);
+      } catch (UnsupportedEncodingException e) {
+        throw new RuntimeException(e);
+      }
+    }).collect(Collectors.toList());
+    return "http://" + apiHost + STYX_API_ENDPOINT + "/" + String.join("/", encodedPartsList);
+  }
+
+  private String addQueryToApiUrl(String url, List<String> queries) {
+    final List<String> encodedQueryParts = queries.stream().map(query -> {
+      try {
+        return URLEncoder.encode(query, UTF_8);
+      } catch (UnsupportedEncodingException e) {
+        throw new RuntimeException(e);
+      }
+    }).collect(Collectors.toList());
+    return url + "?" + String.join("&", encodedQueryParts);
+  }
+
+  private String addQueryToApiUrl(String url, String... queries) {
+    return addQueryToApiUrl(url, Arrays.stream(queries).collect(Collectors.toList()));
+  }
+}

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
@@ -60,7 +60,9 @@ import java.util.stream.Collectors;
 import okio.ByteString;
 
 /**
- * Styx Apollo Client Implementation
+ * Styx Apollo Client Implementation. In case of API errors, the {@link Throwable} in the returned
+ * {@link CompletionStage} will be of kind {@link ApiErrorException}. Other errors will be treated
+ * as {@link RuntimeException} instead.
  */
 public class StyxApolloClient
     implements StyxWorkflowClient, StyxBackfillClient, StyxResourceClient,
@@ -163,7 +165,7 @@ public class StyxApolloClient
           Request.forUri(url, "POST").withPayload(payload))
           .thenApply(response -> (Void) null);
     } catch (JsonProcessingException e) {
-      return CompletableFutures.exceptionallyCompletedFuture(e);
+      return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
     }
   }
 
@@ -181,7 +183,7 @@ public class StyxApolloClient
           Request.forUri(url, "POST").withPayload(payload))
           .thenApply(response -> (Void) null);
     } catch (JsonProcessingException e) {
-      return CompletableFutures.exceptionallyCompletedFuture(e);
+      return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
     }
   }
 
@@ -199,7 +201,7 @@ public class StyxApolloClient
           Request.forUri(url, "POST").withPayload(payload))
           .thenApply(response -> (Void) null);
     } catch (JsonProcessingException e) {
-      return CompletableFutures.exceptionallyCompletedFuture(e);
+      return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
     }
   }
 
@@ -210,7 +212,7 @@ public class StyxApolloClient
       final ByteString payload = serialize(Resource.create(resourceId, concurrency));
       return executeRequest(Request.forUri(url, "POST").withPayload(payload), Resource.class);
     } catch (JsonProcessingException e) {
-      return CompletableFutures.exceptionallyCompletedFuture(e);
+      return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
     }
   }
 
@@ -221,7 +223,7 @@ public class StyxApolloClient
       final ByteString payload = serialize(Resource.create(resourceId, concurrency));
       return executeRequest(Request.forUri(url, "PUT").withPayload(payload), Resource.class);
     } catch (JsonProcessingException e) {
-      return CompletableFutures.exceptionallyCompletedFuture(e);
+      return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
     }
   }
 
@@ -247,7 +249,7 @@ public class StyxApolloClient
           Instant.parse(start), Instant.parse(end), componentId, workflowId, concurrency));
       return executeRequest(Request.forUri(url, "POST").withPayload(payload), Backfill.class);
     } catch (JsonProcessingException e) {
-      return CompletableFutures.exceptionallyCompletedFuture(e);
+      return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
     }
   }
 
@@ -260,7 +262,7 @@ public class StyxApolloClient
         final ByteString payload = serialize(editedBackfill);
         return executeRequest(Request.forUri(url, "PUT").withPayload(payload), Backfill.class);
       } catch (JsonProcessingException e) {
-        return CompletableFutures.exceptionallyCompletedFuture(e);
+        return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
       }
     });
   }
@@ -315,8 +317,8 @@ public class StyxApolloClient
         case SUCCESSFUL:
           return response;
         default:
-          final String status = response.status().code() + " " + response.status().reasonPhrase();
-          throw new RuntimeException("API error: " + status);
+          final String message = response.status().code() + " " + response.status().reasonPhrase();
+          throw new ApiErrorException(message, response.status().code());
       }
     });
   }

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
@@ -64,9 +64,7 @@ import okio.ByteString;
  * {@link CompletionStage} will be of kind {@link ApiErrorException}. Other errors will be treated
  * as {@link RuntimeException} instead.
  */
-public class StyxApolloClient
-    implements StyxWorkflowClient, StyxBackfillClient, StyxResourceClient,
-               StyxSchedulerClient, StyxStatusClient {
+class StyxApolloClient implements StyxClient {
   private static final String STYX_API_ENDPOINT = "/api/v2";
   private static final String UTF_8 = "UTF-8";
   private static final String STYX_CLIENT_VERSION =
@@ -76,8 +74,8 @@ public class StyxApolloClient
   private final String apiHost;
   private final Client client;
 
-  public StyxApolloClient(final Client client,
-                          final String apiHost) {
+  StyxApolloClient(final Client client,
+                   final String apiHost) {
     this.apiHost = apiHost;
     this.client = client;
   }

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxBackfillClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxBackfillClient.java
@@ -1,0 +1,89 @@
+/*-
+ * -\-\-
+ * styx-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.client;
+
+import com.spotify.styx.api.BackfillPayload;
+import com.spotify.styx.api.BackfillsPayload;
+import com.spotify.styx.model.Backfill;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Interface for Styx client, backfill resources.
+ */
+public interface StyxBackfillClient {
+
+  /**
+   * Create a {@link Backfill}
+   *
+   * @param componentId componentId id
+   * @param workflowId  workflowId id
+   * @param start       beginning of backfill range, inclusive
+   * @param end         end of backfill range, exclusive
+   * @param concurrency maximum number of concurrent active states for the backfill
+   * @return The created {@link Backfill}
+   */
+  CompletionStage<Backfill> backfillCreate(final String componentId,
+                                           final String workflowId,
+                                           final String start,
+                                           final String end,
+                                           final int concurrency);
+
+  /**
+   * Edit concurrency value of existing {@link Backfill}
+   *
+   * @param backfillId  backfill id
+   * @param concurrency the updated concurrency value
+   * @return The updated {@link Backfill}
+   */
+  CompletionStage<Backfill> backfillEditConcurrency(final String backfillId,
+                                                    final int concurrency);
+
+  /**
+   * Halt an existing {@link Backfill}
+   *
+   * @param backfillId backfill id
+   */
+  CompletionStage<Void> backfillHalt(final String backfillId);
+
+  /**
+   * Get an existing {@link Backfill}
+   *
+   * @param backfillId backfill id
+   * @return The required {@link Backfill}
+   */
+  CompletionStage<BackfillPayload> backfill(final String backfillId);
+
+  /**
+   * List of existing {@link Backfill}s
+   *
+   * @param componentId componentId id to filter on
+   * @param workflowId  componentId id to filter on
+   * @param showAll     if to include also inactive {@link Backfill}s
+   * @param status      if to include status info for the {@link Backfill}s
+   * @return The required list of {@link Backfill}s, according to the applied filters/options
+   */
+  CompletionStage<BackfillsPayload> backfillList(final Optional<String> componentId,
+                                                 final Optional<String> workflowId,
+                                                 final boolean showAll,
+                                                 final boolean status);
+
+}

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxClient.java
@@ -1,0 +1,29 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.client;
+
+/**
+ * Interface for the complete Styx client.
+ */
+public interface StyxClient
+    extends StyxStatusClient, StyxSchedulerClient, StyxResourceClient,
+            StyxBackfillClient, StyxWorkflowClient {
+}

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxClientFactory.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxClientFactory.java
@@ -1,0 +1,53 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.client;
+
+import com.spotify.apollo.Client;
+
+/**
+ * Factory to get a StyxClient implementation.
+ */
+public class StyxClientFactory {
+
+  public static StyxClient create(Client client, String apiHost) {
+    return new StyxApolloClient(client, apiHost);
+  }
+
+  public static StyxStatusClient createStatusClient(Client client, String apiHost) {
+    return new StyxApolloClient(client, apiHost);
+  }
+
+  public static StyxBackfillClient createBackfillClient(Client client, String apiHost) {
+    return new StyxApolloClient(client, apiHost);
+  }
+
+  public static StyxSchedulerClient createSchedulerClient(Client client, String apiHost) {
+    return new StyxApolloClient(client, apiHost);
+  }
+
+  public static StyxResourceClient createResourceClient(Client client, String apiHost) {
+    return new StyxApolloClient(client, apiHost);
+  }
+
+  public static StyxWorkflowClient createWorkflowClient(Client client, String apiHost) {
+    return new StyxApolloClient(client, apiHost);
+  }
+}

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxResourceClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxResourceClient.java
@@ -1,0 +1,67 @@
+/*-
+ * -\-\-
+ * styx-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.client;
+
+import com.spotify.styx.api.ResourcesPayload;
+import com.spotify.styx.model.Resource;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Interface for Styx client, Styx resource resources.
+ */
+interface StyxResourceClient {
+
+  /**
+   * Create a {@link Resource}
+   *
+   * @param resourceId  resource id to use for the {@link Resource}
+   * @param concurrency resource value
+   * @return The created {@link Resource}
+   */
+  CompletionStage<Resource> resourceCreate(final String resourceId,
+                                           final int concurrency);
+
+  /**
+   * Edit an existing {@link Resource}
+   *
+   * @param resourceId  resource id
+   * @param concurrency the updated resource value
+   * @return The updated{@link Resource}
+   */
+  CompletionStage<Resource> resourceEdit(final String resourceId,
+                                         final int concurrency);
+
+  /**
+   * Get an existing {@link Resource}
+   *
+   * @param resourceId resource id
+   * @return The required {@link Resource}
+   */
+  CompletionStage<Resource> resource(final String resourceId);
+
+  /**
+   * List of existing {@link Resource}s
+   *
+   * @return The list of all existing {@link Resource}s
+   */
+  CompletionStage<ResourcesPayload> resourceList();
+
+}

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxSchedulerClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxSchedulerClient.java
@@ -1,0 +1,63 @@
+/*-
+ * -\-\-
+ * styx-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.client;
+
+import com.spotify.styx.model.WorkflowInstance;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Interface for Styx client, scheduler resources.
+ */
+public interface StyxSchedulerClient {
+
+  /**
+   * Trigger a {@link WorkflowInstance}
+   *
+   * @param componentId component id
+   * @param workflowId  workflow id
+   * @param parameter   parameter
+   */
+  CompletionStage<Void> triggerWorkflowInstance(final String componentId,
+                                                final String workflowId,
+                                                final String parameter);
+
+  /**
+   * Halt a {@link WorkflowInstance}
+   *
+   * @param componentId component id
+   * @param workflowId  workflow id
+   * @param parameter   parameter
+   */
+  CompletionStage<Void> haltWorkflowInstance(final String componentId,
+                                             final String workflowId,
+                                             final String parameter);
+
+  /**
+   * Retry a {@link WorkflowInstance}
+   *
+   * @param componentId component id
+   * @param workflowId  workflow id
+   * @param parameter   parameter
+   */
+  CompletionStage<Void> retryWorkflowInstance(final String componentId,
+                                              final String workflowId,
+                                              final String parameter);
+}

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxStatusClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxStatusClient.java
@@ -1,0 +1,59 @@
+/*-
+ * -\-\-
+ * styx-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.client;
+
+import com.spotify.styx.api.RunStateDataPayload;
+import com.spotify.styx.model.Event;
+import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.model.data.EventInfo;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Interface for Styx client, status resources.
+ */
+public interface StyxStatusClient {
+
+  /**
+   * Get information about the active stats
+   *
+   * @param componentId component id to filter on
+   * @return The information about the active states
+   */
+  CompletionStage<RunStateDataPayload> activeStates(final Optional<String> componentId);
+
+  /**
+   * Get {@link EventInfo}s for a {@link WorkflowInstance}. If an unrecognized {@link Event} is
+   * received, possibly because of version difference between client and server, a best effort
+   * attempt is performed to construct the {@link EventInfo} with basic information for the
+   * received {@link Event}, i.e the event name and event timestamp.
+   *
+   * @param componentId component id
+   * @param workflowId  workflow id
+   * @param parameter   parameter
+   *
+   * @return The list of {@link EventInfo}s for the selected {@link WorkflowInstance}
+   */
+  CompletionStage<List<EventInfo>> eventsForWorkflowInstance(final String componentId,
+                                                             final String workflowId,
+                                                             final String parameter);
+}

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxWorkflowClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxWorkflowClient.java
@@ -1,0 +1,47 @@
+/*-
+ * -\-\-
+ * styx-client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.client;
+
+import com.spotify.styx.model.Workflow;
+import com.spotify.styx.model.WorkflowState;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Interface for Styx client, workflow resources.
+ */
+public interface StyxWorkflowClient {
+
+  /**
+   * Get a {@link Workflow}
+   *
+   * @param componentId componentId id
+   * @param workflowId  workflowId id
+   */
+  CompletionStage<Workflow> workflow(final String componentId, final String workflowId);
+
+  /**
+   * Get a {@link WorkflowState}
+   *
+   * @param componentId componentId id
+   * @param workflowId  workflowId id
+   */
+  CompletionStage<WorkflowState> workflowState(final String componentId, final String workflowId);
+}

--- a/styx-common/src/main/java/com/spotify/styx/model/data/EventInfo.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/EventInfo.java
@@ -1,0 +1,37 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.model.data;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class EventInfo {
+
+  public abstract long timestamp();
+
+  public abstract String name();
+
+  public abstract String info();
+
+  public static EventInfo create(long ts, String eventName, String eventInfo) {
+    return new AutoValue_EventInfo(ts, eventName, eventInfo);
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/util/EventUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/EventUtil.java
@@ -27,6 +27,7 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.Trigger;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Utility for getting information about {@link Event}s
@@ -38,6 +39,97 @@ public final class EventUtil {
 
   public static String name(Event event) {
     return event.accept(EventNameVisitor.INSTANCE);
+  }
+
+  public static String info(Event event) {
+    return event.accept(EventInfoVisitor.INSTANCE);
+  }
+
+  /**
+   * An {@link EventVisitor} for extracting the info of an {@link Event}.
+   */
+  private enum EventInfoVisitor implements EventVisitor<String> {
+    INSTANCE;
+
+    @Override
+    public String timeTrigger(WorkflowInstance workflowInstance) {
+      return "";
+    }
+
+    @Override
+    public String triggerExecution(WorkflowInstance workflowInstance, Trigger trigger) {
+      return String.format("Trigger id: %s", TriggerUtil.triggerId(trigger));
+    }
+
+    @Override
+    public String info(WorkflowInstance workflowInstance, Message message) {
+      return message.line();
+    }
+
+    @Override
+    public String created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
+      return String.format("Execution id: %s, Docker image: %s", executionId, dockerImage);
+    }
+
+    @Override
+    public String dequeue(WorkflowInstance workflowInstance) {
+      return "";
+    }
+
+    @Override
+    public String started(WorkflowInstance workflowInstance) {
+      return "";
+    }
+
+    @Override
+    public String terminate(WorkflowInstance workflowInstance, Optional<Integer> exitCode) {
+      return "Exit code: " + exitCode.map(String::valueOf).orElse("-");
+    }
+
+    @Override
+    public String runError(WorkflowInstance workflowInstance, String message) {
+      return "Error message: " + message;
+    }
+
+    @Override
+    public String success(WorkflowInstance workflowInstance) {
+      return "";
+    }
+
+    @Override
+    public String retryAfter(WorkflowInstance workflowInstance, long delayMillis) {
+      return String.format("Delay (seconds): %d", TimeUnit.MILLISECONDS.toSeconds(delayMillis));
+    }
+
+    @Override
+    public String retry(WorkflowInstance workflowInstance) {
+      return "";
+    }
+
+    @Override
+    public String stop(WorkflowInstance workflowInstance) {
+      return "";
+    }
+
+    @Override
+    public String timeout(WorkflowInstance workflowInstance) {
+      return "";
+    }
+
+    @Override
+    public String halt(WorkflowInstance workflowInstance) {
+      return "";
+    }
+
+    @Override
+    public String submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription) {
+      return String.format("Execution description: %s", executionDescription);
+    }
+
+    @Override
+    public String submitted(WorkflowInstance workflowInstance, String executionId) {
+      return String.format("Execution id: %s", executionId);
+    }
   }
 
   /**

--- a/styx-schedule-source/pom.xml
+++ b/styx-schedule-source/pom.xml
@@ -31,7 +31,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
The CLI would use the `styx-client` to perform the requests, also part of this PR.

**TODO**
- The CLI version is part of the requests' header; (removed)

_NOTE_
I am not sure about the way the client handles errors and exceptions at this point. The `throwable` we add to a failing `CompletionStage` is different in different cases but very obscure to users. 
I think we should extract at least two kind of checked exceptions: `ClientErrorException` and `ServerErrorException`. A more generic `IOException` can also be added to the signatures for unexpected arguments/payloads. In this way errors can be better documented and easier to handle.
However I am not sure what are the best practices for this case.