### PR TITLE
validate & recreate SA keys if necessary

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx;
 
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.iam.v1.Iam;
 import com.google.api.services.iam.v1.model.CreateServiceAccountKeyRequest;
 import com.google.api.services.iam.v1.model.ServiceAccountKey;
@@ -41,6 +42,33 @@ public class ServiceAccountKeyManager {
   public ServiceAccountKey createP12Key(String serviceAccount) throws IOException {
     return createKey(serviceAccount, new CreateServiceAccountKeyRequest()
         .setPrivateKeyType("TYPE_PKCS12_FILE"));
+  }
+
+  public boolean serviceAccountExists(String serviceAccount) throws IOException {
+    try {
+      iam.projects().serviceAccounts().get("projects/-/serviceAccounts/" + serviceAccount)
+          .execute();
+      return true;
+    } catch (GoogleJsonResponseException e) {
+      if (e.getStatusCode() == 404) {
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  public boolean keyExists(String keyName) throws IOException {
+    try {
+      iam.projects().serviceAccounts().keys()
+          .get(keyName)
+          .execute();
+      return true;
+    } catch (GoogleJsonResponseException e) {
+      if (e.getStatusCode() == 404) {
+        return false;
+      }
+      throw e;
+    }
   }
 
   private ServiceAccountKey createKey(String serviceAccount,

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -172,7 +172,8 @@ class KubernetesDockerRunner implements DockerRunner {
         LOG.error("[AUDIT] Workflow {} tries to mount secret {} to the reserved path",
                   workflowInstance.workflowId(), specSecret.name());
         throw new InvalidExecutionException(
-            STYX_WORKFLOW_SA_SECRET_MOUNT_PATH + " is a reserved mount path");
+            "Referenced secret '" + specSecret.name() + "' has the mount path "
+            + STYX_WORKFLOW_SA_SECRET_MOUNT_PATH + " defined that is reserved");
       }
 
       final Secret secret = client.secrets().withName(specSecret.name()).get();
@@ -200,7 +201,7 @@ class KubernetesDockerRunner implements DockerRunner {
     if (!serviceAccountExists) {
       LOG.error("[AUDIT] Workflow {} refers to non-existent service account {}", workflowInstance.workflowId(),
           serviceAccount);
-      throw new InvalidExecutionException("Referenced service account '" + serviceAccount + "' was not found");
+      throw new InvalidExecutionException("Referenced service account " + serviceAccount + " was not found");
     }
 
     final String secretName = buildSecretName(serviceAccount);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -375,7 +375,7 @@ public class KubernetesDockerRunnerTest {
     kdr.init();
 
     exception.expect(InvalidExecutionException.class);
-    exception.expectMessage("Referenced service account '" + SERVICE_ACCOUNT + "' was not found");
+    exception.expectMessage("Referenced service account " + SERVICE_ACCOUNT + " was not found");
 
     kdr.start(WORKFLOW_INSTANCE, RUN_SPEC_WITH_SA);
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -108,6 +108,12 @@ public class KubernetesDockerRunnerTest {
                                                                  empty(),
                                                                  Optional.of(SERVICE_ACCOUNT),
                                                                  empty());
+  private static final RunSpec RUN_SPEC_WITH_SECRET_AND_SA = RunSpec.create("busybox",
+                                                                            ImmutableList.copyOf(new String[0]),
+                                                                            false,
+                                                                            Optional.of(WorkflowConfiguration.Secret.create("secret1", KubernetesDockerRunner.STYX_WORKFLOW_SA_SECRET_MOUNT_PATH)),
+                                                                            Optional.of(SERVICE_ACCOUNT),
+                                                                            empty());
 
   @Mock NamespacedKubernetesClient k8sClient;
 
@@ -196,6 +202,24 @@ public class KubernetesDockerRunnerTest {
     kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountKeyManager);
     kdr.init();
     kdr.start(WORKFLOW_INSTANCE, RUN_SPEC_WITH_SECRET);
+  }
+
+  @Test(expected = InvalidExecutionException.class)
+  public void shouldThrowIfMountToReservedPath() throws IOException, StateManager.IsClosed {
+    when(secrets.withName(any(String.class))).thenReturn(namedResource);
+    when(namedResource.get()).thenReturn(null);
+    when(k8sClient.secrets()).thenReturn(secrets);
+    Pod createdPod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC_WITH_SECRET_AND_SA);
+    when(pods.create(any(Pod.class))).thenReturn(createdPod);
+
+    stateManager.receive(Event.terminate(WORKFLOW_INSTANCE, Optional.of(0)));
+    stateManager.receive(Event.success(WORKFLOW_INSTANCE));
+    kdr.close();
+
+    // Start a new runner
+    kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountKeyManager);
+    kdr.init();
+    kdr.start(WORKFLOW_INSTANCE, RUN_SPEC_WITH_SECRET_AND_SA);
   }
 
   @Test


### PR DESCRIPTION
Also makes SA key secret checking and creation single threaded to avoid concurrent executions of workflows using the same service account from stepping on each others feet.