### PR TITLE
fix execution id creation & submission race

### DIFF
--- a/doc/design-overview.md
+++ b/doc/design-overview.md
@@ -50,11 +50,11 @@ source code repository, etc.
 
 #### State SUBMITTING
 
-This state submits a new pod to GKE and waits until GKE has accepted it.
+This state sends a request for starting a new pod to GKE.
 
 #### State SUBMITTED
 
-GKE have received the request for starting a new pod. Styx is now waiting
+The request for starting a new pod has been sent to GKE. Styx is now waiting
 for GKE to report back that the pod has started.
 
 #### State RUNNING

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -24,6 +24,7 @@ import static com.spotify.apollo.test.unit.ResponseMatchers.hasStatus;
 import static com.spotify.apollo.test.unit.StatusTypeMatchers.belongsToFamily;
 import static com.spotify.styx.api.JsonMatchers.assertJson;
 import static com.spotify.styx.api.JsonMatchers.assertNoJson;
+import static com.spotify.styx.testdata.TestData.EXECUTION_DESCRIPTION;
 import static java.util.Optional.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -315,7 +316,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T02:00:00Z")).build());
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi, Trigger.backfill("backfill-1")), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi),                                          2L, 2L));
-    storage.writeEvent(SequenceEvent.create(Event.submit(wfi, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi),                                          5L, 5L));
     storage.writeActiveState(wfi, 5L);
@@ -430,7 +431,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T02:00:00Z")).build());
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi, Trigger.backfill("backfill-1")), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi),                                          2L, 2L));
-    storage.writeEvent(SequenceEvent.create(Event.submit(wfi, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi),                                          5L, 5L));
     storage.writeActiveState(wfi, 5L);
@@ -457,7 +458,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T03:00:00Z")).build());
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi1, Trigger.backfill("backfill-1")), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1),                                          2L, 2L));
-    storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi1, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi1),                                          5L, 5L));
     storage.writeActiveState(wfi1, 5L);
@@ -492,13 +493,13 @@ public class BackfillResourceTest extends VersionedApiTest {
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi1, Trigger.backfill("backfill-1")), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1),                                          2L, 2L));
-    storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi1, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi1),                                          5L, 5L));
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi2, Trigger.backfill("backfill-1")), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi2),                                          2L, 2L));
-    storage.writeEvent(SequenceEvent.create(Event.submit(wfi2, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi2, EXECUTION_DESCRIPTION, "exec-2"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi2, "exec-2"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi2),                                          5L, 5L));
 

--- a/styx-api-service/src/test/java/com/spotify/styx/api/deprecated/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/deprecated/BackfillResourceTest.java
@@ -24,6 +24,7 @@ import static com.spotify.apollo.test.unit.ResponseMatchers.hasStatus;
 import static com.spotify.apollo.test.unit.StatusTypeMatchers.belongsToFamily;
 import static com.spotify.styx.api.JsonMatchers.assertJson;
 import static com.spotify.styx.api.JsonMatchers.assertNoJson;
+import static com.spotify.styx.testdata.TestData.EXECUTION_DESCRIPTION;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -246,7 +247,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T02:00:00Z")).build());
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi, Trigger.backfill("backfill-1")), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi),                                          2L, 2L));
-    storage.writeEvent(SequenceEvent.create(Event.submit(wfi, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi),                                          5L, 5L));
     storage.writeActiveState(wfi, 5L);
@@ -364,7 +365,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T02:00:00Z")).build());
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi, Trigger.backfill("backfill-1")), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi),                                          2L, 2L));
-    storage.writeEvent(SequenceEvent.create(Event.submit(wfi, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi),                                          5L, 5L));
     storage.writeActiveState(wfi, 5L);
@@ -391,7 +392,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T03:00:00Z")).build());
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi1, Trigger.backfill("backfill-1")), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1),                                          2L, 2L));
-    storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi1, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi1),                                          5L, 5L));
     storage.writeActiveState(wfi1, 5L);
@@ -426,13 +427,13 @@ public class BackfillResourceTest extends VersionedApiTest {
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi1, Trigger.backfill("backfill-1")), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1),                                          2L, 2L));
-    storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi1, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi1),                                          5L, 5L));
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi2, Trigger.backfill("backfill-1")), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi2),                                          2L, 2L));
-    storage.writeEvent(SequenceEvent.create(Event.submit(wfi2, TestData.EXECUTION_DESCRIPTION),           3L, 3L));
+    storage.writeEvent(SequenceEvent.create(Event.submit(wfi2, EXECUTION_DESCRIPTION, "exec-2"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi2, "exec-2"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi2),                                          5L, 5L));
 

--- a/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
@@ -26,6 +26,7 @@ import com.github.sviperll.adt4j.Visitor;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.Trigger;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Generated {@link Event} ADT for all events that can be received by RunState
@@ -37,8 +38,9 @@ public interface EventVisitor<R> {
   R triggerExecution(@Getter WorkflowInstance workflowInstance, Trigger trigger);
   R info(@Getter WorkflowInstance workflowInstance, Message message);
   R dequeue(@Getter WorkflowInstance workflowInstance);
-  R submit(@Getter WorkflowInstance workflowInstance, ExecutionDescription executionDescription);
-  R submitted(@Getter WorkflowInstance workflowInstance, String executionId);
+  R submit(@Getter WorkflowInstance workflowInstance, ExecutionDescription executionDescription,
+      @Nullable String executionId);
+  R submitted(@Getter WorkflowInstance workflowInstance, @Nullable String executionId);
   R started(@Getter WorkflowInstance workflowInstance);
   R terminate(@Getter WorkflowInstance workflowInstance, Optional<Integer> exitCode);
   R runError(@Getter WorkflowInstance workflowInstance, String message);

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -117,9 +117,11 @@ class WFIExecutionBuilder {
     }
 
     @Override
-    public Void submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription) {
+    public Void submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription,
+        String executionId) {
       currWorkflowInstance = workflowInstance;
       currDockerImg = executionDescription.dockerImage();
+      currExecutionId = executionId;
 
       return null;
     }
@@ -127,7 +129,9 @@ class WFIExecutionBuilder {
     @Override
     public Void submitted(WorkflowInstance workflowInstance, String executionId) {
       currWorkflowInstance = workflowInstance;
-      currExecutionId = executionId;
+      if (currExecutionId == null) {
+        currExecutionId = executionId;
+      }
 
       executionStatusList.add(ExecStatus.create(eventTs, "SUBMITTED"));
       return null;

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -129,9 +129,7 @@ class WFIExecutionBuilder {
     @Override
     public Void submitted(WorkflowInstance workflowInstance, String executionId) {
       currWorkflowInstance = workflowInstance;
-      if (currExecutionId == null) {
-        currExecutionId = executionId;
-      }
+      currExecutionId = executionId;
 
       executionStatusList.add(ExecStatus.create(eventTs, "SUBMITTED"));
       return null;

--- a/styx-common/src/main/java/com/spotify/styx/serialization/PersistentEvent.java
+++ b/styx-common/src/main/java/com/spotify/styx/serialization/PersistentEvent.java
@@ -92,8 +92,9 @@ class PersistentEvent {
     }
 
     @Override
-    public PersistentEvent submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription) {
-      return new Submit(workflowInstance.toKey(), executionDescription);
+    public PersistentEvent submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription,
+        String executionId) {
+      return new Submit(workflowInstance.toKey(), executionDescription, executionId);
     }
 
     @Override
@@ -341,18 +342,21 @@ class PersistentEvent {
   public static class Submit extends PersistentEvent {
 
     public final ExecutionDescription executionDescription;
+    public final String executionId;
 
     @JsonCreator
     public Submit(
         @JsonProperty("workflow_instance") String workflowInstance,
-        @JsonProperty("execution_description") ExecutionDescription executionDescription) {
+        @JsonProperty("execution_description") ExecutionDescription executionDescription,
+        @JsonProperty("execution_id") String executionId) {
       super("submit", workflowInstance);
       this.executionDescription = executionDescription;
+      this.executionId = executionId;
     }
 
     @Override
     public Event toEvent() {
-      return Event.submit(WorkflowInstance.parseKey(workflowInstance), executionDescription);
+      return Event.submit(WorkflowInstance.parseKey(workflowInstance), executionDescription, executionId);
     }
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/state/RunState.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/RunState.java
@@ -215,7 +215,8 @@ public abstract class RunState {
     }
 
     @Override
-    public RunState submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription) {
+    public RunState submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription,
+        String executionId) {
       switch (state()) {
         case QUEUED: // for backwards compatibility
         case PREPARE:
@@ -223,6 +224,7 @@ public abstract class RunState {
               SUBMITTING,
               data().builder()
                   .executionDescription(executionDescription)
+                  .executionId(executionId)
                   .build());
 
         default:
@@ -237,8 +239,9 @@ public abstract class RunState {
           return state(
               SUBMITTED,
               data().builder()
-                  .executionId(executionId)
                   .tries(data().tries() + 1)
+                  // backwards compatibility
+                  .executionId(data().executionId().orElse(executionId))
                   .build());
 
         default:

--- a/styx-common/src/main/java/com/spotify/styx/util/EventUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/EventUtil.java
@@ -122,8 +122,9 @@ public final class EventUtil {
     }
 
     @Override
-    public String submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription) {
-      return String.format("Execution description: %s", executionDescription);
+    public String submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription,
+        String executionId) {
+      return String.format("Execution description: %s, id: %s", executionDescription, executionId);
     }
 
     @Override
@@ -209,7 +210,8 @@ public final class EventUtil {
     }
 
     @Override
-    public String submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription) {
+    public String submit(WorkflowInstance workflowInstance, ExecutionDescription executionDescription,
+        String executionId) {
       return "submit";
     }
 

--- a/styx-common/src/test/java/com/spotify/styx/WorkflowInstanceEventFactory.java
+++ b/styx-common/src/test/java/com/spotify/styx/WorkflowInstanceEventFactory.java
@@ -55,8 +55,8 @@ public class WorkflowInstanceEventFactory {
     return Event.dequeue(workflowInstance);
   }
 
-  public Event submit(ExecutionDescription executionDescription) {
-    return Event.submit(workflowInstance, executionDescription);
+  public Event submit(ExecutionDescription executionDescription, String executionId) {
+    return Event.submit(workflowInstance, executionDescription, executionId);
   }
 
   public Event submitted(String executionId) {

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
@@ -87,14 +87,14 @@ public class WFIExecutionBuilderTest {
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
         SequenceEvent.create(E.dequeue(), c++, ts("07:55")),
-        SequenceEvent.create(E.submit(desc("img1")), c++, ts("07:55")),
+        SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57")),
         SequenceEvent.create(E.terminate(RunState.MISSING_DEPS_EXIT_CODE), c++, ts("07:58")),
         SequenceEvent.create(E.retryAfter(10), c++, ts("07:59")),
 
         SequenceEvent.create(E.retry(), c++, ts("08:56")),
-        SequenceEvent.create(E.submit(desc("img2")), c++, ts("08:55")),
+        SequenceEvent.create(E.submit(desc("img2"), "exec-id-01"), c++, ts("08:55")),
         SequenceEvent.create(E.submitted("exec-id-01"), c++, ts("08:56")),
         SequenceEvent.create(E.started(), c++, ts("08:57")),
         SequenceEvent.create(E.terminate(0), c++, ts("08:58")),
@@ -102,14 +102,14 @@ public class WFIExecutionBuilderTest {
 
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER1), c++, ts("09:55")),
         SequenceEvent.create(E.dequeue(), c++, ts("09:55")),
-        SequenceEvent.create(E.submit(desc("img3")), c++, ts("09:55")),
+        SequenceEvent.create(E.submit(desc("img3"), "exec-id-10"), c++, ts("09:55")),
         SequenceEvent.create(E.submitted("exec-id-10"), c++, ts("09:56")),
         SequenceEvent.create(E.started(), c++, ts("09:57")),
         SequenceEvent.create(E.terminate(1), c++, ts("09:58")),
         SequenceEvent.create(E.retryAfter(10), c++, ts("09:59")),
 
         SequenceEvent.create(E.retry(), c++, ts("10:56")),
-        SequenceEvent.create(E.submit(desc("img4")), c++, ts("10:55")),
+        SequenceEvent.create(E.submit(desc("img4"), "exec-id-11"), c++, ts("10:55")),
         SequenceEvent.create(E.submitted("exec-id-11"), c++, ts("10:56")),
         SequenceEvent.create(E.started(), c++, ts("10:57"))
     );
@@ -182,14 +182,14 @@ public class WFIExecutionBuilderTest {
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
         SequenceEvent.create(E.dequeue(), c++, ts("07:55")),
-        SequenceEvent.create(E.submit(desc("img1")), c++, ts("07:55")),
+        SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57")),
         SequenceEvent.create(E.timeout(), c++, ts("07:58")),
         SequenceEvent.create(E.retryAfter(10), c++, ts("07:59")),
 
         SequenceEvent.create(E.retry(), c++, ts("08:56")),
-        SequenceEvent.create(E.submit(desc("img2")), c++, ts("08:55")),
+        SequenceEvent.create(E.submit(desc("img2"), "exec-id-01"), c++, ts("08:55")),
         SequenceEvent.create(E.submitted("exec-id-01"), c++, ts("08:56")),
         SequenceEvent.create(E.started(), c++, ts("08:57"))
     );
@@ -237,14 +237,14 @@ public class WFIExecutionBuilderTest {
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
         SequenceEvent.create(E.dequeue(), c++, ts("07:55")),
-        SequenceEvent.create(E.submit(desc("img1")), c++, ts("07:55")),
+        SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57")),
         SequenceEvent.create(E.runError("Something failed"), c++, ts("07:58")),
         SequenceEvent.create(E.retryAfter(10), c++, ts("07:59")),
 
         SequenceEvent.create(E.retry(), c++, ts("08:56")),
-        SequenceEvent.create(E.submit(desc("img2")), c++, ts("08:55")),
+        SequenceEvent.create(E.submit(desc("img2"), "exec-id-01"), c++, ts("08:55")),
         SequenceEvent.create(E.submitted("exec-id-01"), c++, ts("08:56")),
         SequenceEvent.create(E.started(), c++, ts("08:57"))
     );
@@ -292,13 +292,13 @@ public class WFIExecutionBuilderTest {
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
         SequenceEvent.create(E.dequeue(), c++, ts("07:55")),
-        SequenceEvent.create(E.submit(desc("img1")), c++, ts("07:55")),
+        SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.halt(), c++, ts("07:57")),
 
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER1), c++, ts("08:56")),
         SequenceEvent.create(E.dequeue(), c++, ts("08:56")),
-        SequenceEvent.create(E.submit(desc("img2")), c++, ts("08:55")),
+        SequenceEvent.create(E.submit(desc("img2"), "exec-id-10"), c++, ts("08:55")),
         SequenceEvent.create(E.submitted("exec-id-10"), c++, ts("08:56")),
         SequenceEvent.create(E.started(), c++, ts("08:57"))
     );

--- a/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
@@ -75,7 +75,7 @@ public class PersistentEventTest {
     assertRoundtrip(Event.stop(INSTANCE1));
     assertRoundtrip(Event.timeout(INSTANCE1));
     assertRoundtrip(Event.halt(INSTANCE1));
-    assertRoundtrip(Event.submit(INSTANCE1, EXECUTION_DESCRIPTION));
+    assertRoundtrip(Event.submit(INSTANCE1, EXECUTION_DESCRIPTION, POD_NAME));
     assertRoundtrip(Event.submitted(INSTANCE1, POD_NAME));
   }
 
@@ -95,10 +95,21 @@ public class PersistentEventTest {
                                                + "\"secret\":{\"name\":\"secret\",\"mount_path\":\"/dev/null\"},"
                                                + "\"commit_sha\":\"" + COMMIT_SHA
                                                + "\"}")),
-        is(Event.submit(INSTANCE1, EXECUTION_DESCRIPTION)));
+        is(Event.submit(INSTANCE1, EXECUTION_DESCRIPTION, null)));
+    assertThat(deserializeEvent(json("submit", "\"execution_description\": { "
+                                               + "\"docker_image\":\"" + DOCKER_IMAGE + "\","
+                                               + "\"docker_args\":[\"foo\",\"bar\"],"
+                                               + "\"secret\":{\"name\":\"secret\",\"mount_path\":\"/dev/null\"},"
+                                               + "\"commit_sha\":\"" + COMMIT_SHA
+                                               + "\"}, "
+                                               + "\"execution_id\": \"" + POD_NAME + "\"")),
+        is(Event.submit(INSTANCE1, EXECUTION_DESCRIPTION, POD_NAME)));
     assertThat(
         deserializeEvent(json("info", "\"message\":{\"line\":\"InfoMessage\",\"level\":\"INFO\"}")),
         is(Event.info(INSTANCE1, Message.info("InfoMessage"))));
+    assertThat(
+        deserializeEvent(json("submitted")),
+        is(Event.submitted(INSTANCE1, null)));
     assertThat(
         deserializeEvent(json("submitted", "\"execution_id\":\"" + POD_NAME + "\"")),
         is(Event.submitted(INSTANCE1, POD_NAME)));

--- a/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
@@ -24,6 +24,7 @@ import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresent;
 import static com.google.common.collect.Sets.newTreeSet;
 import static com.spotify.styx.state.RunState.State.DONE;
 import static com.spotify.styx.state.RunState.State.RUNNING;
+import static com.spotify.styx.testdata.TestData.EXECUTION_DESCRIPTION;
 import static com.spotify.styx.testdata.TestData.WORKFLOW_INSTANCE;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -58,7 +59,7 @@ public class ReplayEventsTest {
     events.add(SequenceEvent.create(Event.halt(WORKFLOW_INSTANCE),                                       1L, 1L));
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.backfill("bf-1")), 2L, 2L));
     events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE),                                    3L, 3L));
-    events.add(SequenceEvent.create(Event.submit(WORKFLOW_INSTANCE, TestData.EXECUTION_DESCRIPTION),     4L, 4L));
+    events.add(SequenceEvent.create(Event.submit(WORKFLOW_INSTANCE, EXECUTION_DESCRIPTION, "exec-1"),    4L, 4L));
     events.add(SequenceEvent.create(Event.submitted(WORKFLOW_INSTANCE, "exec-1"),                        5L, 5L));
     events.add(SequenceEvent.create(Event.started(WORKFLOW_INSTANCE),                                    6L, 6L));
 
@@ -79,7 +80,7 @@ public class ReplayEventsTest {
     SortedSet<SequenceEvent> events = newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.backfill("bf-1")), 1L, 1L));
     events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE),                                    2L, 2L));
-    events.add(SequenceEvent.create(Event.submit(WORKFLOW_INSTANCE, TestData.EXECUTION_DESCRIPTION),     3L, 3L));
+    events.add(SequenceEvent.create(Event.submit(WORKFLOW_INSTANCE, EXECUTION_DESCRIPTION, "exec-1"),    3L, 3L));
     events.add(SequenceEvent.create(Event.submitted(WORKFLOW_INSTANCE, "exec-1"),                        4L, 4L));
     events.add(SequenceEvent.create(Event.started(WORKFLOW_INSTANCE),                                    5L, 5L));
     events.add(SequenceEvent.create(Event.terminate(WORKFLOW_INSTANCE, Optional.of(0)),                  6L, 6L));

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -47,8 +47,6 @@ import org.slf4j.LoggerFactory;
  */
 public interface DockerRunner extends Closeable {
 
-  String STYX_RUN = "styx-run";
-
   Logger LOG = LoggerFactory.getLogger(DockerRunner.class);
 
   /**

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -26,6 +26,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.spotify.styx.ServiceAccountKeyManager;
 import com.spotify.styx.model.WorkflowConfiguration;
+import com.spotify.styx.model.WorkflowConfiguration.Secret;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.StateManager;
@@ -58,9 +59,8 @@ public interface DockerRunner extends Closeable {
    * Starts a workflow instance asynchronously.
    * @param workflowInstance The workflow instance that the run belongs to
    * @param runSpec          Specification of what to run
-   * @return The execution id for the started workflow instance
    */
-  String start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException;
+  void start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException;
 
   /**
    * Perform cleanup for resources such as secrets etc. Resources that are not in use by any currently live workflows
@@ -78,6 +78,8 @@ public interface DockerRunner extends Closeable {
   @AutoValue
   abstract class RunSpec {
 
+    public abstract String executionId();
+
     public abstract String imageName();
 
     public abstract ImmutableList<String> args();
@@ -91,18 +93,19 @@ public interface DockerRunner extends Closeable {
     public abstract Optional<Trigger> trigger();
 
     public static RunSpec create(
+        String executionId,
         String imageName,
         ImmutableList<String> args,
         boolean terminationLogging,
-        Optional<WorkflowConfiguration.Secret> secret,
+        Optional<Secret> secret,
         Optional<String> serviceAccount,
         Optional<Trigger> trigger) {
-      return new AutoValue_DockerRunner_RunSpec(imageName, args, terminationLogging, secret,
+      return new AutoValue_DockerRunner_RunSpec(executionId, imageName, args, terminationLogging, secret,
                                                 serviceAccount, trigger);
     }
 
-    public static RunSpec simple(String imageName, String... args) {
-      return new AutoValue_DockerRunner_RunSpec(imageName, ImmutableList.copyOf(args),
+    public static RunSpec simple(String executionId, String imageName, String... args) {
+      return new AutoValue_DockerRunner_RunSpec(executionId, imageName, ImmutableList.copyOf(args),
                                                 false, empty(), empty(), empty());
     }
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -85,6 +85,7 @@ import java.util.concurrent.TimeUnit;
  */
 class KubernetesDockerRunner implements DockerRunner {
 
+  static final String STYX_RUN = "styx-run";
   static final String STYX_WORKFLOW_INSTANCE_ANNOTATION = "styx-workflow-instance";
   static final String DOCKER_TERMINATION_LOGGING_ANNOTATION = "styx-docker-termination-logging";
   static final String COMPONENT_ID = "STYX_COMPONENT_ID";

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
@@ -53,7 +53,7 @@ public final class KubernetesPodEventTranslator {
   }
 
   private static final Predicate<ContainerStatus> IS_STYX_CONTAINER =
-      (cs) -> DockerRunner.STYX_RUN.equals(cs.getName());
+      (cs) -> KubernetesDockerRunner.STYX_RUN.equals(cs.getName());
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   private static class TerminationLogMessage {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
@@ -81,7 +81,7 @@ class LocalDockerRunner implements DockerRunner {
   }
 
   @Override
-  public String start(WorkflowInstance workflowInstance, RunSpec runSpec) {
+  public void start(WorkflowInstance workflowInstance, RunSpec runSpec) {
     final String imageTag = runSpec.imageName().contains(":")
         ? runSpec.imageName()
         : runSpec.imageName() + ":latest";
@@ -101,15 +101,14 @@ class LocalDockerRunner implements DockerRunner {
           .image(imageTag)
           .cmd(runSpec.args())
           .build();
-      creation = client.createContainer(containerConfig);
+      creation = client.createContainer(containerConfig, runSpec.executionId());
       client.startContainer(creation.id());
     } catch (DockerException | InterruptedException e) {
       throw new RuntimeException(e);
     }
 
     inFlight.put(creation.id(), workflowInstance);
-    LOG.info("Started container with id " + creation.id());
-    return creation.id();
+    LOG.info("Started container with id " + creation.id() + " and name " + runSpec.executionId());
   }
 
   @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
@@ -52,8 +52,8 @@ class RoutingDockerRunner implements DockerRunner {
   }
 
   @Override
-  public String start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException {
-    return runner().start(workflowInstance, runSpec);
+  public void start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException {
+    runner().start(workflowInstance, runSpec);
   }
 
   @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -125,8 +125,10 @@ public class DockerRunnerHandler implements OutputHandler {
         () -> new ResourceNotFoundException("Missing execution description for "
                                             + state.workflowInstance().toKey()));
 
+    // For backwards compatibility, create an execution ID here for RunStates that do not have one as
+    // they transitioned through a SUBMITTING state that did not create execution IDs. This execution ID
+    // will be added to the RunState through the submitted event.
     final String executionId = state.data().executionId()
-        // Backwards compatibility fallback
         .orElseGet(ExecutionDescriptionHandler::createExecutionId);
 
     final String dockerImage = executionDescription.dockerImage();

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -20,7 +20,6 @@
 
 package com.spotify.styx.state.handlers;
 
-import static com.spotify.styx.docker.DockerRunner.STYX_RUN;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
@@ -37,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -36,7 +36,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.spotify.apollo.test.ServiceHelper;
 import com.spotify.styx.docker.DockerRunner;
-import com.spotify.styx.docker.DockerRunner.RunSpec;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.Resource;
@@ -64,7 +63,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import javaslang.Tuple;
 import javaslang.Tuple2;
-import javaslang.Tuple3;
 import org.apache.hadoop.hbase.client.Connection;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.After;
@@ -81,8 +79,6 @@ public class StyxSchedulerServiceFixture {
 
   private static final Logger LOG = LoggerFactory.getLogger(StyxSchedulerServiceFixture.class);
 
-//  static final String TEST_EXECUTION_ID = "execution_1";
-
   private static LocalDatastoreHelper localDatastore;
 
   private Datastore datastore = localDatastore.getOptions().getService();
@@ -97,7 +93,7 @@ public class StyxSchedulerServiceFixture {
   private List<Workflow> workflows = Lists.newArrayList();
 
   // captured fields from fakes
-  List<Tuple2<WorkflowInstance, RunSpec>> dockerRuns = Lists.newArrayList();
+  List<Tuple2<WorkflowInstance, DockerRunner.RunSpec>> dockerRuns = Lists.newArrayList();
   List<String> dockerCleans = Lists.newArrayList();
   AtomicInteger dockerRestores = new AtomicInteger();
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -79,7 +79,7 @@ public class StyxSchedulerServiceFixture {
 
   private static final Logger LOG = LoggerFactory.getLogger(StyxSchedulerServiceFixture.class);
 
-  static final String TEST_EXECUTION_ID = "execution_1";
+//  static final String TEST_EXECUTION_ID = "execution_1";
 
   private static LocalDatastoreHelper localDatastore;
 
@@ -329,9 +329,8 @@ public class StyxSchedulerServiceFixture {
       }
 
       @Override
-      public String start(WorkflowInstance workflowInstance, RunSpec runSpec) {
+      public void start(WorkflowInstance workflowInstance, RunSpec runSpec) {
         dockerRuns.add(Tuple.of(workflowInstance, runSpec));
-        return TEST_EXECUTION_ID;
       }
 
       @Override

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -63,7 +63,9 @@ public class KubernetesDockerRunnerPodPollerTest {
   private static final WorkflowInstance WORKFLOW_INSTANCE_2 =
       WorkflowInstance.create(TestData.WORKFLOW_ID_2, "bar");
   private static final DockerRunner.RunSpec RUN_SPEC =
-      DockerRunner.RunSpec.simple("busybox");
+      DockerRunner.RunSpec.simple("eid1", "busybox");
+  private static final DockerRunner.RunSpec RUN_SPEC_2 =
+      DockerRunner.RunSpec.simple("eid2", "busybox");
   private final static KubernetesSecretSpec SECRET_SPEC = KubernetesSecretSpec.builder().build();
 
   @Mock
@@ -155,14 +157,12 @@ public class KubernetesDockerRunnerPodPollerTest {
   @Test
   public void shouldDeleteUnwantedStyxPods() throws Exception {
     final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
-    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
-    final String podName1 = createdPod1.getMetadata().getName();
-    final String podName2 = createdPod2.getMetadata().getName();
+    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC_2, SECRET_SPEC);
 
     podList.setItems(Arrays.asList(createdPod1, createdPod2));
     when(k8sClient.pods().list()).thenReturn(podList);
-    when(k8sClient.pods().withName(podName1)).thenReturn(namedPod1);
-    when(k8sClient.pods().withName(podName2)).thenReturn(namedPod2);
+    when(k8sClient.pods().withName(RUN_SPEC.executionId())).thenReturn(namedPod1);
+    when(k8sClient.pods().withName(RUN_SPEC_2.executionId())).thenReturn(namedPod2);
 
     kdr.pollPods();
 
@@ -175,14 +175,12 @@ public class KubernetesDockerRunnerPodPollerTest {
     when(debug.get()).thenReturn(true);
 
     final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
-    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
-    final String podName1 = createdPod1.getMetadata().getName();
-    final String podName2 = createdPod2.getMetadata().getName();
+    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC_2, SECRET_SPEC);
 
     podList.setItems(Arrays.asList(createdPod1, createdPod2));
     when(k8sClient.pods().list()).thenReturn(podList);
-    when(k8sClient.pods().withName(podName1)).thenReturn(namedPod1);
-    when(k8sClient.pods().withName(podName2)).thenReturn(namedPod2);
+    when(k8sClient.pods().withName(RUN_SPEC.executionId())).thenReturn(namedPod1);
+    when(k8sClient.pods().withName(RUN_SPEC_2.executionId())).thenReturn(namedPod2);
 
     kdr.pollPods();
 
@@ -197,17 +195,15 @@ public class KubernetesDockerRunnerPodPollerTest {
   @Test
   public void shouldNotDeleteUnwantedNonStyxPods() throws Exception {
     final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
-    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
-    final String podName1 = createdPod1.getMetadata().getName();
-    final String podName2 = createdPod2.getMetadata().getName();
+    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC_2, SECRET_SPEC);
 
     createdPod1.getMetadata().getAnnotations().remove("styx-workflow-instance");
     createdPod2.getMetadata().getAnnotations().remove("styx-workflow-instance");
 
     podList.setItems(Arrays.asList(createdPod1, createdPod2));
     when(k8sClient.pods().list()).thenReturn(podList);
-    when(k8sClient.pods().withName(podName1)).thenReturn(namedPod1);
-    when(k8sClient.pods().withName(podName2)).thenReturn(namedPod2);
+    when(k8sClient.pods().withName(RUN_SPEC.executionId())).thenReturn(namedPod1);
+    when(k8sClient.pods().withName(RUN_SPEC_2.executionId())).thenReturn(namedPod2);
 
     kdr.pollPods();
 
@@ -223,15 +219,13 @@ public class KubernetesDockerRunnerPodPollerTest {
   public void shouldNotDeleteWantedStyxPods() throws Exception {
     final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
     final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
-    final String podName1 = createdPod1.getMetadata().getName();
-    final String podName2 = createdPod2.getMetadata().getName();
 
     podList.setItems(Arrays.asList(createdPod1, createdPod2));
     when(k8sClient.pods().list()).thenReturn(podList);
-    when(k8sClient.pods().withName(podName1)).thenReturn(namedPod1);
-    when(k8sClient.pods().withName(podName2)).thenReturn(namedPod2);
+    when(k8sClient.pods().withName(RUN_SPEC.executionId())).thenReturn(namedPod1);
+    when(k8sClient.pods().withName(RUN_SPEC_2.executionId())).thenReturn(namedPod2);
 
-    setupActiveInstances(RunState.State.RUNNING, podName1, podName2);
+    setupActiveInstances(RunState.State.RUNNING, RUN_SPEC.executionId(), RUN_SPEC_2.executionId());
 
     kdr.pollPods();
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
@@ -57,11 +57,13 @@ public class KubernetesDockerRunnerPodResourceTest {
 
   private final static KubernetesSecretSpec EMPTY_SECRET_SPEC = KubernetesSecretSpec.builder().build();
 
+  private static final String TEST_EXECUTION_ID = "execution_1";
+
   @Test
   public void shouldAddLatestTag() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("eid", "busybox"), EMPTY_SECRET_SPEC);
 
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(containers.size(), is(1));
@@ -74,7 +76,7 @@ public class KubernetesDockerRunnerPodResourceTest {
   public void shouldUseConfiguredTag() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox:v7"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("eid", "busybox:v7"), EMPTY_SECRET_SPEC);
 
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(containers.size(), is(1));
@@ -87,7 +89,7 @@ public class KubernetesDockerRunnerPodResourceTest {
   public void shouldAddArgs() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox", "echo", "foo", "bar"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("eid", "busybox", "echo", "foo", "bar"), EMPTY_SECRET_SPEC);
 
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(containers.size(), is(1));
@@ -100,7 +102,7 @@ public class KubernetesDockerRunnerPodResourceTest {
   public void shouldAddWorkflowInstanceAnnotation() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("eid", "busybox"), EMPTY_SECRET_SPEC);
 
     Map<String, String> annotations = pod.getMetadata().getAnnotations();
     assertThat(annotations, hasEntry(STYX_WORKFLOW_INSTANCE_ANNOTATION, WORKFLOW_INSTANCE.toKey()));
@@ -114,7 +116,7 @@ public class KubernetesDockerRunnerPodResourceTest {
   public void shouldDisableTerminationLoggingWhenFalse() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("eid", "busybox"), EMPTY_SECRET_SPEC);
 
     Map<String, String> annotations = pod.getMetadata().getAnnotations();
     assertThat(annotations.get(DOCKER_TERMINATION_LOGGING_ANNOTATION), is("false"));
@@ -130,7 +132,7 @@ public class KubernetesDockerRunnerPodResourceTest {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
             DockerRunner.RunSpec.create(
-                "busybox", ImmutableList.of(), true,
+                "eid", "busybox", ImmutableList.of(), true,
                 empty(), empty(), empty()), EMPTY_SECRET_SPEC);
 
     Map<String, String> annotations = pod.getMetadata().getAnnotations();
@@ -146,7 +148,7 @@ public class KubernetesDockerRunnerPodResourceTest {
   public void shouldHaveRestartPolicyNever() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("eid", "busybox"), EMPTY_SECRET_SPEC);
 
     assertThat(pod.getSpec().getRestartPolicy(), is("Never"));
   }
@@ -155,7 +157,7 @@ public class KubernetesDockerRunnerPodResourceTest {
   public void shouldNotHaveSecretsMountIfNoSecret() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("eid", "busybox"), EMPTY_SECRET_SPEC);
 
     List<Volume> volumes = pod.getSpec().getVolumes();
     List<Container> containers = pod.getSpec().getContainers();
@@ -176,7 +178,7 @@ public class KubernetesDockerRunnerPodResourceTest {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
         DockerRunner.RunSpec.create(
-            "busybox", ImmutableList.of(), false, Optional.of(secret),
+            "eid", "busybox", ImmutableList.of(), false, Optional.of(secret),
             empty(), empty()), secretSpec);
 
     List<Volume> volumes = pod.getSpec().getVolumes();
@@ -203,7 +205,7 @@ public class KubernetesDockerRunnerPodResourceTest {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
         DockerRunner.RunSpec
-            .create("busybox", ImmutableList.of(), false, empty(),
+            .create(TEST_EXECUTION_ID, "busybox", ImmutableList.of(), false, empty(),
                     empty(), Optional.of(Trigger.unknown("trigger-id"))), EMPTY_SECRET_SPEC);
     List<EnvVar> envVars = pod.getSpec().getContainers().get(0).getEnv();
 
@@ -232,7 +234,6 @@ public class KubernetesDockerRunnerPodResourceTest {
 
     EnvVar execution = envVars.get(4);
     assertThat(execution.getName(),is(KubernetesDockerRunner.EXECUTION_ID));
-    assertThat(execution.getValue(),
-        matchesPattern(KubernetesDockerRunner.STYX_RUN + "-" + UUID_REGEX));
+    assertThat(execution.getValue(), is(TEST_EXECUTION_ID));
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
@@ -107,7 +107,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
 
   private static final WorkflowInstance WORKFLOW_INSTANCE = WorkflowInstance.create(WORKFLOW_ID, "foo");
 
-  private static final RunSpec RUN_SPEC_WITH_SA = RunSpec.create("busybox",
+  private static final RunSpec RUN_SPEC_WITH_SA = RunSpec.create("eid", "busybox",
       ImmutableList.copyOf(new String[0]),
       false,
       empty(),

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -51,7 +51,7 @@ public class KubernetesPodEventTranslatorTest {
   private static final WorkflowInstance WFI =
       WorkflowInstance.create(TestData.WORKFLOW_ID, "foo");
   private static final DockerRunner.RunSpec RUN_SPEC =
-      DockerRunner.RunSpec.simple("busybox");
+      DockerRunner.RunSpec.simple("eid", "busybox");
   private static final String MESSAGE_FORMAT = "{\"rfu\":{\"dum\":\"my\"},\"component_id\":\"dummy\",\"workflow_id\":\"dummy\",\"parameter\":\"dummy\",\"execution_id\":\"dummy\",\"event\":\"dummy\",\"exit_code\":%d}\n";
   private static final KubernetesSecretSpec SECRET_SPEC = KubernetesSecretSpec.builder().build();
 
@@ -334,7 +334,7 @@ public class KubernetesPodEventTranslatorTest {
   private Pod podWithTerminationLogging() {
     return KubernetesDockerRunner.createPod(
         WFI,
-        DockerRunner.RunSpec.create("busybox", ImmutableList.of(), true,
+        DockerRunner.RunSpec.create("eid", "busybox", ImmutableList.of(), true,
             Optional.empty(), Optional.empty(), Optional.empty()), SECRET_SPEC);
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -322,8 +322,8 @@ public class KubernetesPodEventTranslatorTest {
   static PodStatus podStatus(String phase, boolean ready, ContainerState containerState) {
     PodStatus podStatus = podStatusNoContainer(phase);
     podStatus.getContainerStatuses()
-        .add(new ContainerStatus(DockerRunner.STYX_RUN, "", "", containerState,
-                                 DockerRunner.STYX_RUN, ready, 0, containerState));
+        .add(new ContainerStatus(KubernetesDockerRunner.STYX_RUN, "", "", containerState,
+                                 KubernetesDockerRunner.STYX_RUN, ready, 0, containerState));
     return podStatus;
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/RoutingDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/RoutingDockerRunnerTest.java
@@ -43,9 +43,9 @@ public class RoutingDockerRunnerTest {
 
   static final WorkflowInstance WORKFLOW_INSTANCE = WorkflowInstance.create(
       TestData.WORKFLOW_ID, "param");
-  static final DockerRunner.RunSpec RUN_SPEC =
-      DockerRunner.RunSpec.simple("busybox");
   static final String MOCK_EXEC_ID = "mock-run-id-0";
+  static final DockerRunner.RunSpec RUN_SPEC =
+      DockerRunner.RunSpec.simple(MOCK_EXEC_ID, "busybox");
 
   int createCounter = 0;
   Map<String, DockerRunner> createdRunners = Maps.newHashMap();
@@ -61,10 +61,10 @@ public class RoutingDockerRunnerTest {
   @Test
   public void testUsesCreatesRunnerOnStart() throws Exception {
     when(dockerId.get()).thenReturn("default");
-    final String execId = dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC);
+    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC);
 
     assertThat(createdRunners, hasKey("default"));
-    assertThat(execId, is(MOCK_EXEC_ID));
+    verify(createdRunners.get("default")).start(WORKFLOW_INSTANCE, RUN_SPEC);
   }
 
   @Test
@@ -138,13 +138,6 @@ public class RoutingDockerRunnerTest {
   private DockerRunner create(String id) {
     DockerRunner mock = mock(DockerRunner.class);
     createCounter++;
-
-    try {
-      when(mock.start(Mockito.any(), Mockito.any())).thenReturn(MOCK_EXEC_ID);
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
-
     createdRunners.put(id, mock);
     return mock;
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
@@ -329,7 +329,7 @@ public class QueuedStateManagerTest {
       try {
         stateManager.receive(Event.submit(instance, ExecutionDescription.create(
             "", Collections.emptyList(), false, Optional.empty(),
-            Optional.empty(), Optional.empty())));
+            Optional.empty(), Optional.empty()), "id"));
         stateManager.receive(Event.submitted(instance, "id"));
         stateManager.receive(Event.started(instance));
         stateManager.receive(Event.terminate(instance, Optional.of(20)));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
@@ -195,6 +195,9 @@ public class DockerRunnerHandlerTest {
     stateManager.initialize(runState);
     dockerRunnerHandler.transitionInto(runState);
 
+    // Verify that the state manager receives two events:
+    // 1. submitted
+    // 2. runError
     verify(stateManager, timeout(60_000).times(2)).receive(any(Event.class));
 
     assertThat(stateManager.get(workflowInstance).state(), is(RunState.State.FAILED));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
@@ -26,6 +26,7 @@ import static com.spotify.styx.state.RunState.State.SUBMITTING;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
 
@@ -90,6 +91,8 @@ public class ExecutionDescriptionHandlerTest {
     StateData data = currentState.data();
 
     assertThat(currentState.state(), is(SUBMITTING));
+    assertTrue(data.executionId().isPresent());
+    assertThat(data.executionId().get(), startsWith("styx-run-"));
     assertTrue(data.executionDescription().isPresent());
     assertThat(data.executionDescription().get().dockerImage(), is(DOCKER_IMAGE));
     assertThat(data.executionDescription().get().dockerArgs(), contains("--date", "{}", "--bar"));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/MonitoringHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/MonitoringHandlerTest.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx.state.handlers;
 
+import static com.spotify.styx.testdata.TestData.EXECUTION_DESCRIPTION;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.never;
@@ -83,7 +84,7 @@ public class MonitoringHandlerTest {
 
     stateManager.receive(Event.triggerExecution(state.workflowInstance(), Trigger.natural()));
     stateManager.receive(Event.dequeue(state.workflowInstance()));
-    stateManager.receive(Event.submit(state.workflowInstance(), TestData.EXECUTION_DESCRIPTION));
+    stateManager.receive(Event.submit(state.workflowInstance(), EXECUTION_DESCRIPTION, "exec-1"));
     stateManager.receive(Event.submitted(state.workflowInstance(), "exec-1"));
     stateManager.receive(Event.started(state.workflowInstance()));
     stateManager.receive(Event.terminate(state.workflowInstance(), Optional.of(20)));
@@ -98,7 +99,7 @@ public class MonitoringHandlerTest {
 
     stateManager.receive(Event.triggerExecution(state.workflowInstance(), Trigger.natural()));
     stateManager.receive(Event.dequeue(state.workflowInstance()));
-    stateManager.receive(Event.submit(state.workflowInstance(), TestData.EXECUTION_DESCRIPTION));
+    stateManager.receive(Event.submit(state.workflowInstance(), EXECUTION_DESCRIPTION, "exec-1"));
     stateManager.receive(Event.submitted(state.workflowInstance(), "exec-1"));
     stateManager.receive(Event.started(state.workflowInstance()));
     stateManager.receive(Event.terminate(state.workflowInstance(), Optional.empty()));


### PR DESCRIPTION
Create the execution id in the prepare state and add it to the run state as part of the submit event. This eliminates the race between k8s submission and execution id persistence that caused the runner to not be able to look up run states for newly started pods.

This also means that styx will not "lose" any pods that were in the middle of being created during a styx restart.

For backwards compatibility, the `executionId` field is kept in the `submitted` event to ensure that we can replay old events and do not lose execution id's when deploying this change.