### PR TITLE
fail fast upon receiving exit code 50

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ complement each other.
 
 ### More docs
 
-* [Styx design](doc/design-overview.md)
+* [Styx design]
 * [External services]
 * [API Specification](doc/api.apib) - [HTML version](https://spotify.github.io/styx/api.html)
 
@@ -214,11 +214,8 @@ each one of them complete successfully.
 
 Styx does not have any assumptions about what is executed in the container, it only cares about
 the exit code. Any execution returning a non-zero exit code will either cause a re-try to be scheduled;
-or cause an immediate failure of the workflow instance.
-
-* `20` exit code will cause a re-try to be scheduled after 10 minutes
-* `50` exit code will cause an immediate failure of the workflow instance (no re-try will be scheduled)
-* Other non-zero exit code will cause a re-try to be scheduled with  an exponential back-off between each try
+or cause an immediate failure of the workflow instance. For detailed description of exit codes,
+please refer to **Workflow state graph** section in [Styx design].
 
 ### Injected environment variables
 
@@ -254,6 +251,7 @@ jacoco report can be viewed under the Artifacts tab in the Circle-CI build view.
 This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are
 expected to honor this code.
 
+[Styx design]: doc/design-overview.md
 [External services]: doc/external-services.md
 [Kubernetes]: http://kubernetes.io/
 [Apollo]: https://spotify.github.io/apollo/

--- a/README.md
+++ b/README.md
@@ -213,8 +213,12 @@ with one running container. Because Styx treats each Trigger individually, it ca
 each one of them complete successfully.
 
 Styx does not have any assumptions about what is executed in the container, it only cares about
-the exit code. Any execution returning a non-zero exit code will cause a re-try to be scheduled,
-with an exponential back-off between each try.
+the exit code. Any execution returning a non-zero exit code will either cause a re-try to be scheduled;
+or cause an immediate failure of the workflow instance.
+
+* `20` exit code will cause a re-try to be scheduled after 10 minutes
+* `50` exit code will cause an immediate failure of the workflow instance (no re-try will be scheduled)
+* Other non-zero exit code will cause a re-try to be scheduled with  an exponential back-off between each try
 
 ### Injected environment variables
 

--- a/doc/design-overview.md
+++ b/doc/design-overview.md
@@ -26,6 +26,7 @@ See [`RunState.java`](../styx-common/src/main/java/com/spotify/styx/state/RunSta
 Each workflow instance will be executed until completion or until the maximum number of retries is reached. This means that one or more actual docker runs will happen per workflow instance. How many depends on the exit codes of the runs:
 - _**Exit code 0**_ is treated as a successful run and the associated workflow instance is removed from the active set;
 - _**Exit code 20**_ is considered by Styx as a run that failed due to missing dependencies that are expected to be present in the following executions. The approach in this case is to schedule a retry after a fixed timeout;
+- _**Exit code 50**_ will cause an immediate failure of the workflow instance (no re-try will be scheduled). This can be used by workflow to indicate an unrecoverable failure and instruct Styx not to retry.
 - _**Other exit codes**_ are treated as generic execution errors. In this case Styx reruns the workflow instance after a timeout that increases with the number of attempts.
 
 This whole process follows this state graph:

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TerminationHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TerminationHandler.java
@@ -28,6 +28,7 @@ import com.spotify.styx.state.StateManager;
 import com.spotify.styx.util.RetryUtil;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A {@link OutputHandler} that manages scheduling generation of {@link Event}s
@@ -39,6 +40,7 @@ public class TerminationHandler implements OutputHandler {
   // See the different costs for failures and missing dependencies in RunState
   public static final double MAX_RETRY_COST = 50.0;
   public static final int MISSING_DEPS_EXIT_CODE = 20;
+  public static final int FAIL_FAST_EXIT_CODE = 50;
   public static final int MISSING_DEPS_RETRY_DELAY_MINUTES = 10;
 
   private final RetryUtil retryUtil;
@@ -73,15 +75,28 @@ public class TerminationHandler implements OutputHandler {
     final WorkflowInstance workflowInstance = state.workflowInstance();
 
     if (state.data().retryCost() < MAX_RETRY_COST) {
-      final long delayMillis;
-      if (state.data().lastExit().map(c -> c == MISSING_DEPS_EXIT_CODE).orElse(false)) {
-        delayMillis = Duration.ofMinutes(MISSING_DEPS_RETRY_DELAY_MINUTES).toMillis();
+      final Optional<Integer> exitCode = state.data().lastExit();
+      if (shouldFailFast(exitCode)) {
+        stateManager.receiveIgnoreClosed(Event.stop(workflowInstance));
       } else {
-        delayMillis = retryUtil.calculateDelay(state.data().consecutiveFailures()).toMillis();
+        final long delayMillis;
+        if (isMissingDependency(exitCode)) {
+          delayMillis = Duration.ofMinutes(MISSING_DEPS_RETRY_DELAY_MINUTES).toMillis();
+        } else {
+          delayMillis = retryUtil.calculateDelay(state.data().consecutiveFailures()).toMillis();
+        }
+        stateManager.receiveIgnoreClosed(Event.retryAfter(workflowInstance, delayMillis));
       }
-      stateManager.receiveIgnoreClosed(Event.retryAfter(workflowInstance, delayMillis));
     } else {
       stateManager.receiveIgnoreClosed(Event.stop(workflowInstance));
     }
+  }
+
+  private static boolean isMissingDependency(Optional<Integer> exitCode) {
+    return exitCode.map(c -> c == MISSING_DEPS_EXIT_CODE).orElse(false);
+  }
+
+  private static boolean shouldFailFast(Optional<Integer> exitCode) {
+    return exitCode.map(c -> c == FAIL_FAST_EXIT_CODE).orElse(false);
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/TerminationHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/TerminationHandlerTest.java
@@ -143,6 +143,17 @@ public class TerminationHandlerTest {
     assertThat(nextState.data().retryDelayMillis(), hasValue(Duration.ofMinutes(10).toMillis()));
   }
 
+  @Test
+  public void shouldFailOnFailFastExitCodeReceived() throws Exception {
+    StateData data = data(1, 1.0, Optional.of(50));
+    RunState maxedTerm = RunState.create(WORKFLOW_INSTANCE, FAILED, data, transitions::add);
+    stateManager.initialize(maxedTerm);
+    outputHandler.transitionInto(maxedTerm);
+
+    RunState nextState = transitions.get(0);
+    assertThat(nextState.state(), is(ERROR));
+  }
+
   private StateData data(int tries, double cost, Optional<Integer> lastExit) {
     return StateData.newBuilder()
         .tries(tries)


### PR DESCRIPTION
For certain use cases, an workflow instance execution would like to
return a well-known exit code (similar as 20 for missing dependency)
to Styx, and that would instruct Styx to stop retrying and fail the
execution immediately.

With something like 50 to mean "permanently failed, don't even retry",
by following this pattern:

https://github.com/spotify/luigi/blob/master/doc/configuration.rst#retcode

@ulzha PTAL