### PR TITLE
allow decoration of workflow resources

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -156,7 +156,7 @@ public class Scheduler {
 
       final Set<String> instanceResourceRefs = workflowCache.workflow(instance.workflowInstance().workflowId())
           .map(workflow -> resourceDecorator.decorateResources(
-              instance.workflowInstance(), workflow.configuration(), workflowResourceRefs))
+              instance.runState(), workflow.configuration(), workflowResourceRefs))
           .orElse(workflowResourceRefs);
 
       if (instanceResourceRefs.isEmpty()) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -85,14 +85,17 @@ public class Scheduler {
   private final StateManager stateManager;
   private final WorkflowCache workflowCache;
   private final Storage storage;
+  private final WorkflowResourceDecorator resourceDecorator;
 
   public Scheduler(Time time, TimeoutConfig ttls, StateManager stateManager,
-                   WorkflowCache workflowCache, Storage storage) {
+      WorkflowCache workflowCache, Storage storage,
+      WorkflowResourceDecorator resourceDecorator) {
     this.time = Objects.requireNonNull(time);
     this.ttls = Objects.requireNonNull(ttls);
     this.stateManager = Objects.requireNonNull(stateManager);
     this.workflowCache = Objects.requireNonNull(workflowCache);
     this.storage = Objects.requireNonNull(storage);
+    this.resourceDecorator = Objects.requireNonNull(resourceDecorator);
   }
 
   void tick() {
@@ -148,14 +151,18 @@ public class Scheduler {
     Collections.shuffle(eligibleInstances);
 
     final Consumer<InstanceState> limitAndDequeue = (instance) -> {
-      final Set<String> resourceRefs =
-          workflowResourceReferences.getOrDefault(instance.workflowInstance().workflowId(),
-              emptySet());
+      final Set<String> workflowResourceRefs =
+          workflowResourceReferences.getOrDefault(instance.workflowInstance().workflowId(), emptySet());
 
-      if (resourceRefs.isEmpty()) {
+      final Set<String> instanceResourceRefs = workflowCache.workflow(instance.workflowInstance().workflowId())
+          .map(workflow -> resourceDecorator.decorateResources(
+              instance.workflowInstance(), workflow.configuration(), workflowResourceRefs))
+          .orElse(workflowResourceRefs);
+
+      if (instanceResourceRefs.isEmpty()) {
         sendDequeue(instance);
       } else {
-        evaluateResourcesForDequeue(resources, currentResourceUsage, instance, resourceRefs);
+        evaluateResourcesForDequeue(resources, currentResourceUsage, instance, instanceResourceRefs);
       }
     };
 
@@ -218,8 +225,8 @@ public class Scheduler {
 
     globalConcurrency.ifPresent(concurrency -> builder.add(GLOBAL_RESOURCE_ID));
 
-    workflowCache.workflow(workflowId)
-        .ifPresent(workflow -> builder.addAll(workflow.configuration().resources()));
+    workflowCache.workflow(workflowId).ifPresent(workflow ->
+        builder.addAll(workflow.configuration().resources()));
 
     return builder.build();
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/WorkflowResourceDecorator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/WorkflowResourceDecorator.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/WorkflowResourceDecorator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/WorkflowResourceDecorator.java
@@ -1,0 +1,35 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx;
+
+import com.spotify.styx.model.WorkflowConfiguration;
+import com.spotify.styx.model.WorkflowInstance;
+import java.util.Set;
+
+public interface WorkflowResourceDecorator {
+
+  WorkflowResourceDecorator NOOP = (wfi, cfg, res) -> res;
+
+  Set<String> decorateResources(
+      WorkflowInstance workflowInstance,
+      WorkflowConfiguration workflowConfiguration,
+      Set<String> workflowResources);
+}

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/WorkflowResourceDecorator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/WorkflowResourceDecorator.java
@@ -21,15 +21,14 @@
 package com.spotify.styx;
 
 import com.spotify.styx.model.WorkflowConfiguration;
-import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.state.RunState;
 import java.util.Set;
 
 public interface WorkflowResourceDecorator {
 
-  WorkflowResourceDecorator NOOP = (wfi, cfg, res) -> res;
+  WorkflowResourceDecorator NOOP = (rs, cfg, res) -> res;
 
   Set<String> decorateResources(
-      WorkflowInstance workflowInstance,
-      WorkflowConfiguration workflowConfiguration,
+      RunState runState, WorkflowConfiguration workflowConfiguration,
       Set<String> workflowResources);
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anySetOf;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -104,7 +105,7 @@ public class SchedulerTest {
     when(storage.globalConcurrency()).thenReturn(Optional.empty());
 
     when(resourceDecorator.decorateResources(
-        any(WorkflowInstance.class), any(WorkflowConfiguration.class), anySetOf(String.class)))
+        any(RunState.class), any(WorkflowConfiguration.class), anySetOf(String.class)))
         .thenAnswer(a -> a.getArgumentAt(2, Set.class));
 
     stateManager = Mockito.spy(new SyncStateManager());
@@ -429,7 +430,7 @@ public class SchedulerTest {
 
     Workflow workflow = workflowUsingResources(WORKFLOW_ID1, "foo", "bar");
     when(resourceDecorator.decorateResources(
-        any(WorkflowInstance.class), any(WorkflowConfiguration.class), anySetOf(String.class)))
+        any(RunState.class), any(WorkflowConfiguration.class), anySetOf(String.class)))
         .thenReturn(ImmutableSet.of("baz", "quux", "GLOBAL_STYX_CLUSTER"));
 
     when(storage.globalConcurrency()).thenReturn(Optional.of(17L));
@@ -441,8 +442,8 @@ public class SchedulerTest {
 
     scheduler.tick();
 
-    verify(resourceDecorator).decorateResources(INSTANCE, workflow.configuration(), ImmutableSet.of(
-        "foo", "bar", "GLOBAL_STYX_CLUSTER"));
+    verify(resourceDecorator).decorateResources(any(RunState.class), eq(workflow.configuration()),
+        eq(ImmutableSet.of("foo", "bar", "GLOBAL_STYX_CLUSTER")));
 
     verify(stateManager).receiveIgnoreClosed(Event.dequeue(INSTANCE));
   }
@@ -453,7 +454,7 @@ public class SchedulerTest {
 
     Workflow workflow = workflowUsingResources(WORKFLOW_ID1, "foo", "bar");
     when(resourceDecorator.decorateResources(
-        any(WorkflowInstance.class), any(WorkflowConfiguration.class), anySetOf(String.class)))
+        any(RunState.class), any(WorkflowConfiguration.class), anySetOf(String.class)))
         .thenReturn(ImmutableSet.of("baz", "GLOBAL_STYX_CLUSTER"));
 
     when(storage.globalConcurrency()).thenReturn(Optional.of(17L));
@@ -464,8 +465,8 @@ public class SchedulerTest {
 
     scheduler.tick();
 
-    verify(resourceDecorator).decorateResources(INSTANCE, workflow.configuration(), ImmutableSet.of(
-        "foo", "bar", "GLOBAL_STYX_CLUSTER"));
+    verify(resourceDecorator).decorateResources(any(RunState.class), eq(workflow.configuration()),
+        eq(ImmutableSet.of("foo", "bar", "GLOBAL_STYX_CLUSTER")));
 
     verify(stateManager).receiveIgnoreClosed(Event.info(INSTANCE,
         Message.info("Resource limit reached for: [Resource{id=baz, concurrency=0}]")));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -25,9 +25,14 @@ import static java.time.Duration.ofSeconds;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.Resource;
@@ -36,6 +41,7 @@ import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.state.Message;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.state.StateData;
@@ -50,11 +56,14 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -79,6 +88,8 @@ public class SchedulerTest {
 
   private ExecutorService executor = Executors.newCachedThreadPool();
 
+  @Mock WorkflowResourceDecorator resourceDecorator;
+
   @After
   public void tearDown() throws Exception {
     executor.shutdownNow();
@@ -92,8 +103,12 @@ public class SchedulerTest {
     when(storage.resources()).thenReturn(resourceLimits);
     when(storage.globalConcurrency()).thenReturn(Optional.empty());
 
-    stateManager = new SyncStateManager();
-    scheduler = new Scheduler(time, timeoutConfig, stateManager, workflowCache, storage);
+    when(resourceDecorator.decorateResources(
+        any(WorkflowInstance.class), any(WorkflowConfiguration.class), anySetOf(String.class)))
+        .thenAnswer(a -> a.getArgumentAt(2, Set.class));
+
+    stateManager = Mockito.spy(new SyncStateManager());
+    scheduler = new Scheduler(time, timeoutConfig, stateManager, workflowCache, storage, resourceDecorator);
   }
 
   private void setResourceLimit(String resourceId, long limit) {
@@ -406,6 +421,56 @@ public class SchedulerTest {
 
     assertThat(countInState(State.QUEUED), is(4 - expectedRuns1 - expectedRuns2));
     assertThat(countInState(State.PREPARE), is(expectedRuns1 + expectedRuns2));
+  }
+
+  @Test
+  public void shouldDecorateWorkflowInstanceResources() throws Exception {
+    setUp(20);
+
+    Workflow workflow = workflowUsingResources(WORKFLOW_ID1, "foo", "bar");
+    when(resourceDecorator.decorateResources(
+        any(WorkflowInstance.class), any(WorkflowConfiguration.class), anySetOf(String.class)))
+        .thenReturn(ImmutableSet.of("baz", "quux", "GLOBAL_STYX_CLUSTER"));
+
+    when(storage.globalConcurrency()).thenReturn(Optional.of(17L));
+
+    setResourceLimit("baz", 4);
+    setResourceLimit("quux", 4);
+    initWorkflow(workflow);
+    init(RunState.create(INSTANCE, State.QUEUED, time));
+
+    scheduler.tick();
+
+    verify(resourceDecorator).decorateResources(INSTANCE, workflow.configuration(), ImmutableSet.of(
+        "foo", "bar", "GLOBAL_STYX_CLUSTER"));
+
+    verify(stateManager).receiveIgnoreClosed(Event.dequeue(INSTANCE));
+  }
+
+  @Test
+  public void shouldLimitOnDecoratedWorkflowInstanceResourcesIfNotAvailable() throws Exception {
+    setUp(20);
+
+    Workflow workflow = workflowUsingResources(WORKFLOW_ID1, "foo", "bar");
+    when(resourceDecorator.decorateResources(
+        any(WorkflowInstance.class), any(WorkflowConfiguration.class), anySetOf(String.class)))
+        .thenReturn(ImmutableSet.of("baz", "GLOBAL_STYX_CLUSTER"));
+
+    when(storage.globalConcurrency()).thenReturn(Optional.of(17L));
+
+    setResourceLimit("baz", 0);
+    initWorkflow(workflow);
+    init(RunState.create(INSTANCE, State.QUEUED, time));
+
+    scheduler.tick();
+
+    verify(resourceDecorator).decorateResources(INSTANCE, workflow.configuration(), ImmutableSet.of(
+        "foo", "bar", "GLOBAL_STYX_CLUSTER"));
+
+    verify(stateManager).receiveIgnoreClosed(Event.info(INSTANCE,
+        Message.info("Resource limit reached for: [Resource{id=baz, concurrency=0}]")));
+
+    verify(stateManager, never()).receiveIgnoreClosed(Event.dequeue(INSTANCE));
   }
 
   private WorkflowInstance instance(WorkflowId id, String instanceId) {


### PR DESCRIPTION
The `WorkflowResourceDecorator` interface can be implemented to perform arbitrary modification of effective resource use by workflow instances at scheduler dequeue time.

This is effective regardless of trigger type.