### PR TITLE
log a nicer workflow SA permission denied message

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/GcpUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/GcpUtil.java
@@ -27,8 +27,8 @@ import java.util.Optional;
 public class GcpUtil {
 
   public static boolean isPermissionDenied(Throwable t) {
-    return t instanceof GoogleJsonResponseException &&
-        isPermissionDenied((GoogleJsonResponseException) t);
+    return t instanceof GoogleJsonResponseException
+        && isPermissionDenied((GoogleJsonResponseException) t);
   }
 
   public static boolean isPermissionDenied(GoogleJsonResponseException e) {

--- a/styx-common/src/main/java/com/spotify/styx/util/GcpUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/GcpUtil.java
@@ -26,6 +26,11 @@ import java.util.Optional;
 
 public class GcpUtil {
 
+  public static boolean isPermissionDenied(Throwable t) {
+    return t instanceof GoogleJsonResponseException &&
+        isPermissionDenied((GoogleJsonResponseException) t);
+  }
+
   public static boolean isPermissionDenied(GoogleJsonResponseException e) {
     return e.getStatusCode() == 403 && Optional.ofNullable(e.getDetails())
         .map(GcpUtil::isPermissionDenied)

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
@@ -108,8 +108,11 @@ class KubernetesGCPServiceAccountSecretManager {
       return serviceAccountSecretCache.get(serviceAccount, () ->
           getOrCreateSecret(workflowId, serviceAccount, epoch, secretName));
     } catch (Exception e) {
-      if (e.getCause() instanceof InvalidExecutionException) {
-        throw (InvalidExecutionException) e.getCause();
+      final Throwable cause = e.getCause();
+      if (cause instanceof InvalidExecutionException) {
+        throw (InvalidExecutionException) cause;
+      } else if (GcpUtil.isPermissionDenied(cause)) {
+        throw new InvalidExecutionException("Permission denied to service account: " + serviceAccount);
       } else {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
Current `styx e` cli output for an instance with wf SA permission problems is the raw json from the GoogleJsonResponseException message. That is not very user friendly.

With this change, the cli output will be something like:

```
Permission denied to service account: foo@barz.iam.google.com
```

Not sure if we should also add instructions here about granting e.g. `Key Admin` role on the wf SA for the Styx SA.