### PR TITLE
use netty-tcnative-boringssl-static uberjar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,6 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
         <version>1.1.33.Fork19</version>
-        <classifier>${os.detected.classifier}</classifier>
       </dependency>
 
       <!-- test libs -->
@@ -346,15 +345,6 @@
   </dependencyManagement>
 
   <build>
-    <extensions>
-      <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.4.0.Final</version>
-      </extension>
-    </extensions>
-
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/styx-common/pom.xml
+++ b/styx-common/pom.xml
@@ -78,7 +78,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <classifier>${os.detected.classifier}</classifier>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The uberjar contains native code for windows, linux and osx. Eliminates risk of build/run-time platform mismatch.