### PR TITLE
remove secrets used by terminated pods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,12 @@
         <version>2.0.0</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>pl.pragmatists</groupId>
+        <artifactId>JUnitParams</artifactId>
+        <version>1.1.0</version>
+        <scope>test</scope>
+      </dependency>
 
       <!-- version resolution -->
       <dependency>

--- a/styx-scheduler-service/pom.xml
+++ b/styx-scheduler-service/pom.xml
@@ -118,5 +118,10 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Orphaned styx pods (e.g. due to https://github.com/spotify/styx/pull/185) currently causes SA secrets and keys from being removed when rotated.

Mitigate that by excluding terminated pods when enumerating actively used secrets.