### PR TITLE
WFIExecutionData returns FAILED execution even if no exec id

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/model/data/Execution.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/Execution.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Value representing an execution attempt
@@ -32,7 +33,7 @@ import java.util.List;
 public abstract class Execution {
 
   @JsonProperty
-  public abstract String executionId();
+  public abstract Optional<String> executionId();
 
   @JsonProperty
   public abstract String dockerImage();
@@ -42,7 +43,7 @@ public abstract class Execution {
 
   @JsonCreator
   public static Execution create(
-      @JsonProperty("execution_id") String executionId,
+      @JsonProperty("execution_id") Optional<String> executionId,
       @JsonProperty("docker_image") String dockerImage,
       @JsonProperty("statuses") List<ExecStatus> statuses) {
     return new AutoValue_Execution(executionId, dockerImage, statuses);

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -49,8 +49,11 @@ class WFIExecutionBuilder {
   private Instant eventTs;
 
   private void closeExecution() {
-    if (currExecutionId != null && currDockerImg != null) {
-      Execution execution = Execution.create(currExecutionId, currDockerImg, executionStatusList);
+    if (currDockerImg != null) {
+      Execution execution = Execution.create(
+          Optional.ofNullable(currExecutionId),
+          currDockerImg,
+          executionStatusList);
       executionList.add(execution);
     }
 

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
@@ -36,6 +36,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 
 public class WFIExecutionBuilderTest {
@@ -127,7 +128,7 @@ public class WFIExecutionBuilderTest {
                     true,
                     Arrays.asList(
                         Execution.create(
-                            "exec-id-00",
+                            Optional.of("exec-id-00"),
                             "img1",
                             Arrays.asList(
                                 ExecStatus.create(time("07:56"), "SUBMITTED"),
@@ -136,7 +137,7 @@ public class WFIExecutionBuilderTest {
                             )
                         ),
                         Execution.create(
-                            "exec-id-01",
+                            Optional.of("exec-id-01"),
                             "img2",
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED"),
@@ -152,7 +153,7 @@ public class WFIExecutionBuilderTest {
                     false,
                     Arrays.asList(
                         Execution.create(
-                            "exec-id-10",
+                            Optional.of("exec-id-10"),
                             "img3",
                             Arrays.asList(
                                 ExecStatus.create(time("09:56"), "SUBMITTED"),
@@ -161,7 +162,7 @@ public class WFIExecutionBuilderTest {
                             )
                         ),
                         Execution.create(
-                            "exec-id-11",
+                            Optional.of("exec-id-11"),
                             "img4",
                             Arrays.asList(
                                 ExecStatus.create(time("10:56"), "SUBMITTED"),
@@ -207,7 +208,7 @@ public class WFIExecutionBuilderTest {
                     false,
                     Arrays.asList(
                         Execution.create(
-                            "exec-id-00",
+                            Optional.of("exec-id-00"),
                             "img1",
                             Arrays.asList(
                                 ExecStatus.create(time("07:56"), "SUBMITTED"),
@@ -216,7 +217,7 @@ public class WFIExecutionBuilderTest {
                             )
                         ),
                         Execution.create(
-                            "exec-id-01",
+                            Optional.of("exec-id-01"),
                             "img2",
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED"),
@@ -238,15 +239,14 @@ public class WFIExecutionBuilderTest {
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
         SequenceEvent.create(E.dequeue(), c++, ts("07:55")),
         SequenceEvent.create(E.submit(desc("img1")), c++, ts("07:55")),
-        SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
-        SequenceEvent.create(E.started(), c++, ts("07:57")),
-        SequenceEvent.create(E.runError("Something failed"), c++, ts("07:58")),
+        SequenceEvent.create(E.runError("First failure"), c++, ts("07:58")),
         SequenceEvent.create(E.retryAfter(10), c++, ts("07:59")),
 
         SequenceEvent.create(E.retry(), c++, ts("08:56")),
         SequenceEvent.create(E.submit(desc("img2")), c++, ts("08:55")),
         SequenceEvent.create(E.submitted("exec-id-01"), c++, ts("08:56")),
-        SequenceEvent.create(E.started(), c++, ts("08:57"))
+        SequenceEvent.create(E.started(), c++, ts("08:57")),
+        SequenceEvent.create(E.runError("Second failure"), c++, ts("08:59"))
     );
     assertValidTransitionSequence(events);
 
@@ -262,20 +262,19 @@ public class WFIExecutionBuilderTest {
                     false,
                     Arrays.asList(
                         Execution.create(
-                            "exec-id-00",
+                            Optional.empty(),
                             "img1",
                             Arrays.asList(
-                                ExecStatus.create(time("07:56"), "SUBMITTED"),
-                                ExecStatus.create(time("07:57"), "STARTED"),
-                                ExecStatus.create(time("07:58"), "Something failed")
+                                ExecStatus.create(time("07:58"), "First failure")
                             )
                         ),
                         Execution.create(
-                            "exec-id-01",
+                            Optional.of("exec-id-01"),
                             "img2",
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED"),
-                                ExecStatus.create(time("08:57"), "STARTED")
+                                ExecStatus.create(time("08:57"), "STARTED"),
+                                ExecStatus.create(time("08:59"), "Second failure")
                             )
                         )
                     )
@@ -316,7 +315,7 @@ public class WFIExecutionBuilderTest {
                     true,
                     Collections.singletonList(
                         Execution.create(
-                            "exec-id-00",
+                            Optional.of("exec-id-00"),
                             "img1",
                             Arrays.asList(
                                 ExecStatus.create(time("07:56"), "SUBMITTED"),
@@ -331,7 +330,7 @@ public class WFIExecutionBuilderTest {
                     false,
                     Collections.singletonList(
                         Execution.create(
-                            "exec-id-10",
+                            Optional.of("exec-id-10"),
                             "img2",
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED"),

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertThat;
 import com.spotify.styx.model.WorkflowInstance;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Optional;
 import org.junit.Test;
 
 public class WorkflowInstanceExecutionDataTest {
@@ -46,7 +47,7 @@ public class WorkflowInstanceExecutionDataTest {
 
     Execution execution = OBJECT_MAPPER.readValue(json, Execution.class);
     Execution expected = Execution.create(
-        "exec-id",
+        Optional.of("exec-id"),
         "busybox:1.0",
         Arrays.asList(
             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
@@ -78,7 +79,7 @@ public class WorkflowInstanceExecutionDataTest {
         true,
         Arrays.asList(
             Execution.create(
-                "exec-id-0",
+                Optional.of("exec-id-0"),
                 "busybox:1.0",
                 Arrays.asList(
                     ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
@@ -87,7 +88,7 @@ public class WorkflowInstanceExecutionDataTest {
                 )
             ),
             Execution.create(
-                "exec-id-1",
+                Optional.of("exec-id-1"),
                 "busybox:1.1",
                 Arrays.asList(
                     ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),
@@ -150,7 +151,7 @@ public class WorkflowInstanceExecutionDataTest {
                 true,
                 Arrays.asList(
                     Execution.create(
-                        "exec-id-00",
+                        Optional.of("exec-id-00"),
                         "busybox:1.0",
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T07:56:03.607Z"), "STARTED"),
@@ -159,7 +160,7 @@ public class WorkflowInstanceExecutionDataTest {
                         )
                     ),
                     Execution.create(
-                        "exec-id-01",
+                        Optional.of("exec-id-01"),
                         "busybox:1.1",
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T08:56:03.607Z"), "STARTED"),
@@ -175,7 +176,7 @@ public class WorkflowInstanceExecutionDataTest {
                 false,
                 Arrays.asList(
                     Execution.create(
-                        "exec-id-10",
+                        Optional.of("exec-id-10"),
                         "busybox:1.2",
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
@@ -184,7 +185,7 @@ public class WorkflowInstanceExecutionDataTest {
                         )
                     ),
                     Execution.create(
-                        "exec-id-11",
+                        Optional.of("exec-id-11"),
                         "busybox:1.3",
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),

--- a/styx-common/src/test/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionDataTest.java
@@ -31,6 +31,7 @@ import com.spotify.styx.model.data.Trigger;
 import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Optional;
 import org.junit.Test;
 
 @Deprecated
@@ -51,7 +52,7 @@ public class WorkflowInstanceExecutionDataTest {
 
     Execution execution = OBJECT_MAPPER.readValue(json, Execution.class);
     Execution expected = Execution.create(
-        "exec-id",
+        Optional.of("exec-id"),
         "busybox:1.0",
         Arrays.asList(
             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
@@ -83,7 +84,7 @@ public class WorkflowInstanceExecutionDataTest {
         true,
         Arrays.asList(
             Execution.create(
-                "exec-id-0",
+                Optional.of("exec-id-0"),
                 "busybox:1.0",
                 Arrays.asList(
                     ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
@@ -92,7 +93,7 @@ public class WorkflowInstanceExecutionDataTest {
                 )
             ),
             Execution.create(
-                "exec-id-1",
+                Optional.of("exec-id-1"),
                 "busybox:1.1",
                 Arrays.asList(
                     ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),
@@ -156,7 +157,7 @@ public class WorkflowInstanceExecutionDataTest {
                 true,
                 Arrays.asList(
                     Execution.create(
-                        "exec-id-00",
+                        Optional.of("exec-id-00"),
                         "busybox:1.0",
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T07:56:03.607Z"), "STARTED"),
@@ -165,7 +166,7 @@ public class WorkflowInstanceExecutionDataTest {
                         )
                     ),
                     Execution.create(
-                        "exec-id-01",
+                        Optional.of("exec-id-01"),
                         "busybox:1.1",
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T08:56:03.607Z"), "STARTED"),
@@ -181,7 +182,7 @@ public class WorkflowInstanceExecutionDataTest {
                 false,
                 Arrays.asList(
                     Execution.create(
-                        "exec-id-10",
+                        Optional.of("exec-id-10"),
                         "busybox:1.2",
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
@@ -190,7 +191,7 @@ public class WorkflowInstanceExecutionDataTest {
                         )
                     ),
                     Execution.create(
-                        "exec-id-11",
+                        Optional.of("exec-id-11"),
                         "busybox:1.3",
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),

--- a/styx-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.apache.hadoop.hbase.client.Connection;
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,7 +86,8 @@ public class BigTableStorageTest {
 
     WorkflowInstanceExecutionData workflowInstanceExecutionData = storage.executionData(WFI1);
     assertThat(workflowInstanceExecutionData.triggers().get(0).triggerId(), is("triggerId"));
-    assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).executionId(), is("execId"));
+    assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).executionId(),
+        is(Optional.of("execId")));
     assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).dockerImage(), is("img"));
     assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).statuses().get(0), is(
         ExecStatus.create(Instant.ofEpochMilli(1L), "SUBMITTED")));
@@ -110,14 +112,16 @@ public class BigTableStorageTest {
     assertThat(workflowInstanceExecutionData.size(), is(2));
 
     assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).triggerId(), is("triggerId1"));
-    assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).executionId(), is("execId1"));
+    assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).executionId(),
+        is(Optional.of("execId1")));
     assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).dockerImage(), is("img1"));
     assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).statuses()
                    .get(0), is(ExecStatus.create(Instant.ofEpochMilli(1L), "SUBMITTED")));
     assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).statuses()
                    .get(1), is(ExecStatus.create(Instant.ofEpochMilli(2L), "STARTED")));
     assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).triggerId(), is("triggerId2"));
-    assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).executionId(), is("execId2"));
+    assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).executionId(),
+        is(Optional.of("execId2")));
     assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).dockerImage(), is("img2"));
     assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).statuses()
                    .get(0), is(ExecStatus.create(Instant.ofEpochMilli(4L), "SUBMITTED")));


### PR DESCRIPTION
Even if a `runError` event is issued before the `submitted` event, hence before the execution id is available, the `WorkflowInstanceExecutionData` now shows the related error for the failed execution. 