### PR TITLE
emit submitted event before creating pod

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -46,6 +46,8 @@ import org.slf4j.LoggerFactory;
  */
 public interface DockerRunner extends Closeable {
 
+  String STYX_RUN = "styx-run";
+
   Logger LOG = LoggerFactory.getLogger(DockerRunner.class);
 
   /**
@@ -58,9 +60,9 @@ public interface DockerRunner extends Closeable {
    * Starts a workflow instance asynchronously.
    * @param workflowInstance The workflow instance that the run belongs to
    * @param runSpec          Specification of what to run
-   * @return The execution id for the started workflow instance
+   * @param executionId      The execution id of the run
    */
-  String start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException;
+  void start(WorkflowInstance workflowInstance, RunSpec runSpec, String executionId) throws IOException;
 
   /**
    * Perform cleanup for resources such as secrets etc. Resources that are not in use by any currently live workflows

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
@@ -53,7 +53,7 @@ public final class KubernetesPodEventTranslator {
   }
 
   private static final Predicate<ContainerStatus> IS_STYX_CONTAINER =
-      (cs) -> KubernetesDockerRunner.STYX_RUN.equals(cs.getName());
+      (cs) -> DockerRunner.STYX_RUN.equals(cs.getName());
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   private static class TerminationLogMessage {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
@@ -81,7 +81,7 @@ class LocalDockerRunner implements DockerRunner {
   }
 
   @Override
-  public String start(WorkflowInstance workflowInstance, RunSpec runSpec) {
+  public void start(WorkflowInstance workflowInstance, RunSpec runSpec, String executionId) {
     final String imageTag = runSpec.imageName().contains(":")
         ? runSpec.imageName()
         : runSpec.imageName() + ":latest";
@@ -101,7 +101,7 @@ class LocalDockerRunner implements DockerRunner {
           .image(imageTag)
           .cmd(runSpec.args())
           .build();
-      creation = client.createContainer(containerConfig);
+      creation = client.createContainer(containerConfig, executionId);
       client.startContainer(creation.id());
     } catch (DockerException | InterruptedException e) {
       throw new RuntimeException(e);
@@ -109,7 +109,6 @@ class LocalDockerRunner implements DockerRunner {
 
     inFlight.put(creation.id(), workflowInstance);
     LOG.info("Started container with id " + creation.id());
-    return creation.id();
   }
 
   @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
@@ -52,8 +52,8 @@ class RoutingDockerRunner implements DockerRunner {
   }
 
   @Override
-  public String start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException {
-    return runner().start(workflowInstance, runSpec);
+  public void start(WorkflowInstance workflowInstance, RunSpec runSpec, String executionId) throws IOException {
+    runner().start(workflowInstance, runSpec, executionId);
   }
 
   @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -20,23 +20,24 @@
 
 package com.spotify.styx.state.handlers;
 
+import static com.spotify.styx.docker.DockerRunner.STYX_RUN;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.RateLimiter;
 import com.spotify.styx.docker.DockerRunner;
+import com.spotify.styx.docker.DockerRunner.RunSpec;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.ExecutionDescription;
-import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.OutputHandler;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.util.ResourceNotFoundException;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,18 +72,30 @@ public class DockerRunnerHandler implements OutputHandler {
         // Perform rate limited submission on a separate thread pool to avoid blocking the caller.
         executor.submit(() -> {
           rateLimiter.acquire();
+
+          final RunSpec runSpec;
           try {
-            final String executionId = dockerRunnerStart(state);
-            // this is racy
-            final Event submitted = Event.submitted(state.workflowInstance(), executionId);
-            try {
-              stateManager.receive(submitted);
-            } catch (StateManager.IsClosed isClosed) {
-              LOG.warn("Could not send 'created' event", isClosed);
-            }
+            runSpec = createRunSpec(state);
           } catch (ResourceNotFoundException e) {
             LOG.error("Unable to start docker procedure.", e);
             stateManager.receiveIgnoreClosed(Event.halt(state.workflowInstance()));
+            return;
+          }
+
+          // Emit submitted event first to store execution id before starting
+          final String executionId = STYX_RUN + "-" + UUID.randomUUID().toString();
+          final Event submitted = Event.submitted(state.workflowInstance(), executionId);
+          try {
+            stateManager.receive(submitted);
+          } catch (StateManager.IsClosed isClosed) {
+            LOG.warn("Could not emit 'submitted' event", isClosed);
+            return;
+          }
+
+          try {
+            LOG.info("running:{} image:{} args:{} termination_logging:{}", state.workflowInstance().toKey(),
+                runSpec.imageName(), runSpec.args(), runSpec.terminationLogging());
+            dockerRunner.start(state.workflowInstance(), runSpec, executionId);
           } catch (Throwable e) {
             try {
               LOG.error("Failed the docker starting procedure for " + state.workflowInstance().toKey(), e);
@@ -108,8 +121,7 @@ public class DockerRunnerHandler implements OutputHandler {
     }
   }
 
-  private String dockerRunnerStart(RunState state) throws IOException {
-    final WorkflowInstance workflowInstance = state.workflowInstance();
+  private RunSpec createRunSpec(RunState state) throws ResourceNotFoundException {
     final Optional<ExecutionDescription> executionDescriptionOpt = state.data().executionDescription();
 
     final ExecutionDescription executionDescription = executionDescriptionOpt.orElseThrow(
@@ -118,20 +130,15 @@ public class DockerRunnerHandler implements OutputHandler {
 
     final String dockerImage = executionDescription.dockerImage();
     final List<String> dockerArgs = executionDescription.dockerArgs();
-    final String parameter = workflowInstance.parameter();
+    final String parameter = state.workflowInstance().parameter();
     final List<String> command = argsReplace(dockerArgs, parameter);
-    final DockerRunner.RunSpec runSpec = DockerRunner.RunSpec.create(
+    return RunSpec.create(
         dockerImage,
         ImmutableList.copyOf(command),
         executionDescription.dockerTerminationLogging(),
         executionDescription.secret(),
         executionDescription.serviceAccount(),
         state.data().trigger());
-
-    LOG.info("running:{} image:{} args:{} termination_logging:{}", workflowInstance.toKey(),
-        runSpec.imageName(), runSpec.args(), runSpec.terminationLogging());
-
-    return dockerRunner.start(workflowInstance, runSpec);
   }
 
   private static List<String> argsReplace(List<String> template, String parameter) {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -36,6 +36,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.spotify.apollo.test.ServiceHelper;
 import com.spotify.styx.docker.DockerRunner;
+import com.spotify.styx.docker.DockerRunner.RunSpec;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.Resource;
@@ -63,6 +64,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import javaslang.Tuple;
 import javaslang.Tuple2;
+import javaslang.Tuple3;
 import org.apache.hadoop.hbase.client.Connection;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.After;
@@ -95,7 +97,7 @@ public class StyxSchedulerServiceFixture {
   private List<Workflow> workflows = Lists.newArrayList();
 
   // captured fields from fakes
-  List<Tuple2<WorkflowInstance, DockerRunner.RunSpec>> dockerRuns = Lists.newArrayList();
+  List<Tuple3<WorkflowInstance, RunSpec, String>> dockerRuns = Lists.newArrayList();
   List<String> dockerCleans = Lists.newArrayList();
   AtomicInteger dockerRestores = new AtomicInteger();
 
@@ -329,9 +331,8 @@ public class StyxSchedulerServiceFixture {
       }
 
       @Override
-      public String start(WorkflowInstance workflowInstance, RunSpec runSpec) {
-        dockerRuns.add(Tuple.of(workflowInstance, runSpec));
-        return TEST_EXECUTION_ID;
+      public void start(WorkflowInstance workflowInstance, RunSpec runSpec, String executionId) {
+        dockerRuns.add(Tuple.of(workflowInstance, runSpec, executionId));
       }
 
       @Override

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -423,12 +423,13 @@ public class SystemTest extends StyxSchedulerServiceFixture {
     awaitNumberOfDockerRuns(1);
 
     WorkflowInstance workflowInstance = dockerRuns.get(0)._1;
+    String executionId = dockerRuns.get(0)._3;
 
     injectEvent(Event.started(workflowInstance));
     injectEvent(Event.terminate(workflowInstance, Optional.of(20)));
     awaitWorkflowInstanceState(workflowInstance, RunState.State.QUEUED);
 
-    assertThat(dockerCleans, contains(TEST_EXECUTION_ID));
+    assertThat(dockerCleans, contains(executionId));
   }
 
   @Test
@@ -444,11 +445,12 @@ public class SystemTest extends StyxSchedulerServiceFixture {
     awaitNumberOfDockerRuns(1);
 
     WorkflowInstance workflowInstance = dockerRuns.get(0)._1;
+    String executionId = dockerRuns.get(0)._3;
 
     injectEvent(Event.runError(workflowInstance, "Something failed"));
     awaitWorkflowInstanceState(workflowInstance, RunState.State.QUEUED);
 
-    assertThat(dockerCleans, contains(TEST_EXECUTION_ID));
+    assertThat(dockerCleans, contains(executionId));
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -99,7 +99,7 @@ public class KubernetesDockerRunnerPodPollerTest {
 
   @Test
   public void shouldSendRunErrorWhenPodForRunningWFIDoesntExist() throws Exception {
-    Pod createdPod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
+    Pod createdPod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC, POD_NAME);
     podList.setItems(Arrays.asList(createdPod));
     when(k8sClient.pods().list()).thenReturn(podList);
     setupActiveInstances(RunState.State.RUNNING, POD_NAME, POD_NAME_2);
@@ -112,8 +112,8 @@ public class KubernetesDockerRunnerPodPollerTest {
 
   @Test
   public void shouldNotSendRunErrorWhenPodForRunningWFIExists() throws Exception {
-    Pod createdPod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
-    Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    Pod createdPod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC, POD_NAME);
+    Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC, POD_NAME_2);
     podList.setItems(Arrays.asList(createdPod, createdPod2));
     when(k8sClient.pods().list()).thenReturn(podList);
     setupActiveInstances(RunState.State.RUNNING, POD_NAME, POD_NAME_2);
@@ -154,8 +154,8 @@ public class KubernetesDockerRunnerPodPollerTest {
 
   @Test
   public void shouldDeleteUnwantedStyxPods() throws Exception {
-    final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
-    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC, POD_NAME);
+    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC, POD_NAME_2);
     final String podName1 = createdPod1.getMetadata().getName();
     final String podName2 = createdPod2.getMetadata().getName();
 
@@ -174,8 +174,8 @@ public class KubernetesDockerRunnerPodPollerTest {
   public void shouldNotDeleteUnwantedStyxPodsIfDebugEnabled() throws Exception {
     when(debug.get()).thenReturn(true);
 
-    final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
-    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC, POD_NAME);
+    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC, POD_NAME_2);
     final String podName1 = createdPod1.getMetadata().getName();
     final String podName2 = createdPod2.getMetadata().getName();
 
@@ -196,8 +196,8 @@ public class KubernetesDockerRunnerPodPollerTest {
 
   @Test
   public void shouldNotDeleteUnwantedNonStyxPods() throws Exception {
-    final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
-    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC, POD_NAME);
+    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC, POD_NAME_2);
     final String podName1 = createdPod1.getMetadata().getName();
     final String podName2 = createdPod2.getMetadata().getName();
 
@@ -221,8 +221,8 @@ public class KubernetesDockerRunnerPodPollerTest {
 
   @Test
   public void shouldNotDeleteWantedStyxPods() throws Exception {
-    final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC);
-    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC);
+    final Pod createdPod1 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC, SECRET_SPEC, POD_NAME);
+    final Pod createdPod2 = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE_2, RUN_SPEC, SECRET_SPEC, POD_NAME_2);
     final String podName1 = createdPod1.getMetadata().getName();
     final String podName2 = createdPod2.getMetadata().getName();
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
@@ -57,11 +57,13 @@ public class KubernetesDockerRunnerPodResourceTest {
 
   private final static KubernetesSecretSpec EMPTY_SECRET_SPEC = KubernetesSecretSpec.builder().build();
 
+  private static final String TEST_EXEC_ID = "test-exec-id";
+
   @Test
   public void shouldAddLatestTag() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC, TEST_EXEC_ID);
 
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(containers.size(), is(1));
@@ -74,7 +76,7 @@ public class KubernetesDockerRunnerPodResourceTest {
   public void shouldUseConfiguredTag() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox:v7"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("busybox:v7"), EMPTY_SECRET_SPEC, TEST_EXEC_ID);
 
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(containers.size(), is(1));
@@ -87,7 +89,7 @@ public class KubernetesDockerRunnerPodResourceTest {
   public void shouldAddArgs() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox", "echo", "foo", "bar"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("busybox", "echo", "foo", "bar"), EMPTY_SECRET_SPEC, TEST_EXEC_ID);
 
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(containers.size(), is(1));
@@ -100,7 +102,7 @@ public class KubernetesDockerRunnerPodResourceTest {
   public void shouldAddWorkflowInstanceAnnotation() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC, TEST_EXEC_ID);
 
     Map<String, String> annotations = pod.getMetadata().getAnnotations();
     assertThat(annotations, hasEntry(STYX_WORKFLOW_INSTANCE_ANNOTATION, WORKFLOW_INSTANCE.toKey()));
@@ -114,7 +116,7 @@ public class KubernetesDockerRunnerPodResourceTest {
   public void shouldDisableTerminationLoggingWhenFalse() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC, TEST_EXEC_ID);
 
     Map<String, String> annotations = pod.getMetadata().getAnnotations();
     assertThat(annotations.get(DOCKER_TERMINATION_LOGGING_ANNOTATION), is("false"));
@@ -131,7 +133,7 @@ public class KubernetesDockerRunnerPodResourceTest {
         WORKFLOW_INSTANCE,
             DockerRunner.RunSpec.create(
                 "busybox", ImmutableList.of(), true,
-                empty(), empty(), empty()), EMPTY_SECRET_SPEC);
+                empty(), empty(), empty()), EMPTY_SECRET_SPEC, TEST_EXEC_ID);
 
     Map<String, String> annotations = pod.getMetadata().getAnnotations();
     assertThat(annotations.get(DOCKER_TERMINATION_LOGGING_ANNOTATION), is("true"));
@@ -146,7 +148,7 @@ public class KubernetesDockerRunnerPodResourceTest {
   public void shouldHaveRestartPolicyNever() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC, TEST_EXEC_ID);
 
     assertThat(pod.getSpec().getRestartPolicy(), is("Never"));
   }
@@ -155,7 +157,7 @@ public class KubernetesDockerRunnerPodResourceTest {
   public void shouldNotHaveSecretsMountIfNoSecret() throws Exception {
     Pod pod = KubernetesDockerRunner.createPod(
         WORKFLOW_INSTANCE,
-        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC);
+        DockerRunner.RunSpec.simple("busybox"), EMPTY_SECRET_SPEC, TEST_EXEC_ID);
 
     List<Volume> volumes = pod.getSpec().getVolumes();
     List<Container> containers = pod.getSpec().getContainers();
@@ -177,7 +179,7 @@ public class KubernetesDockerRunnerPodResourceTest {
         WORKFLOW_INSTANCE,
         DockerRunner.RunSpec.create(
             "busybox", ImmutableList.of(), false, Optional.of(secret),
-            empty(), empty()), secretSpec);
+            empty(), empty()), secretSpec, TEST_EXEC_ID);
 
     List<Volume> volumes = pod.getSpec().getVolumes();
     List<Container> containers = pod.getSpec().getContainers();
@@ -204,7 +206,7 @@ public class KubernetesDockerRunnerPodResourceTest {
         WORKFLOW_INSTANCE,
         DockerRunner.RunSpec
             .create("busybox", ImmutableList.of(), false, empty(),
-                    empty(), Optional.of(Trigger.unknown("trigger-id"))), EMPTY_SECRET_SPEC);
+                    empty(), Optional.of(Trigger.unknown("trigger-id"))), EMPTY_SECRET_SPEC, TEST_EXEC_ID);
     List<EnvVar> envVars = pod.getSpec().getContainers().get(0).getEnv();
 
     EnvVar workflow = new EnvVar();
@@ -232,7 +234,6 @@ public class KubernetesDockerRunnerPodResourceTest {
 
     EnvVar execution = envVars.get(4);
     assertThat(execution.getName(),is(KubernetesDockerRunner.EXECUTION_ID));
-    assertThat(execution.getValue(),
-        matchesPattern(KubernetesDockerRunner.STYX_RUN + "-" + UUID_REGEX));
+    assertThat(execution.getValue(), is(TEST_EXEC_ID));
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
@@ -114,6 +114,8 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
       Optional.of(SERVICE_ACCOUNT),
       empty());
 
+  private static final String TEST_EXEC_ID = "test-exec-id";
+
   private ExecutorService executor;
 
   @Mock NamespacedKubernetesClient k8sClient;
@@ -267,7 +269,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
     final KubernetesSecretSpec secretSpec = KubernetesSecretSpec.builder()
         .serviceAccountSecret(secret.getMetadata().getName())
         .build();
-    final Pod pod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC_WITH_SA, secretSpec);
+    final Pod pod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC_WITH_SA, secretSpec, TEST_EXEC_ID);
 
     final PodStatus podStatus = podStatus(phase);
     pod.setStatus(podStatus);
@@ -291,7 +293,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
     final KubernetesSecretSpec secretSpec = KubernetesSecretSpec.builder()
         .serviceAccountSecret(secret.getMetadata().getName())
         .build();
-    final Pod pod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC_WITH_SA, secretSpec);
+    final Pod pod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC_WITH_SA, secretSpec, TEST_EXEC_ID);
     pod.setStatus(podStatus("Running"));
     when(podList.getItems()).thenReturn(ImmutableList.of(pod));
     sut.cleanup();

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -55,7 +55,7 @@ public class KubernetesPodEventTranslatorTest {
   private static final String MESSAGE_FORMAT = "{\"rfu\":{\"dum\":\"my\"},\"component_id\":\"dummy\",\"workflow_id\":\"dummy\",\"parameter\":\"dummy\",\"execution_id\":\"dummy\",\"event\":\"dummy\",\"exit_code\":%d}\n";
   private static final KubernetesSecretSpec SECRET_SPEC = KubernetesSecretSpec.builder().build();
 
-  Pod pod = KubernetesDockerRunner.createPod(WFI, RUN_SPEC, SECRET_SPEC);
+  Pod pod = KubernetesDockerRunner.createPod(WFI, RUN_SPEC, SECRET_SPEC, "test-exec-id");
 
   @Test
   public void terminateOnSuccessfulTermination() throws Exception {
@@ -322,8 +322,8 @@ public class KubernetesPodEventTranslatorTest {
   static PodStatus podStatus(String phase, boolean ready, ContainerState containerState) {
     PodStatus podStatus = podStatusNoContainer(phase);
     podStatus.getContainerStatuses()
-        .add(new ContainerStatus(KubernetesDockerRunner.STYX_RUN, "", "", containerState,
-                                 KubernetesDockerRunner.STYX_RUN, ready, 0, containerState));
+        .add(new ContainerStatus(DockerRunner.STYX_RUN, "", "", containerState,
+                                 DockerRunner.STYX_RUN, ready, 0, containerState));
     return podStatus;
   }
 
@@ -335,6 +335,6 @@ public class KubernetesPodEventTranslatorTest {
     return KubernetesDockerRunner.createPod(
         WFI,
         DockerRunner.RunSpec.create("busybox", ImmutableList.of(), true,
-            Optional.empty(), Optional.empty(), Optional.empty()), SECRET_SPEC);
+            Optional.empty(), Optional.empty(), Optional.empty()), SECRET_SPEC, "test-exec-id");
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/RoutingDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/RoutingDockerRunnerTest.java
@@ -61,10 +61,10 @@ public class RoutingDockerRunnerTest {
   @Test
   public void testUsesCreatesRunnerOnStart() throws Exception {
     when(dockerId.get()).thenReturn("default");
-    final String execId = dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC);
+    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC, MOCK_EXEC_ID);
 
     assertThat(createdRunners, hasKey("default"));
-    assertThat(execId, is(MOCK_EXEC_ID));
+    verify(createdRunners.get("default")).start(WORKFLOW_INSTANCE, RUN_SPEC, MOCK_EXEC_ID);
   }
 
   @Test
@@ -97,8 +97,8 @@ public class RoutingDockerRunnerTest {
   @Test
   public void testCreatesOnlyOneRunnerPerDockerId() throws Exception {
     when(dockerId.get()).thenReturn("default");
-    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC);
-    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC);
+    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC, MOCK_EXEC_ID);
+    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC, MOCK_EXEC_ID);
     dockerRunner.cleanup(WORKFLOW_INSTANCE, MOCK_EXEC_ID);
     dockerRunner.cleanup(WORKFLOW_INSTANCE, MOCK_EXEC_ID);
 
@@ -112,8 +112,8 @@ public class RoutingDockerRunnerTest {
     Mockito.reset(dockerId);
     when(dockerId.get()).thenReturn("id-1", "id-2");
 
-    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC);
-    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC);
+    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC, MOCK_EXEC_ID);
+    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC, MOCK_EXEC_ID);
 
     assertThat(createdRunners, hasKey("id-1"));
     assertThat(createdRunners, hasKey("id-2"));
@@ -124,8 +124,8 @@ public class RoutingDockerRunnerTest {
     Mockito.reset(dockerId);
     when(dockerId.get()).thenReturn("id-1", "id-2");
 
-    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC);
-    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC);
+    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC, MOCK_EXEC_ID);
+    dockerRunner.start(WORKFLOW_INSTANCE, RUN_SPEC, MOCK_EXEC_ID);
     dockerRunner.close();
 
     assertThat(createCounter, is(2));
@@ -138,13 +138,6 @@ public class RoutingDockerRunnerTest {
   private DockerRunner create(String id) {
     DockerRunner mock = mock(DockerRunner.class);
     createCounter++;
-
-    try {
-      when(mock.start(Mockito.any(), Mockito.any())).thenReturn(MOCK_EXEC_ID);
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
-
     createdRunners.put(id, mock);
     return mock;
   }


### PR DESCRIPTION
* Change the semantics of the `submitted` event to mean `workflow instance start has been asynchronously requested`. 

* Guarantee that `submitted` is received before the `started` event from the container.
