### PR TITLE
s/SchedulerResource/SchedulerResourceProxy

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -33,7 +33,7 @@ import com.spotify.apollo.Environment;
 import com.spotify.apollo.route.Route;
 import com.spotify.styx.api.BackfillResource;
 import com.spotify.styx.api.ResourceResource;
-import com.spotify.styx.api.SchedulerResource;
+import com.spotify.styx.api.SchedulerProxyResource;
 import com.spotify.styx.api.StatusResource;
 import com.spotify.styx.api.StyxConfigResource;
 import com.spotify.styx.api.WorkflowResource;
@@ -107,7 +107,7 @@ public class StyxApi implements AppInit {
     final ResourceResource resourceResource = new ResourceResource(storage);
     final StyxConfigResource styxConfigResource = new StyxConfigResource(storage);
     final StatusResource statusResource = new StatusResource(storage);
-    final SchedulerResource schedulerResource = new SchedulerResource(schedulerServiceBaseUrl);
+    final SchedulerProxyResource schedulerProxyResource = new SchedulerProxyResource(schedulerServiceBaseUrl);
 
     final com.spotify.styx.api.deprecated.WorkflowResource
         deprecatedWorkflowResource =
@@ -157,7 +157,7 @@ public class StyxApi implements AppInit {
                             .map(r -> r
                                 .withMiddleware(clientValidator(clientBlacklistSupplier))
                                 .withMiddleware(auditLogging())))
-        .registerRoutes(schedulerResource.routes()
+        .registerRoutes(schedulerProxyResource.routes()
                             .map(r -> r
                                 .withMiddleware(clientValidator(clientBlacklistSupplier))
                                 .withMiddleware(auditLogging())));

--- a/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
@@ -36,14 +36,14 @@ import okio.ByteString;
 /**
  * API endpoints for scheduler
  */
-public class SchedulerResource {
+public class SchedulerProxyResource {
 
   static final String BASE = "/scheduler";
   private static final String SCHEDULER_BASE_PATH = "/api/v0";
 
   private final String schedulerServiceBaseUrl;
 
-  public SchedulerResource(String schedulerServiceBaseUrl) {
+  public SchedulerProxyResource(String schedulerServiceBaseUrl) {
     this.schedulerServiceBaseUrl = Objects.requireNonNull(schedulerServiceBaseUrl);
   }
 

--- a/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
@@ -30,19 +30,19 @@ import com.spotify.apollo.Status;
 import okio.ByteString;
 import org.junit.Test;
 
-public class SchedulerResourceTest extends VersionedApiTest {
+public class SchedulerProxyResourceTest extends VersionedApiTest {
 
   private static final String SCHEDULER_BASE = "http://localhost:8080";
 
-  public SchedulerResourceTest(Api.Version version) {
-    super(SchedulerResource.BASE, version);
+  public SchedulerProxyResourceTest(Api.Version version) {
+    super(SchedulerProxyResource.BASE, version);
   }
 
   @Override
   protected void init(Environment environment) {
-    final SchedulerResource schedulerResource = new SchedulerResource(SCHEDULER_BASE);
+    final SchedulerProxyResource schedulerProxyResource = new SchedulerProxyResource(SCHEDULER_BASE);
 
-    environment.routingEngine().registerRoutes(schedulerResource.routes());
+    environment.routingEngine().registerRoutes(schedulerProxyResource.routes());
   }
 
   @Test


### PR DESCRIPTION
Rename the `SchedulerResource` class in the api module to `SchedulerProxyResource` in order to resolve the conflict with `SchedulerResource` in the scheduler module. The full class names, including package names, were exactly the same, causing e.g. the standalone service to fail as only one of them would be loaded.