### PR TITLE
Aggressively garbage collect service account keys and secrets

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -172,6 +172,11 @@ public class AggregateStorage implements Storage {
   }
 
   @Override
+  public Map<WorkflowId, Workflow> workflows() throws IOException {
+    return datastoreStorage.workflows();
+  }
+
+  @Override
   public void patchState(WorkflowId workflowId, WorkflowState state) throws IOException {
     datastoreStorage.patchState(workflowId, state);
   }

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -307,6 +307,26 @@ class DatastoreStorage {
     return map;
   }
 
+  public Map<WorkflowId, Workflow> workflows() {
+    final Map<WorkflowId, Workflow> map = Maps.newHashMap();
+    final EntityQuery query = Query.newEntityQueryBuilder().setKind(KIND_WORKFLOW).build();
+    final QueryResults<Entity> result = datastore.run(query);
+
+    while (result.hasNext()) {
+      final Entity entity = result.next();
+      final Workflow workflow;
+      try {
+        workflow = OBJECT_MAPPER.readValue(entity.getString(PROPERTY_WORKFLOW_JSON), Workflow.class);
+      } catch (IOException e) {
+        LOG.warn("Failed to read workflow {}.", entity.getKey());
+        continue;
+      }
+      map.put(workflow.id(), workflow);
+    }
+
+    return map;
+  }
+
   Map<WorkflowInstance, Long> allActiveStates() throws IOException {
     final EntityQuery query =
         Query.newEntityQueryBuilder().setKind(KIND_ACTIVE_WORKFLOW_INSTANCE).build();

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -136,6 +136,11 @@ public class InMemStorage implements Storage {
   }
 
   @Override
+  public Map<WorkflowId, Workflow> workflows() throws IOException {
+    throw new UnsupportedOperationException("Unsupported Operation!");
+  }
+
+  @Override
   public WorkflowInstanceExecutionData executionData(WorkflowInstance workflowInstance) throws IOException {
     throw new UnsupportedOperationException("Unsupported Operation!");
   }

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -140,6 +140,11 @@ public interface Storage {
   Map<Workflow, TriggerInstantSpec> workflowsWithNextNaturalTrigger() throws IOException;
 
   /**
+   * Get all {@link Workflow}s.
+   */
+  Map<WorkflowId, Workflow> workflows() throws IOException;
+
+  /**
    * Stores information about an active {@link WorkflowInstance} to be tracked.
    *
    * @param workflowInstance  The {@link WorkflowInstance} that entered an active state

--- a/styx-common/src/main/java/com/spotify/styx/util/GcpUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/GcpUtil.java
@@ -1,0 +1,42 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.util;
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import java.util.Optional;
+
+public class GcpUtil {
+
+  public static final String PERMISSION_DENIED = "PERMISSION_DENIED";
+
+  public static boolean isPermissionDenied(GoogleJsonResponseException e) {
+    return e.getStatusCode() == 403 && Optional.ofNullable(e.getDetails())
+        .map(GcpUtil::isPermissionDenied)
+        .orElse(false);
+  }
+
+  public static boolean isPermissionDenied(GoogleJsonError error) {
+    return Optional.ofNullable(error.get("status"))
+        .map(PERMISSION_DENIED::equals)
+        .orElse(false);
+  }
+}

--- a/styx-common/src/test/java/com/spotify/styx/util/GcpUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/GcpUtilTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/styx-common/src/test/java/com/spotify/styx/util/GcpUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/GcpUtilTest.java
@@ -1,0 +1,62 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.util;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException.Builder;
+import org.junit.Test;
+
+public class GcpUtilTest {
+
+  private static final GoogleJsonError PERMISSION_DENIED_ERROR = new GoogleJsonError()
+      .set("status", "PERMISSION_DENIED");
+
+  @Test
+  public void responseIsPermissionDenied() throws Exception {
+    final GoogleJsonResponseException permissionDenied = new GoogleJsonResponseException(
+        new Builder(403, "Forbidden", new HttpHeaders()), PERMISSION_DENIED_ERROR);
+    assertThat(GcpUtil.isPermissionDenied(permissionDenied), is(true));
+  }
+
+  @Test
+  public void notFoundResponseIsNotPermissionDenied() throws Exception {
+    assertThat(GcpUtil.isPermissionDenied(new GoogleJsonResponseException(
+        new Builder(404, "Not Found", new HttpHeaders()), new GoogleJsonError())), is(false));
+    assertThat(GcpUtil.isPermissionDenied(new GoogleJsonResponseException(
+        new Builder(404, "Not Found", new HttpHeaders()), null)), is(false));
+  }
+
+  @Test
+  public void errorIsPermissionDenied() throws Exception {
+    assertThat(GcpUtil.isPermissionDenied(PERMISSION_DENIED_ERROR), is(true));
+  }
+
+  @Test
+  public void errorIsNotPermissionDenied() throws Exception {
+    assertThat(GcpUtil.isPermissionDenied(new GoogleJsonError()), is(false));
+    assertThat(GcpUtil.isPermissionDenied(new GoogleJsonError().set("status", "foo failed")), is(false));
+  }
+}

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Cleaner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Cleaner.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Cleaner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Cleaner.java
@@ -39,7 +39,7 @@ class Cleaner {
 
   void tick() {
     try {
-      dockerRunner.cleanup(workflowCache.all());
+      dockerRunner.cleanup();
     } catch (IOException e) {
       logger.warn("Docker runner cleanup failed", e);
     }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Cleaner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Cleaner.java
@@ -1,0 +1,47 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx;
+
+import com.spotify.styx.docker.DockerRunner;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class Cleaner {
+
+  private static final Logger logger = LoggerFactory.getLogger(Cleaner.class);
+
+  private final WorkflowCache workflowCache;
+  private final DockerRunner dockerRunner;
+
+  Cleaner(WorkflowCache workflowCache, DockerRunner dockerRunner) {
+    this.workflowCache = workflowCache;
+    this.dockerRunner = dockerRunner;
+  }
+
+  void tick() {
+    try {
+      dockerRunner.cleanup(workflowCache.all());
+    } catch (IOException e) {
+      logger.warn("Docker runner cleanup failed", e);
+    }
+  }
+}

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
@@ -79,4 +79,16 @@ public class ServiceAccountKeyManager {
         .execute();
   }
 
+  public void deleteKey(String keyName) throws IOException {
+    try {
+      iam.projects().serviceAccounts().keys()
+          .delete(keyName)
+          .execute();
+    } catch (GoogleJsonResponseException e) {
+      if (e.getStatusCode() == 404) {
+        return;
+      }
+      throw e;
+    }
+  }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -122,6 +122,7 @@ public class StyxScheduler implements AppInit {
 
   public static final int SCHEDULER_TICK_INTERVAL_SECONDS = 2;
   public static final int TRIGGER_MANAGER_TICK_INTERVAL_SECONDS = 1;
+  public static final int CLEANER_TICK_INTERVAL_SECONDS = 30;
   public static final int RUNTIME_CONFIG_UPDATE_INTERVAL_SECONDS = 5;
   public static final Duration DEFAULT_RETRY_BASE_DELAY = Duration.ofMinutes(3);
   public static final int DEFAULT_RETRY_MAX_EXPONENT = 4;
@@ -336,11 +337,14 @@ public class StyxScheduler implements AppInit {
     final Scheduler scheduler = new Scheduler(time, timeoutConfig, stateManager, workflowCache,
         storage, trigger);
 
+    final Cleaner cleaner = new Cleaner(workflowCache, dockerRunner);
+
     restoreState(storage, outputHandlers, stateManager, dockerRunner);
     startTriggerManager(triggerManager, executor);
     startScheduleSources(environment, executor, workflowChangeListener, workflowRemoveListener);
     startScheduler(scheduler, executor);
     startRuntimeConfigUpdate(storage, executor, submissionRateLimiter);
+    startCleaner(cleaner, executor);
     setupMetrics(stateManager, workflowCache, storage, submissionRateLimiter, stats);
 
     final SchedulerResource schedulerResource = new SchedulerResource(stateManager, trigger,
@@ -426,8 +430,16 @@ public class StyxScheduler implements AppInit {
     }
   }
 
-  private static void startTriggerManager(TriggerManager triggerManager, ScheduledExecutorService exec) {
+  private static void startCleaner(Cleaner cleaner, ScheduledExecutorService exec) {
     exec.scheduleAtFixedRate(
+        guard(cleaner::tick),
+        CLEANER_TICK_INTERVAL_SECONDS,
+        CLEANER_TICK_INTERVAL_SECONDS,
+        TimeUnit.SECONDS);
+  }
+
+  private static void startTriggerManager(TriggerManager triggerManager, ScheduledExecutorService exec) {
+    exec.scheduleWithFixedDelay(
         guard(triggerManager::tick),
         TRIGGER_MANAGER_TICK_INTERVAL_SECONDS,
         TRIGGER_MANAGER_TICK_INTERVAL_SECONDS,

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -377,7 +377,7 @@ public class StyxScheduler implements AppInit {
 
   private void warmUpCache(WorkflowCache cache, Storage storage) {
     try {
-      storage.workflowsWithNextNaturalTrigger().keySet().forEach(cache::store);
+      storage.workflows().values().forEach(cache::store);
     } catch (IOException e) {
       LOG.warn("Failed to get workflows from storage", e);
     }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -25,7 +25,6 @@ import static java.util.Optional.empty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.spotify.styx.ServiceAccountKeyManager;
-import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
@@ -35,7 +34,6 @@ import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -66,9 +64,8 @@ public interface DockerRunner extends Closeable {
   /**
    * Perform cleanup for resources such as secrets etc. Resources that are not in use by any currently live workflows
    * should be removed.
-   * @param workflows All currently live workflows.
    */
-  default void cleanup(Set<Workflow> workflows) throws IOException {
+  default void cleanup() throws IOException {
   }
 
   /**

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -25,6 +25,7 @@ import static java.util.Optional.empty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.spotify.styx.ServiceAccountKeyManager;
+import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
@@ -34,6 +35,7 @@ import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -60,6 +62,14 @@ public interface DockerRunner extends Closeable {
    * @return The execution id for the started workflow instance
    */
   String start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException;
+
+  /**
+   * Perform cleanup for resources such as secrets etc. Resources that are not in use by any currently live workflows
+   * should be removed.
+   * @param workflows All currently live workflows.
+   */
+  default void cleanup(Set<Workflow> workflows) throws IOException {
+  }
 
   /**
    * Execute cleanup operations for when an execution finishes.

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -182,8 +182,9 @@ class KubernetesDockerRunner implements DockerRunner {
         final String serviceAcountEmail = serviceAccountEmail(secret);
 
         try {
-          final String jsonKeyName = secret.getMetadata().getAnnotations().get(STYX_WORKFLOW_SA_JSON_KEY_NAME_ANNOTATION);
-          final String p12KeyName = secret.getMetadata().getAnnotations().get(STYX_WORKFLOW_SA_P12_KEY_NAME_ANNOTATION);
+          final Map<String, String> annotations = secret.getMetadata().getAnnotations();
+          final String jsonKeyName = annotations.get(STYX_WORKFLOW_SA_JSON_KEY_NAME_ANNOTATION);
+          final String p12KeyName = annotations.get(STYX_WORKFLOW_SA_P12_KEY_NAME_ANNOTATION);
 
           LOG.info("[AUDIT] Deleting unused service account key: {}", jsonKeyName);
           tryDeleteServiceAccountKey(jsonKeyName);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -194,7 +194,7 @@ class KubernetesDockerRunner implements DockerRunner {
 
           LOG.info("[AUDIT] Deleting unused service account {} secret {}", serviceAcountEmail, name);
           client.secrets().delete(secret);
-        } catch (IOException e) {
+        } catch (IOException | KubernetesClientException e) {
           LOG.warn("[AUDIT] Failed to delete unused service account {} keys and/or secret {}",
               serviceAcountEmail, name);
         }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -359,7 +359,6 @@ public class KubernetesDockerRunnerTest {
     final GoogleJsonResponseException permissionDenied = new GoogleJsonResponseException(
         new Builder(403, "Forbidden", new HttpHeaders()), new GoogleJsonError()
         .set("status", "PERMISSION_DENIED"));
-    assertThat(GcpUtil.isPermissionDenied(permissionDenied), is(true));
     doThrow(permissionDenied).when(serviceAccountKeyManager).deleteKey(jsonKeyName);
     doThrow(permissionDenied).when(serviceAccountKeyManager).deleteKey(p12KeyName);
     kdr.cleanup(ImmutableSet.of());

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/monitoring/MeteredProxyTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/monitoring/MeteredProxyTest.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.monitoring;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -75,7 +76,7 @@ public class MeteredProxyTest {
     DockerRunner mock = mock(DockerRunner.class);
     DockerRunner proxy = MeteredProxy.instrument(DockerRunner.class, mock, stats, time);
 
-    doThrow(new RuntimeException("with message")).when(mock).cleanup(any());
+    doThrow(new RuntimeException("with message")).when(mock).cleanup(anyString());
 
     expect.expect(RuntimeException.class);
     expect.expectMessage("with message");


### PR DESCRIPTION
An alternative to https://github.com/spotify/styx/pull/170. This PR makes styx more aggressively remove keys and secrets that are not in immediate use by any pods. It is assumed that it is fine for workflows to recreate keys and secrets as needed.