### PR TITLE
warning instead of error

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
@@ -97,7 +97,7 @@ public class BackfillTriggerManager {
 
     for (int i = 0; i < remainingCapacity && partition.isBefore(backfill.end()); i++) {
       try {
-        CompletableFuture<Void> processed = triggerListener
+        final CompletableFuture<Void> processed = triggerListener
             .event(workflow, Trigger.backfill(backfill.id()), partition)
             .toCompletableFuture();
         // Wait for the trigger execution to complete before proceeding to the next partition

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -69,7 +69,7 @@ public class ExecutionDescriptionHandler implements OutputHandler {
             LOG.warn("Could not send 'created' event", isClosed);
           }
         } catch (ResourceNotFoundException e) {
-          LOG.error("Failed to prepare execution description for "
+          LOG.warn("Failed to prepare execution description for "
                    + state.workflowInstance().toKey(), e);
           stateManager.receiveIgnoreClosed(Event.halt(workflowInstance));
         } catch (IOException e) {


### PR DESCRIPTION
in most cases, this is due to workflow being removed or renamed by
users, so a warning feels better.

@fabriziodemaria PTAL