### PR TITLE
add cleanup method do routing docker runner

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -65,8 +65,7 @@ public interface DockerRunner extends Closeable {
    * Perform cleanup for resources such as secrets etc. Resources that are not in use by any currently live workflows
    * should be removed.
    */
-  default void cleanup() throws IOException {
-  }
+  void cleanup() throws IOException;
 
   /**
    * Execute cleanup operations for when an execution finishes.

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
@@ -113,6 +113,10 @@ class LocalDockerRunner implements DockerRunner {
   }
 
   @Override
+  public void cleanup() throws IOException {
+  }
+
+  @Override
   public void cleanup(String executionId) {
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
@@ -57,6 +57,11 @@ class RoutingDockerRunner implements DockerRunner {
   }
 
   @Override
+  public void cleanup() throws IOException {
+    runner().cleanup();
+  }
+
+  @Override
   public void cleanup(String executionId) {
     runner().cleanup(executionId);
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -336,6 +336,10 @@ public class StyxSchedulerServiceFixture {
       }
 
       @Override
+      public void cleanup() throws IOException {
+      }
+
+      @Override
       public void cleanup(String executionId) {
         dockerCleans.add(executionId);
       }


### PR DESCRIPTION
Also remove default method, force all DockerRunner implementations to implement `cleanup()`.