### PR TITLE
pod garbage collection

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/Debug.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/Debug.java
@@ -1,0 +1,27 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.util;
+
+import java.time.Instant;
+import java.util.function.Supplier;
+
+public interface Debug extends Supplier<Boolean> {
+}

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -70,9 +70,10 @@ public interface DockerRunner extends Closeable {
 
   /**
    * Execute cleanup operations for when an execution finishes.
+   * @param workflowInstance The workflow instance for which cleanup is called
    * @param executionId The execution id for which the cleanup code is called
    */
-  void cleanup(String executionId);
+  void cleanup(WorkflowInstance workflowInstance, String executionId);
 
   @AutoValue
   abstract class RunSpec {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -30,6 +30,7 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.Trigger;
+import com.spotify.styx.util.Debug;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import java.io.Closeable;
 import java.io.IOException;
@@ -115,11 +116,11 @@ public interface DockerRunner extends Closeable {
   }
 
   static DockerRunner kubernetes(NamespacedKubernetesClient kubernetesClient, StateManager stateManager,
-      Stats stats, ServiceAccountKeyManager serviceAccountKeyManager) {
+      Stats stats, ServiceAccountKeyManager serviceAccountKeyManager, Debug debug) {
     final KubernetesGCPServiceAccountSecretManager serviceAccountSecretManager =
         new KubernetesGCPServiceAccountSecretManager(kubernetesClient, serviceAccountKeyManager);
     final KubernetesDockerRunner dockerRunner =
-        new KubernetesDockerRunner(kubernetesClient, stateManager, stats, serviceAccountSecretManager);
+        new KubernetesDockerRunner(kubernetesClient, stateManager, stats, serviceAccountSecretManager, debug);
 
     dockerRunner.init();
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -368,7 +368,7 @@ class KubernetesDockerRunner implements DockerRunner {
     for (Pod pod : list.getItems()) {
       // Emit events
       logEvent(Watcher.Action.MODIFIED, pod, resourceVersion, true);
-      final Optional<WorkflowInstance> workflowInstance = lookupPodWorkflowInstance(pod);
+      final Optional<WorkflowInstance> workflowInstance = readPodWorkflowInstance(pod);
       if (!workflowInstance.isPresent()) {
         continue;
       }
@@ -382,7 +382,7 @@ class KubernetesDockerRunner implements DockerRunner {
     }
   }
 
-  private Optional<WorkflowInstance> lookupPodWorkflowInstance(Pod pod) {
+  private Optional<WorkflowInstance> readPodWorkflowInstance(Pod pod) {
     final Map<String, String> annotations = pod.getMetadata().getAnnotations();
     final String podName = pod.getMetadata().getName();
     if (!annotations.containsKey(KubernetesDockerRunner.STYX_WORKFLOW_INSTANCE_ANNOTATION)) {
@@ -476,7 +476,7 @@ class KubernetesDockerRunner implements DockerRunner {
       logEvent(action, pod, lastResourceVersion, false);
 
       try {
-        lookupPodWorkflowInstance(pod)
+        readPodWorkflowInstance(pod)
             .flatMap(workflowInstance -> lookupPodRunState(pod, workflowInstance))
             .ifPresent(runState -> emitPodEvents(action, pod, runState));
       } finally {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -300,10 +300,10 @@ class KubernetesDockerRunner implements DockerRunner {
         workflowInstance -> {
           if (!debug.get()) {
             LOG.info("Cleaning up {} pod: {}", workflowInstance.toKey(), name);
+            client.pods().delete(pod);
           } else {
             LOG.info("Keeping {} pod: {}", workflowInstance.toKey(), name);
           }
-          client.pods().delete(pod);
         }
     );
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -365,7 +365,6 @@ class KubernetesDockerRunner implements DockerRunner {
     final int resourceVersion = Integer.parseInt(list.getMetadata().getResourceVersion());
 
     for (Pod pod : list.getItems()) {
-      // Emit events
       logEvent(Watcher.Action.MODIFIED, pod, resourceVersion, true);
       final Optional<WorkflowInstance> workflowInstance = readPodWorkflowInstance(pod);
       if (!workflowInstance.isPresent()) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -375,7 +375,7 @@ class KubernetesDockerRunner implements DockerRunner {
       final Optional<RunState> runState = lookupPodRunState(pod, workflowInstance.get());
       if (runState.isPresent()) {
         emitPodEvents(Action.MODIFIED, pod, runState.get());
-      } else      {
+      } else {
         LOG.info("Deleting unwanted pod {}", pod.getMetadata().getName());
         client.pods().delete(pod);
       }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -64,7 +64,6 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.Watcher.Action;
 import io.norberg.automatter.AutoMatter;
 import java.io.IOException;
 import java.net.ProtocolException;
@@ -374,7 +373,7 @@ class KubernetesDockerRunner implements DockerRunner {
       }
       final Optional<RunState> runState = lookupPodRunState(pod, workflowInstance.get());
       if (runState.isPresent()) {
-        emitPodEvents(Action.MODIFIED, pod, runState.get());
+        emitPodEvents(Watcher.Action.MODIFIED, pod, runState.get());
       } else {
         LOG.info("Deleting unwanted pod {}", pod.getMetadata().getName());
         client.pods().delete(pod);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -64,7 +64,6 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.Watcher.Action;
 import io.norberg.automatter.AutoMatter;
 import java.io.IOException;
 import java.net.ProtocolException;
@@ -378,7 +377,7 @@ class KubernetesDockerRunner implements DockerRunner {
     }
   }
 
-  private boolean inspectPod(Action action, Pod pod) {
+  private boolean inspectPod(Watcher.Action action, Pod pod) {
     final Map<String, String> annotations = pod.getMetadata().getAnnotations();
     final String podName = pod.getMetadata().getName();
     if (!annotations.containsKey(KubernetesDockerRunner.STYX_WORKFLOW_INSTANCE_ANNOTATION)) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
@@ -117,7 +117,7 @@ class LocalDockerRunner implements DockerRunner {
   }
 
   @Override
-  public void cleanup(String executionId) {
+  public void cleanup(WorkflowInstance workflowInstance, String executionId) {
   }
 
   private void checkStatuses() {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
@@ -62,8 +62,8 @@ class RoutingDockerRunner implements DockerRunner {
   }
 
   @Override
-  public void cleanup(String executionId) {
-    runner().cleanup(executionId);
+  public void cleanup(WorkflowInstance workflowInstance, String executionId) {
+    runner().cleanup(workflowInstance, executionId);
   }
 
   @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -32,6 +32,7 @@ import com.spotify.styx.state.OutputHandler;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.storage.Storage;
+import com.spotify.styx.util.Debug;
 import com.spotify.styx.util.ResourceNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -51,19 +52,16 @@ public class DockerRunnerHandler implements OutputHandler {
 
   private final DockerRunner dockerRunner;
   private final StateManager stateManager;
-  private final Storage storage;
   private final RateLimiter rateLimiter;
   private final ExecutorService executor;
 
   public DockerRunnerHandler(
       DockerRunner dockerRunner,
       StateManager stateManager,
-      Storage storage,
       RateLimiter rateLimiter,
       ExecutorService executor) {
     this.dockerRunner = requireNonNull(dockerRunner);
     this.stateManager = requireNonNull(stateManager);
-    this.storage = requireNonNull(storage);
     this.rateLimiter = requireNonNull(rateLimiter, "rateLimiter");
     this.executor = requireNonNull(executor, "executor");
   }
@@ -103,20 +101,7 @@ public class DockerRunnerHandler implements OutputHandler {
       case ERROR:
         if (state.data().executionId().isPresent()) {
           final String executionId = state.data().executionId().get();
-
-          boolean debugEnabled = false;
-          try {
-            debugEnabled = storage.debugEnabled();
-          } catch (IOException e) {
-            LOG.info("Couldn't fetch debug flag. Will clean up pod anyway.");
-          }
-
-          if (!debugEnabled) {
-            LOG.info("Cleaning up {} pod: {}", state.workflowInstance().toKey(), executionId);
-            dockerRunner.cleanup(executionId);
-          } else {
-            LOG.info("Keeping {} pod: {}", state.workflowInstance().toKey(), executionId);
-          }
+          dockerRunner.cleanup(executionId);
         }
         break;
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -31,8 +31,6 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.OutputHandler;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
-import com.spotify.styx.storage.Storage;
-import com.spotify.styx.util.Debug;
 import com.spotify.styx.util.ResourceNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -101,7 +99,7 @@ public class DockerRunnerHandler implements OutputHandler {
       case ERROR:
         if (state.data().executionId().isPresent()) {
           final String executionId = state.data().executionId().get();
-          dockerRunner.cleanup(executionId);
+          dockerRunner.cleanup(state.workflowInstance(), executionId);
         }
         break;
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -340,7 +340,7 @@ public class StyxSchedulerServiceFixture {
       }
 
       @Override
-      public void cleanup(String executionId) {
+      public void cleanup(WorkflowInstance workflowInstance, String executionId) {
         dockerCleans.add(executionId);
       }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -128,7 +128,7 @@ public class StyxSchedulerServiceFixture {
     StyxScheduler.ExecutorFactory executorFactory = (ts, tf) -> executor;
     StyxScheduler.PublisherFactory publisherFactory = (env) -> Publisher.NOOP;
     StyxScheduler.DockerRunnerFactory dockerRunnerFactory =
-        (id, env, states, exec, stats) -> fakeDockerRunner();
+        (id, env, states, exec, stats, debug) -> fakeDockerRunner();
 
     styxScheduler = StyxScheduler.newBuilder()
         .setTime(time)

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -164,6 +164,23 @@ public class KubernetesDockerRunnerPodPollerTest {
   }
 
   @Test
+  public void shouldNotDeleteUnwantedStyxPodsIfDebugEnabled() throws Exception {
+    when(debug.get()).thenReturn(true);
+
+    Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
+    Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    podList.setItems(Arrays.asList(createdPod1, createdPod2));
+    when(k8sClient.pods().list()).thenReturn(podList);
+
+    kdr.pollPods();
+
+    verify(k8sClient.pods(), never()).delete(any(Pod.class));
+    verify(k8sClient.pods(), never()).delete(any(Pod[].class));
+    verify(k8sClient.pods(), never()).delete(anyListOf(Pod.class));
+    verify(k8sClient.pods(), never()).delete();
+  }
+
+  @Test
   public void shouldNotDeleteUnwantedNonStyxPods() throws Exception {
     Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
     Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -163,8 +163,8 @@ public class KubernetesDockerRunnerPodPollerTest {
   public void shouldNotDeleteUnwantedNonStyxPods() throws Exception {
     Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
     Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
-    createdPod1.getMetadata().setName("test-1");
-    createdPod2.getMetadata().setName("test-2");
+    createdPod1.getMetadata().getAnnotations().remove("styx-workflow-instance");
+    createdPod2.getMetadata().getAnnotations().remove("styx-workflow-instance");
     podList.setItems(Arrays.asList(createdPod1, createdPod2));
     when(k8sClient.pods().list()).thenReturn(podList);
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -35,6 +35,7 @@ import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.testdata.TestData;
+import com.spotify.styx.util.Debug;
 import io.fabric8.kubernetes.api.model.DoneablePod;
 import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -77,15 +78,18 @@ public class KubernetesDockerRunnerPodPollerTest {
   Stats stats;
 
   @Mock KubernetesGCPServiceAccountSecretManager serviceAccountSecretManager;
+  @Mock Debug debug;
 
   KubernetesDockerRunner kdr;
 
   @Before
   public void setUp() throws Exception {
+    when(debug.get()).thenReturn(false);
+
     when(k8sClient.inNamespace(any(String.class))).thenReturn(k8sClient);
     when(k8sClient.pods()).thenReturn(pods);
 
-    kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager);
+    kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager, debug);
     podList = new PodList();
     podList.setMetadata(new ListMeta());
     podList.getMetadata().setResourceVersion("4711");

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -71,6 +71,8 @@ public class KubernetesDockerRunnerPodPollerTest {
   @Mock
   MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> pods;
   PodList podList;
+  @Mock PodResource<Pod, DoneablePod> namedPod1;
+  @Mock PodResource<Pod, DoneablePod> namedPod2;
 
   @Mock
   StateManager stateManager;
@@ -152,25 +154,35 @@ public class KubernetesDockerRunnerPodPollerTest {
 
   @Test
   public void shouldDeleteUnwantedStyxPods() throws Exception {
-    Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
-    Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
+    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    final String podName1 = createdPod1.getMetadata().getName();
+    final String podName2 = createdPod2.getMetadata().getName();
+
     podList.setItems(Arrays.asList(createdPod1, createdPod2));
     when(k8sClient.pods().list()).thenReturn(podList);
+    when(k8sClient.pods().withName(podName1)).thenReturn(namedPod1);
+    when(k8sClient.pods().withName(podName2)).thenReturn(namedPod2);
 
     kdr.pollPods();
 
-    verify(k8sClient.pods()).delete(createdPod1);
-    verify(k8sClient.pods()).delete(createdPod2);
+    verify(namedPod1).delete();
+    verify(namedPod2).delete();
   }
 
   @Test
   public void shouldNotDeleteUnwantedStyxPodsIfDebugEnabled() throws Exception {
     when(debug.get()).thenReturn(true);
 
-    Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
-    Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
+    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    final String podName1 = createdPod1.getMetadata().getName();
+    final String podName2 = createdPod2.getMetadata().getName();
+
     podList.setItems(Arrays.asList(createdPod1, createdPod2));
     when(k8sClient.pods().list()).thenReturn(podList);
+    when(k8sClient.pods().withName(podName1)).thenReturn(namedPod1);
+    when(k8sClient.pods().withName(podName2)).thenReturn(namedPod2);
 
     kdr.pollPods();
 
@@ -178,16 +190,24 @@ public class KubernetesDockerRunnerPodPollerTest {
     verify(k8sClient.pods(), never()).delete(any(Pod[].class));
     verify(k8sClient.pods(), never()).delete(anyListOf(Pod.class));
     verify(k8sClient.pods(), never()).delete();
+    verify(namedPod1, never()).delete();
+    verify(namedPod2, never()).delete();
   }
 
   @Test
   public void shouldNotDeleteUnwantedNonStyxPods() throws Exception {
-    Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
-    Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
+    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    final String podName1 = createdPod1.getMetadata().getName();
+    final String podName2 = createdPod2.getMetadata().getName();
+
     createdPod1.getMetadata().getAnnotations().remove("styx-workflow-instance");
     createdPod2.getMetadata().getAnnotations().remove("styx-workflow-instance");
+
     podList.setItems(Arrays.asList(createdPod1, createdPod2));
     when(k8sClient.pods().list()).thenReturn(podList);
+    when(k8sClient.pods().withName(podName1)).thenReturn(namedPod1);
+    when(k8sClient.pods().withName(podName2)).thenReturn(namedPod2);
 
     kdr.pollPods();
 
@@ -195,16 +215,22 @@ public class KubernetesDockerRunnerPodPollerTest {
     verify(k8sClient.pods(), never()).delete(any(Pod[].class));
     verify(k8sClient.pods(), never()).delete(anyListOf(Pod.class));
     verify(k8sClient.pods(), never()).delete();
+    verify(namedPod1, never()).delete();
+    verify(namedPod2, never()).delete();
   }
 
   @Test
   public void shouldNotDeleteWantedStyxPods() throws Exception {
-    Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
-    Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
+    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    final String podName1 = createdPod1.getMetadata().getName();
+    final String podName2 = createdPod2.getMetadata().getName();
+
     podList.setItems(Arrays.asList(createdPod1, createdPod2));
     when(k8sClient.pods().list()).thenReturn(podList);
-    String podName1 = createdPod1.getMetadata().getName();
-    String podName2 = createdPod2.getMetadata().getName();
+    when(k8sClient.pods().withName(podName1)).thenReturn(namedPod1);
+    when(k8sClient.pods().withName(podName2)).thenReturn(namedPod2);
+
     setupActiveInstances(RunState.State.RUNNING, podName1, podName2);
 
     kdr.pollPods();

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -160,6 +160,23 @@ public class KubernetesDockerRunnerPodPollerTest {
   }
 
   @Test
+  public void shouldNotDeleteUnwantedNonStyxPods() throws Exception {
+    Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
+    Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    createdPod1.getMetadata().setName("test-1");
+    createdPod2.getMetadata().setName("test-2");
+    podList.setItems(Arrays.asList(createdPod1, createdPod2));
+    when(k8sClient.pods().list()).thenReturn(podList);
+
+    kdr.pollPods();
+
+    verify(k8sClient.pods(), never()).delete(any(Pod.class));
+    verify(k8sClient.pods(), never()).delete(any(Pod[].class));
+    verify(k8sClient.pods(), never()).delete(anyListOf(Pod.class));
+    verify(k8sClient.pods(), never()).delete();
+  }
+
+  @Test
   public void shouldNotDeleteWantedStyxPods() throws Exception {
     Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
     Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -21,12 +21,12 @@
 package com.spotify.styx.docker;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.spotify.styx.ServiceAccountKeyManager;
 import com.spotify.styx.docker.KubernetesDockerRunner.KubernetesSecretSpec;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.WorkflowInstance;
@@ -36,6 +36,7 @@ import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.testdata.TestData;
 import io.fabric8.kubernetes.api.model.DoneablePod;
+import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
@@ -55,6 +56,7 @@ public class KubernetesDockerRunnerPodPollerTest {
 
   private static final String POD_NAME = "test-pod-1";
   private static final String POD_NAME_2 = "test-pod-2";
+
   private static final WorkflowInstance WORKFLOW_INSTANCE =
       WorkflowInstance.create(TestData.WORKFLOW_ID, "foo");
   private static final WorkflowInstance WORKFLOW_INSTANCE_2 =
@@ -85,6 +87,8 @@ public class KubernetesDockerRunnerPodPollerTest {
 
     kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager);
     podList = new PodList();
+    podList.setMetadata(new ListMeta());
+    podList.getMetadata().setResourceVersion("4711");
   }
 
   @Test
@@ -92,7 +96,7 @@ public class KubernetesDockerRunnerPodPollerTest {
     Pod createdPod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
     podList.setItems(Arrays.asList(createdPod));
     when(k8sClient.pods().list()).thenReturn(podList);
-    setupActiveInstances(RunState.State.RUNNING);
+    setupActiveInstances(RunState.State.RUNNING, POD_NAME, POD_NAME_2);
 
     kdr.pollPods();
 
@@ -106,7 +110,7 @@ public class KubernetesDockerRunnerPodPollerTest {
     Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
     podList.setItems(Arrays.asList(createdPod, createdPod2));
     when(k8sClient.pods().list()).thenReturn(podList);
-    setupActiveInstances(RunState.State.RUNNING);
+    setupActiveInstances(RunState.State.RUNNING, POD_NAME, POD_NAME_2);
 
     kdr.pollPods();
 
@@ -119,7 +123,7 @@ public class KubernetesDockerRunnerPodPollerTest {
   @Test
   public void shouldHandleEmptyPodList() throws Exception {
     when(k8sClient.pods().list()).thenReturn(podList);
-    setupActiveInstances(RunState.State.RUNNING);
+    setupActiveInstances(RunState.State.RUNNING, POD_NAME, POD_NAME_2);
 
     kdr.pollPods();
 
@@ -132,7 +136,7 @@ public class KubernetesDockerRunnerPodPollerTest {
   @Test
   public void shouldNotSendErrorEventForInstancesNotInRunningState() throws Exception {
     when(k8sClient.pods().list()).thenReturn(podList);
-    setupActiveInstances(RunState.State.SUBMITTED);
+    setupActiveInstances(RunState.State.SUBMITTED, POD_NAME, POD_NAME_2);
 
     kdr.pollPods();
 
@@ -142,15 +146,47 @@ public class KubernetesDockerRunnerPodPollerTest {
         Event.runError(WORKFLOW_INSTANCE_2, "No pod associated with this instance"));
   }
 
-  private void setupActiveInstances(RunState.State state) {
-    StateData stateData = StateData.newBuilder().executionId(POD_NAME).build();
-    StateData stateData2 = StateData.newBuilder().executionId(POD_NAME_2).build();
-    Map<WorkflowInstance, RunState> map = new HashMap<>();
-    map.put(WORKFLOW_INSTANCE,
-        RunState.create(WORKFLOW_INSTANCE, state, stateData));
-    map.put(WORKFLOW_INSTANCE_2,
-        RunState.create(WORKFLOW_INSTANCE_2, state, stateData2));
+  @Test
+  public void shouldDeleteUnwantedStyxPods() throws Exception {
+    Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
+    Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    podList.setItems(Arrays.asList(createdPod1, createdPod2));
+    when(k8sClient.pods().list()).thenReturn(podList);
 
+    kdr.pollPods();
+
+    verify(k8sClient.pods()).delete(createdPod1);
+    verify(k8sClient.pods()).delete(createdPod2);
+  }
+
+  @Test
+  public void shouldNotDeleteWantedStyxPods() throws Exception {
+    Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
+    Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    podList.setItems(Arrays.asList(createdPod1, createdPod2));
+    when(k8sClient.pods().list()).thenReturn(podList);
+    String podName1 = createdPod1.getMetadata().getName();
+    String podName2 = createdPod2.getMetadata().getName();
+    setupActiveInstances(RunState.State.RUNNING, podName1, podName2);
+
+    kdr.pollPods();
+
+    verify(k8sClient.pods(), never()).delete(any(Pod.class));
+    verify(k8sClient.pods(), never()).delete(any(Pod[].class));
+    verify(k8sClient.pods(), never()).delete(anyListOf(Pod.class));
+    verify(k8sClient.pods(), never()).delete();
+  }
+
+  private void setupActiveInstances(RunState.State state, String podName1, String podName2) {
+    StateData stateData = StateData.newBuilder().executionId(podName1).build();
+    StateData stateData2 = StateData.newBuilder().executionId(podName2).build();
+    Map<WorkflowInstance, RunState> map = new HashMap<>();
+    RunState runState = RunState.create(WORKFLOW_INSTANCE, state, stateData);
+    RunState runState2 = RunState.create(WORKFLOW_INSTANCE_2, state, stateData2);
+    map.put(WORKFLOW_INSTANCE, runState);
+    map.put(WORKFLOW_INSTANCE_2, runState2);
+    when(stateManager.get(WORKFLOW_INSTANCE)).thenReturn(runState);
+    when(stateManager.get(WORKFLOW_INSTANCE_2)).thenReturn(runState2);
     when(stateManager.activeStates()).thenReturn(map);
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -25,7 +25,6 @@ import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.podStatus
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.running;
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.terminated;
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.waiting;
-import static java.lang.Integer.MAX_VALUE;
 import static java.util.Optional.empty;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
@@ -203,8 +202,8 @@ public class KubernetesDockerRunnerTest {
     final String name = createdPod.getMetadata().getName();
     when(k8sClient.pods().withName(name)).thenReturn(namedPod);
     when(namedPod.get()).thenReturn(createdPod);
-    kdr.cleanup(name);
-    verify(k8sClient.pods()).delete(createdPod);
+    kdr.cleanup(WORKFLOW_INSTANCE, name);
+    verify(namedPod).delete();
   }
 
   @Test
@@ -213,11 +212,12 @@ public class KubernetesDockerRunnerTest {
     final String name = createdPod.getMetadata().getName();
     when(k8sClient.pods().withName(name)).thenReturn(namedPod);
     when(namedPod.get()).thenReturn(createdPod);
-    kdr.cleanup(name);
+    kdr.cleanup(WORKFLOW_INSTANCE, name);
     verify(k8sClient.pods(), never()).delete(any(Pod.class));
     verify(k8sClient.pods(), never()).delete(any(Pod[].class));
     verify(k8sClient.pods(), never()).delete(anyListOf(Pod.class));
     verify(k8sClient.pods(), never()).delete();
+    verify(namedPod, never()).delete();
   }
 
   @Test(expected = InvalidExecutionException.class)

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -50,6 +50,7 @@ import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.SyncStateManager;
 import com.spotify.styx.testdata.TestData;
+import com.spotify.styx.util.Debug;
 import io.fabric8.kubernetes.api.model.DoneablePod;
 import io.fabric8.kubernetes.api.model.DoneableSecret;
 import io.fabric8.kubernetes.api.model.ListMeta;
@@ -136,6 +137,8 @@ public class KubernetesDockerRunnerTest {
   @Mock ListMeta listMeta;
   @Mock Watchable<Watch, Watcher<Pod>> podWatchable;
   @Mock Watch watch;
+  @Mock Debug debug;
+
   @Captor ArgumentCaptor<Watcher<Pod>> watchCaptor;
   @Captor ArgumentCaptor<Pod> podCaptor;
 
@@ -150,6 +153,8 @@ public class KubernetesDockerRunnerTest {
 
   @Before
   public void setUp() throws Exception {
+    when(debug.get()).thenReturn(false);
+
     when(k8sClient.inNamespace(any(String.class))).thenReturn(k8sClient);
     when(k8sClient.pods()).thenReturn(pods);
 
@@ -166,7 +171,7 @@ public class KubernetesDockerRunnerTest {
         WORKFLOW_INSTANCE.workflowId().toString(), SERVICE_ACCOUNT))
         .thenReturn(SERVICE_ACCOUNT_SECRET);
 
-    kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager, 60);
+    kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager, debug, 60);
     kdr.init();
     kdr.restore();
 
@@ -423,7 +428,7 @@ public class KubernetesDockerRunnerTest {
     createdPod.setStatus(terminated("Succeeded", 20, null));
 
     // Start a new runner
-    kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager);
+    kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager, debug);
     kdr.init();
 
     // Make the runner poll states for all pods
@@ -440,7 +445,7 @@ public class KubernetesDockerRunnerTest {
 
     // Set up a runner with short poll interval to avoid this test having to wait a long time for the poll
     kdr.close();
-    kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager, 1);
+    kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager, debug, 1);
     kdr.init();
     kdr.restore();
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/RoutingDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/RoutingDockerRunnerTest.java
@@ -70,10 +70,10 @@ public class RoutingDockerRunnerTest {
   @Test
   public void testUsesDefaultRunnerOnWorkflowCleanup() throws Exception {
     when(dockerId.get()).thenReturn("default");
-    dockerRunner.cleanup(MOCK_EXEC_ID);
+    dockerRunner.cleanup(WORKFLOW_INSTANCE, MOCK_EXEC_ID);
 
     assertThat(createdRunners, hasKey("default"));
-    verify(createdRunners.get("default")).cleanup(MOCK_EXEC_ID);
+    verify(createdRunners.get("default")).cleanup(WORKFLOW_INSTANCE, MOCK_EXEC_ID);
   }
 
   @Test
@@ -99,8 +99,8 @@ public class RoutingDockerRunnerTest {
     when(dockerId.get()).thenReturn("default");
     dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC);
     dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC);
-    dockerRunner.cleanup(MOCK_EXEC_ID);
-    dockerRunner.cleanup(MOCK_EXEC_ID);
+    dockerRunner.cleanup(WORKFLOW_INSTANCE, MOCK_EXEC_ID);
+    dockerRunner.cleanup(WORKFLOW_INSTANCE, MOCK_EXEC_ID);
 
     assertThat(createCounter, is(1));
     assertThat(createdRunners.keySet(), hasSize(1));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/monitoring/MeteredProxyTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/monitoring/MeteredProxyTest.java
@@ -83,7 +83,7 @@ public class MeteredProxyTest {
     DockerRunner mock = mock(DockerRunner.class);
     DockerRunner proxy = MeteredProxy.instrument(DockerRunner.class, mock, stats, time);
 
-    doThrow(new RuntimeException("with message")).when(mock).cleanup(workflowInstance, anyString());
+    doThrow(new RuntimeException("with message")).when(mock).cleanup(any(WorkflowInstance.class), anyString());
 
     expect.expect(RuntimeException.class);
     expect.expectMessage("with message");

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/monitoring/MeteredProxyTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/monitoring/MeteredProxyTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.spotify.styx.docker.DockerRunner;
+import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.Time;
 import java.time.Instant;
@@ -35,11 +36,17 @@ import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class MeteredProxyTest {
 
   @Rule
   public ExpectedException expect = ExpectedException.none();
+
+  @Mock WorkflowInstance workflowInstance;
 
   Instant now = Instant.now();
   Instant later = now.plusMillis(123);
@@ -65,9 +72,9 @@ public class MeteredProxyTest {
     DockerRunner mock = mock(DockerRunner.class);
     DockerRunner proxy = MeteredProxy.instrument(DockerRunner.class, mock, stats, time);
 
-    proxy.cleanup("barbaz");
+    proxy.cleanup(workflowInstance, "barbaz");
 
-    verify(mock).cleanup("barbaz");
+    verify(mock).cleanup(workflowInstance, "barbaz");
     verify(stats).dockerOperation("cleanup", 123);
   }
 
@@ -76,11 +83,11 @@ public class MeteredProxyTest {
     DockerRunner mock = mock(DockerRunner.class);
     DockerRunner proxy = MeteredProxy.instrument(DockerRunner.class, mock, stats, time);
 
-    doThrow(new RuntimeException("with message")).when(mock).cleanup(anyString());
+    doThrow(new RuntimeException("with message")).when(mock).cleanup(workflowInstance, anyString());
 
     expect.expect(RuntimeException.class);
     expect.expectMessage("with message");
 
-    proxy.cleanup("foo");
+    proxy.cleanup(workflowInstance, "foo");
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
@@ -51,6 +51,7 @@ import com.spotify.styx.state.SyncStateManager;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.testdata.TestData;
+import com.spotify.styx.util.Debug;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
@@ -68,14 +69,13 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class DockerRunnerHandlerTest {
 
-  private Storage storage = Mockito.mock(Storage.class);
   private RateLimiter rateLimiter = Mockito.mock(RateLimiter.class);
   private ExecutorService executor = Executors.newCachedThreadPool();
 
   private StateManager stateManager = Mockito.spy(new SyncStateManager());
   private DockerRunner dockerRunner = Mockito.mock(DockerRunner.class);
   private DockerRunnerHandler dockerRunnerHandler = new DockerRunnerHandler(
-      dockerRunner, stateManager, storage, rateLimiter, executor);
+      dockerRunner, stateManager, rateLimiter, executor);
 
   private static final String TEST_EXECUTION_ID = "execution_1";
   private static final String TEST_DOCKER_IMAGE = "busybox:1.1";

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
@@ -49,12 +49,9 @@ import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.SyncStateManager;
 import com.spotify.styx.state.Trigger;
-import com.spotify.styx.storage.Storage;
 import com.spotify.styx.testdata.TestData;
-import com.spotify.styx.util.Debug;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
@@ -223,7 +220,7 @@ public class DockerRunnerHandlerTest {
     stateManager.initialize(runState);
     dockerRunnerHandler.transitionInto(runState);
 
-    verify(dockerRunner, timeout(60_000)).cleanup(TEST_EXECUTION_ID);
+    verify(dockerRunner, timeout(60_000)).cleanup(workflowInstance, TEST_EXECUTION_ID);
   }
 
   @Test
@@ -239,7 +236,7 @@ public class DockerRunnerHandlerTest {
     stateManager.receive(Event.submit(workflowInstance, EXECUTION_DESCRIPTION));
     verify(stateManager, timeout(60_000)).receive(Event.submitted(workflowInstance, TEST_EXECUTION_ID));
     stateManager.receive(Event.runError(workflowInstance, ""));
-    verify(dockerRunner).cleanup(TEST_EXECUTION_ID);
+    verify(dockerRunner).cleanup(workflowInstance, TEST_EXECUTION_ID);
   }
 
   private WorkflowConfiguration configuration(String... args) {


### PR DESCRIPTION
When kube submissions time out (e.g. due to styx restart), the pod created by the submission will never be cleaned up.

This PR implements pod garbage collection by removing unwanted pods when polling.