### PR TITLE
be more strict than smart when parsing date time

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/ParameterUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ParameterUtil.java
@@ -37,6 +37,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
@@ -80,6 +81,7 @@ public final class ParameterUtil {
       .optionalEnd()
       .optionalEnd()
       .toFormatter()
+      .withResolverStyle(ResolverStyle.STRICT)
       .withZone(UTC);
 
   private static final DateTimeFormatter ISO_LOCAL_YEAR = new DateTimeFormatterBuilder()

--- a/styx-common/src/test/java/com/spotify/styx/util/ParameterUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ParameterUtilTest.java
@@ -203,7 +203,8 @@ public class ParameterUtilTest {
 
     UNPARSABLE = Arrays.asList(
         example("2017-03-26+01:00", DAYS),
-        example("2017-03-26+01:00", WEEKS)
+        example("2017-03-26+01:00", WEEKS),
+        example("2017-04-31", DAYS)
     );
   }
 


### PR DESCRIPTION
This is to fix #167

@danielnorberg 