### PR TITLE
WFIExecutionData reports Execution even if failure happens before "submitted" event

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/model/data/ExecStatus.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/ExecStatus.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import java.time.Instant;
+import java.util.Optional;
 
 /**
  * Value representing an execution status change
@@ -37,11 +38,15 @@ public abstract class ExecStatus {
   @JsonProperty("status")
   public abstract String status();
 
+  @JsonProperty("message")
+  public abstract Optional<String> message();
+
   @JsonCreator
   public static ExecStatus create(
       @JsonProperty("timestamp") Instant timestamp,
-      @JsonProperty("status") String status
+      @JsonProperty("status") String status,
+      @JsonProperty("message") Optional<String> message
   ) {
-    return new AutoValue_ExecStatus(timestamp, status);
+    return new AutoValue_ExecStatus(timestamp, status, message);
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/model/data/Execution.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/Execution.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Value representing an execution attempt
@@ -32,18 +33,18 @@ import java.util.List;
 public abstract class Execution {
 
   @JsonProperty
-  public abstract String executionId();
+  public abstract Optional<String> executionId();
 
   @JsonProperty
-  public abstract String dockerImage();
+  public abstract Optional<String> dockerImage();
 
   @JsonProperty
   public abstract List<ExecStatus> statuses();
 
   @JsonCreator
   public static Execution create(
-      @JsonProperty("execution_id") String executionId,
-      @JsonProperty("docker_image") String dockerImage,
+      @JsonProperty("execution_id") Optional<String> executionId,
+      @JsonProperty("docker_image") Optional<String> dockerImage,
       @JsonProperty("statuses") List<ExecStatus> statuses) {
     return new AutoValue_Execution(executionId, dockerImage, statuses);
   }

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -49,10 +49,11 @@ class WFIExecutionBuilder {
   private Instant eventTs;
 
   private void closeExecution() {
-    if (currExecutionId != null && currDockerImg != null) {
-      Execution execution = Execution.create(currExecutionId, currDockerImg, executionStatusList);
-      executionList.add(execution);
-    }
+    Execution execution = Execution.create(
+        Optional.ofNullable(currExecutionId),
+        Optional.ofNullable(currDockerImg),
+        executionStatusList);
+    executionList.add(execution);
 
     executionStatusList = new ArrayList<>();
     currExecutionId = null;

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -148,7 +148,7 @@ class WFIExecutionBuilder {
     public Void terminate(WorkflowInstance workflowInstance, Optional<Integer> exitCode) {
       currWorkflowInstance = workflowInstance;
 
-      String status = exitCode.map(c -> {
+      final String status = exitCode.map(c -> {
         if (c == 0) {
           return "SUCCESS";
         } else if (c == RunState.MISSING_DEPS_EXIT_CODE) {
@@ -158,7 +158,16 @@ class WFIExecutionBuilder {
         }
       }).orElse("FAILED");
 
-      executionStatusList.add(ExecStatus.create(eventTs, status, Optional.empty()));
+      final Optional<String> message;
+      if (status.equals("FAILED")) {
+        message = exitCode
+            .map(c -> Optional.of("Exit code: " + c))
+            .orElseGet(() -> Optional.of("Exit code unknown"));
+      } else {
+        message = Optional.empty();
+      }
+
+      executionStatusList.add(ExecStatus.create(eventTs, status, message));
 
       closeExecution();
       return null;

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -49,7 +49,7 @@ class WFIExecutionBuilder {
   private Instant eventTs;
 
   private void closeExecution() {
-    Execution execution = Execution.create(
+    final Execution execution = Execution.create(
         Optional.ofNullable(currExecutionId),
         Optional.ofNullable(currDockerImg),
         executionStatusList);
@@ -65,7 +65,7 @@ class WFIExecutionBuilder {
       closeExecution();
     }
 
-    Trigger trigger = Trigger.create(currTriggerId, triggerTs, completed, executionList);
+    final Trigger trigger = Trigger.create(currTriggerId, triggerTs, completed, executionList);
 
     triggerList.add(trigger);
     executionList = new ArrayList<>();
@@ -162,7 +162,7 @@ class WFIExecutionBuilder {
       if (status.equals("FAILED")) {
         message = exitCode
             .map(c -> Optional.of("Exit code: " + c))
-            .orElseGet(() -> Optional.of("Exit code unknown"));
+            .orElse(Optional.of("Exit code unknown"));
       } else {
         message = Optional.empty();
       }
@@ -177,7 +177,7 @@ class WFIExecutionBuilder {
     public Void runError(WorkflowInstance workflowInstance, String message) {
       currWorkflowInstance = workflowInstance;
 
-      executionStatusList.add(ExecStatus.create(eventTs, "FAILED", Optional.of(message)));
+      executionStatusList.add(ExecStatus.create(eventTs, "FAILED", Optional.ofNullable(message)));
 
       closeExecution();
       return null;

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -177,7 +177,7 @@ class WFIExecutionBuilder {
     public Void runError(WorkflowInstance workflowInstance, String message) {
       currWorkflowInstance = workflowInstance;
 
-      executionStatusList.add(ExecStatus.create(eventTs, message, Optional.empty()));
+      executionStatusList.add(ExecStatus.create(eventTs, "FAILED", Optional.of(message)));
 
       closeExecution();
       return null;

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -113,7 +113,7 @@ class WFIExecutionBuilder {
       currExecutionId = executionId;
       currDockerImg = dockerImage;
 
-      executionStatusList.add(ExecStatus.create(eventTs, "SUBMITTED"));
+      executionStatusList.add(ExecStatus.create(eventTs, "SUBMITTED", Optional.empty()));
       return null;
     }
 
@@ -132,7 +132,7 @@ class WFIExecutionBuilder {
       currWorkflowInstance = workflowInstance;
       currExecutionId = executionId;
 
-      executionStatusList.add(ExecStatus.create(eventTs, "SUBMITTED"));
+      executionStatusList.add(ExecStatus.create(eventTs, "SUBMITTED", Optional.empty()));
       return null;
     }
 
@@ -140,7 +140,7 @@ class WFIExecutionBuilder {
     public Void started(WorkflowInstance workflowInstance) {
       currWorkflowInstance = workflowInstance;
 
-      executionStatusList.add(ExecStatus.create(eventTs, "STARTED"));
+      executionStatusList.add(ExecStatus.create(eventTs, "STARTED", Optional.empty()));
       return null;
     }
 
@@ -158,7 +158,7 @@ class WFIExecutionBuilder {
         }
       }).orElse("FAILED");
 
-      executionStatusList.add(ExecStatus.create(eventTs, status));
+      executionStatusList.add(ExecStatus.create(eventTs, status, Optional.empty()));
 
       closeExecution();
       return null;
@@ -168,7 +168,7 @@ class WFIExecutionBuilder {
     public Void runError(WorkflowInstance workflowInstance, String message) {
       currWorkflowInstance = workflowInstance;
 
-      executionStatusList.add(ExecStatus.create(eventTs, message));
+      executionStatusList.add(ExecStatus.create(eventTs, message, Optional.empty()));
 
       closeExecution();
       return null;
@@ -208,7 +208,7 @@ class WFIExecutionBuilder {
     public Void timeout(WorkflowInstance workflowInstance) {
       currWorkflowInstance = workflowInstance;
 
-      executionStatusList.add(ExecStatus.create(eventTs, "TIMEOUT"));
+      executionStatusList.add(ExecStatus.create(eventTs, "TIMEOUT", Optional.empty()));
 
       closeExecution();
       return null;
@@ -219,7 +219,7 @@ class WFIExecutionBuilder {
       currWorkflowInstance = workflowInstance;
       completed = true;
 
-      executionStatusList.add(ExecStatus.create(eventTs, "HALTED"));
+      executionStatusList.add(ExecStatus.create(eventTs, "HALTED", Optional.empty()));
 
       closeTrigger();
       return null;

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
@@ -36,6 +36,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 
 public class WFIExecutionBuilderTest {
@@ -56,11 +57,11 @@ public class WFIExecutionBuilderTest {
   }
 
   @Test
-  public void testHaltEventDoesNotRequireExecutionAndGoesStraightToComplete() throws Exception {
+  public void testHaltEventAfterTriggerEvent() throws Exception {
     long c = 0L;
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
-        SequenceEvent.create(E.halt(), c++, ts("07:55"))
+        SequenceEvent.create(E.halt(), c++, ts("07:56"))
     );
     assertValidTransitionSequence(events);
     WorkflowInstanceExecutionData workflowInstanceExecutionData =
@@ -73,7 +74,49 @@ public class WFIExecutionBuilderTest {
                     "trig0",
                     time("07:55"),
                     true,
-                    Collections.emptyList()
+                    Arrays.asList(
+                        Execution.create(
+                            Optional.empty(),
+                            Optional.empty(),
+                            Arrays.asList(
+                                ExecStatus.create(time("07:56"), "HALTED")
+                            )
+                        )
+                    )
+                )
+            )
+        );
+
+    assertThat(workflowInstanceExecutionData, is(expected));
+  }
+
+  @Test
+  public void testRunErrorEventAfterTriggerEvent() throws Exception {
+    long c = 0L;
+    List<SequenceEvent> events = Arrays.asList(
+        SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
+        SequenceEvent.create(E.runError("Error message"), c++, ts("07:56"))
+    );
+    assertValidTransitionSequence(events);
+    WorkflowInstanceExecutionData workflowInstanceExecutionData =
+        new WFIExecutionBuilder().executionInfo(events);
+    WorkflowInstanceExecutionData expected =
+        WorkflowInstanceExecutionData.create(
+            WORKFLOW_INSTANCE,
+            Collections.singletonList(
+                Trigger.create(
+                    "trig0",
+                    time("07:55"),
+                    false,
+                    Arrays.asList(
+                        Execution.create(
+                            Optional.empty(),
+                            Optional.empty(),
+                            Arrays.asList(
+                                ExecStatus.create(time("07:56"), "Error message")
+                            )
+                        )
+                    )
                 )
             )
         );
@@ -127,8 +170,8 @@ public class WFIExecutionBuilderTest {
                     true,
                     Arrays.asList(
                         Execution.create(
-                            "exec-id-00",
-                            "img1",
+                            Optional.of("exec-id-00"),
+                            Optional.of("img1"),
                             Arrays.asList(
                                 ExecStatus.create(time("07:56"), "SUBMITTED"),
                                 ExecStatus.create(time("07:57"), "STARTED"),
@@ -136,8 +179,8 @@ public class WFIExecutionBuilderTest {
                             )
                         ),
                         Execution.create(
-                            "exec-id-01",
-                            "img2",
+                            Optional.of("exec-id-01"),
+                            Optional.of("img2"),
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED"),
                                 ExecStatus.create(time("08:57"), "STARTED"),
@@ -152,8 +195,8 @@ public class WFIExecutionBuilderTest {
                     false,
                     Arrays.asList(
                         Execution.create(
-                            "exec-id-10",
-                            "img3",
+                            Optional.of("exec-id-10"),
+                            Optional.of("img3"),
                             Arrays.asList(
                                 ExecStatus.create(time("09:56"), "SUBMITTED"),
                                 ExecStatus.create(time("09:57"), "STARTED"),
@@ -161,8 +204,8 @@ public class WFIExecutionBuilderTest {
                             )
                         ),
                         Execution.create(
-                            "exec-id-11",
-                            "img4",
+                            Optional.of("exec-id-11"),
+                            Optional.of("img4"),
                             Arrays.asList(
                                 ExecStatus.create(time("10:56"), "SUBMITTED"),
                                 ExecStatus.create(time("10:57"), "STARTED")
@@ -207,8 +250,8 @@ public class WFIExecutionBuilderTest {
                     false,
                     Arrays.asList(
                         Execution.create(
-                            "exec-id-00",
-                            "img1",
+                            Optional.of("exec-id-00"),
+                            Optional.of("img1"),
                             Arrays.asList(
                                 ExecStatus.create(time("07:56"), "SUBMITTED"),
                                 ExecStatus.create(time("07:57"), "STARTED"),
@@ -216,8 +259,8 @@ public class WFIExecutionBuilderTest {
                             )
                         ),
                         Execution.create(
-                            "exec-id-01",
-                            "img2",
+                            Optional.of("exec-id-01"),
+                            Optional.of("img2"),
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED"),
                                 ExecStatus.create(time("08:57"), "STARTED")
@@ -238,15 +281,14 @@ public class WFIExecutionBuilderTest {
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
         SequenceEvent.create(E.dequeue(), c++, ts("07:55")),
         SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
-        SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
-        SequenceEvent.create(E.started(), c++, ts("07:57")),
-        SequenceEvent.create(E.runError("Something failed"), c++, ts("07:58")),
+        SequenceEvent.create(E.runError("First failure"), c++, ts("07:58")),
         SequenceEvent.create(E.retryAfter(10), c++, ts("07:59")),
 
         SequenceEvent.create(E.retry(), c++, ts("08:56")),
         SequenceEvent.create(E.submit(desc("img2"), "exec-id-01"), c++, ts("08:55")),
         SequenceEvent.create(E.submitted("exec-id-01"), c++, ts("08:56")),
-        SequenceEvent.create(E.started(), c++, ts("08:57"))
+        SequenceEvent.create(E.started(), c++, ts("08:57")),
+        SequenceEvent.create(E.runError("Second failure"), c++, ts("08:59"))
     );
     assertValidTransitionSequence(events);
 
@@ -262,20 +304,19 @@ public class WFIExecutionBuilderTest {
                     false,
                     Arrays.asList(
                         Execution.create(
-                            "exec-id-00",
-                            "img1",
+                            Optional.of("exec-id-00"),
+                            Optional.of("img1"),
                             Arrays.asList(
-                                ExecStatus.create(time("07:56"), "SUBMITTED"),
-                                ExecStatus.create(time("07:57"), "STARTED"),
-                                ExecStatus.create(time("07:58"), "Something failed")
+                                ExecStatus.create(time("07:58"), "First failure")
                             )
                         ),
                         Execution.create(
-                            "exec-id-01",
-                            "img2",
+                            Optional.of("exec-id-01"),
+                            Optional.of("img2"),
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED"),
-                                ExecStatus.create(time("08:57"), "STARTED")
+                                ExecStatus.create(time("08:57"), "STARTED"),
+                                ExecStatus.create(time("08:59"), "Second failure")
                             )
                         )
                     )
@@ -316,8 +357,8 @@ public class WFIExecutionBuilderTest {
                     true,
                     Collections.singletonList(
                         Execution.create(
-                            "exec-id-00",
-                            "img1",
+                            Optional.of("exec-id-00"),
+                            Optional.of("img1"),
                             Arrays.asList(
                                 ExecStatus.create(time("07:56"), "SUBMITTED"),
                                 ExecStatus.create(time("07:57"), "HALTED")
@@ -331,8 +372,8 @@ public class WFIExecutionBuilderTest {
                     false,
                     Collections.singletonList(
                         Execution.create(
-                            "exec-id-10",
-                            "img2",
+                            Optional.of("exec-id-10"),
+                            Optional.of("img2"),
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED"),
                                 ExecStatus.create(time("08:57"), "STARTED")

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
@@ -79,7 +79,7 @@ public class WFIExecutionBuilderTest {
                             Optional.empty(),
                             Optional.empty(),
                             Arrays.asList(
-                                ExecStatus.create(time("07:56"), "HALTED")
+                                ExecStatus.create(time("07:56"), "HALTED", Optional.empty())
                             )
                         )
                     )
@@ -113,7 +113,7 @@ public class WFIExecutionBuilderTest {
                             Optional.empty(),
                             Optional.empty(),
                             Arrays.asList(
-                                ExecStatus.create(time("07:56"), "Error message")
+                                ExecStatus.create(time("07:56"), "Error message", Optional.empty())
                             )
                         )
                     )
@@ -173,18 +173,18 @@ public class WFIExecutionBuilderTest {
                             Optional.of("exec-id-00"),
                             Optional.of("img1"),
                             Arrays.asList(
-                                ExecStatus.create(time("07:56"), "SUBMITTED"),
-                                ExecStatus.create(time("07:57"), "STARTED"),
-                                ExecStatus.create(time("07:58"), "MISSING_DEPS")
+                                ExecStatus.create(time("07:56"), "SUBMITTED", Optional.empty()),
+                                ExecStatus.create(time("07:57"), "STARTED", Optional.empty()),
+                                ExecStatus.create(time("07:58"), "MISSING_DEPS", Optional.empty())
                             )
                         ),
                         Execution.create(
                             Optional.of("exec-id-01"),
                             Optional.of("img2"),
                             Arrays.asList(
-                                ExecStatus.create(time("08:56"), "SUBMITTED"),
-                                ExecStatus.create(time("08:57"), "STARTED"),
-                                ExecStatus.create(time("08:58"), "SUCCESS")
+                                ExecStatus.create(time("08:56"), "SUBMITTED", Optional.empty()),
+                                ExecStatus.create(time("08:57"), "STARTED", Optional.empty()),
+                                ExecStatus.create(time("08:58"), "SUCCESS", Optional.empty())
                             )
                         )
                     )
@@ -198,17 +198,17 @@ public class WFIExecutionBuilderTest {
                             Optional.of("exec-id-10"),
                             Optional.of("img3"),
                             Arrays.asList(
-                                ExecStatus.create(time("09:56"), "SUBMITTED"),
-                                ExecStatus.create(time("09:57"), "STARTED"),
-                                ExecStatus.create(time("09:58"), "FAILED")
+                                ExecStatus.create(time("09:56"), "SUBMITTED", Optional.empty()),
+                                ExecStatus.create(time("09:57"), "STARTED", Optional.empty()),
+                                ExecStatus.create(time("09:58"), "FAILED", Optional.empty())
                             )
                         ),
                         Execution.create(
                             Optional.of("exec-id-11"),
                             Optional.of("img4"),
                             Arrays.asList(
-                                ExecStatus.create(time("10:56"), "SUBMITTED"),
-                                ExecStatus.create(time("10:57"), "STARTED")
+                                ExecStatus.create(time("10:56"), "SUBMITTED", Optional.empty()),
+                                ExecStatus.create(time("10:57"), "STARTED", Optional.empty())
                             )
                         )
                     )
@@ -253,17 +253,17 @@ public class WFIExecutionBuilderTest {
                             Optional.of("exec-id-00"),
                             Optional.of("img1"),
                             Arrays.asList(
-                                ExecStatus.create(time("07:56"), "SUBMITTED"),
-                                ExecStatus.create(time("07:57"), "STARTED"),
-                                ExecStatus.create(time("07:58"), "TIMEOUT")
+                                ExecStatus.create(time("07:56"), "SUBMITTED", Optional.empty()),
+                                ExecStatus.create(time("07:57"), "STARTED", Optional.empty()),
+                                ExecStatus.create(time("07:58"), "TIMEOUT", Optional.empty())
                             )
                         ),
                         Execution.create(
                             Optional.of("exec-id-01"),
                             Optional.of("img2"),
                             Arrays.asList(
-                                ExecStatus.create(time("08:56"), "SUBMITTED"),
-                                ExecStatus.create(time("08:57"), "STARTED")
+                                ExecStatus.create(time("08:56"), "SUBMITTED", Optional.empty()),
+                                ExecStatus.create(time("08:57"), "STARTED", Optional.empty())
                             )
                         )
                     )
@@ -307,16 +307,16 @@ public class WFIExecutionBuilderTest {
                             Optional.of("exec-id-00"),
                             Optional.of("img1"),
                             Arrays.asList(
-                                ExecStatus.create(time("07:58"), "First failure")
+                                ExecStatus.create(time("07:58"), "First failure", Optional.empty())
                             )
                         ),
                         Execution.create(
                             Optional.of("exec-id-01"),
                             Optional.of("img2"),
                             Arrays.asList(
-                                ExecStatus.create(time("08:56"), "SUBMITTED"),
-                                ExecStatus.create(time("08:57"), "STARTED"),
-                                ExecStatus.create(time("08:59"), "Second failure")
+                                ExecStatus.create(time("08:56"), "SUBMITTED", Optional.empty()),
+                                ExecStatus.create(time("08:57"), "STARTED", Optional.empty()),
+                                ExecStatus.create(time("08:59"), "Second failure", Optional.empty())
                             )
                         )
                     )
@@ -360,8 +360,8 @@ public class WFIExecutionBuilderTest {
                             Optional.of("exec-id-00"),
                             Optional.of("img1"),
                             Arrays.asList(
-                                ExecStatus.create(time("07:56"), "SUBMITTED"),
-                                ExecStatus.create(time("07:57"), "HALTED")
+                                ExecStatus.create(time("07:56"), "SUBMITTED", Optional.empty()),
+                                ExecStatus.create(time("07:57"), "HALTED", Optional.empty())
                             )
                         )
                     )
@@ -375,8 +375,8 @@ public class WFIExecutionBuilderTest {
                             Optional.of("exec-id-10"),
                             Optional.of("img2"),
                             Arrays.asList(
-                                ExecStatus.create(time("08:56"), "SUBMITTED"),
-                                ExecStatus.create(time("08:57"), "STARTED")
+                                ExecStatus.create(time("08:56"), "SUBMITTED", Optional.empty()),
+                                ExecStatus.create(time("08:57"), "STARTED", Optional.empty())
                             )
                         )
                     )

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
@@ -200,7 +200,7 @@ public class WFIExecutionBuilderTest {
                             Arrays.asList(
                                 ExecStatus.create(time("09:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("09:57"), "STARTED", Optional.empty()),
-                                ExecStatus.create(time("09:58"), "FAILED", Optional.empty())
+                                ExecStatus.create(time("09:58"), "FAILED", Optional.of("Exit code: 1"))
                             )
                         ),
                         Execution.create(
@@ -209,6 +209,47 @@ public class WFIExecutionBuilderTest {
                             Arrays.asList(
                                 ExecStatus.create(time("10:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("10:57"), "STARTED", Optional.empty())
+                            )
+                        )
+                    )
+                )
+            )
+        );
+
+    assertThat(workflowInstanceExecutionData, is(expected));
+  }
+
+  @Test
+  public void testFailureNoExitCode() throws Exception {
+    long c = 0L;
+    List<SequenceEvent> events = Arrays.asList(
+        SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
+        SequenceEvent.create(E.dequeue(), c++, ts("07:55")),
+        SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
+        SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
+        SequenceEvent.create(E.started(), c++, ts("07:57")),
+        SequenceEvent.create(E.terminate(Optional.empty()), c++, ts("07:58"))
+    );
+    assertValidTransitionSequence(events);
+
+    WorkflowInstanceExecutionData workflowInstanceExecutionData =
+        new WFIExecutionBuilder().executionInfo(events);
+    WorkflowInstanceExecutionData expected =
+        WorkflowInstanceExecutionData.create(
+            WORKFLOW_INSTANCE,
+            Arrays.asList(
+                Trigger.create(
+                    "trig0",
+                    time("07:55"),
+                    false,
+                    Arrays.asList(
+                        Execution.create(
+                            Optional.of("exec-id-00"),
+                            Optional.of("img1"),
+                            Arrays.asList(
+                                ExecStatus.create(time("07:56"), "SUBMITTED", Optional.empty()),
+                                ExecStatus.create(time("07:57"), "STARTED", Optional.empty()),
+                                ExecStatus.create(time("07:58"), "FAILED", Optional.of("Exit code unknown"))
                             )
                         )
                     )

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
@@ -113,7 +113,7 @@ public class WFIExecutionBuilderTest {
                             Optional.empty(),
                             Optional.empty(),
                             Arrays.asList(
-                                ExecStatus.create(time("07:56"), "Error message", Optional.empty())
+                                ExecStatus.create(time("07:56"), "FAILED", Optional.of("Error message"))
                             )
                         )
                     )
@@ -348,7 +348,7 @@ public class WFIExecutionBuilderTest {
                             Optional.of("exec-id-00"),
                             Optional.of("img1"),
                             Arrays.asList(
-                                ExecStatus.create(time("07:58"), "First failure", Optional.empty())
+                                ExecStatus.create(time("07:58"), "FAILED", Optional.of("First failure"))
                             )
                         ),
                         Execution.create(
@@ -357,7 +357,7 @@ public class WFIExecutionBuilderTest {
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("08:57"), "STARTED", Optional.empty()),
-                                ExecStatus.create(time("08:59"), "Second failure", Optional.empty())
+                                ExecStatus.create(time("08:59"), "FAILED", Optional.of("Second failure"))
                             )
                         )
                     )

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
@@ -50,9 +50,9 @@ public class WorkflowInstanceExecutionDataTest {
         Optional.of("exec-id"),
         Optional.of("busybox:1.0"),
         Arrays.asList(
-            ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
-            ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
-            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "SUCCESS")
+            ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
+            ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
+            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "SUCCESS", Optional.empty())
         )
     );
     assertThat(execution, is(expected));
@@ -70,7 +70,7 @@ public class WorkflowInstanceExecutionDataTest {
         Optional.empty(),
         Optional.empty(),
         Arrays.asList(
-            ExecStatus.create(Instant.parse("2016-08-03T16:56:03.607Z"), "Error encountered")
+            ExecStatus.create(Instant.parse("2016-08-03T16:56:03.607Z"), "Error encountered", Optional.empty())
         )
     );
     assertThat(execution, is(expected));
@@ -100,18 +100,18 @@ public class WorkflowInstanceExecutionDataTest {
                 Optional.of("exec-id-0"),
                 Optional.of("busybox:1.0"),
                 Arrays.asList(
-                    ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
-                    ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
-                    ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED")
+                    ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
+                    ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
+                    ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED", Optional.empty())
                 )
             ),
             Execution.create(
                 Optional.of("exec-id-1"),
                 Optional.of("busybox:1.1"),
                 Arrays.asList(
-                    ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),
-                    ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING"),
-                    ExecStatus.create(Instant.parse("2016-08-03T10:58:03.607Z"), "SUCCESS")
+                    ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED", Optional.empty()),
+                    ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING", Optional.empty()),
+                    ExecStatus.create(Instant.parse("2016-08-03T10:58:03.607Z"), "SUCCESS", Optional.empty())
                 )
             )
         )
@@ -172,18 +172,18 @@ public class WorkflowInstanceExecutionDataTest {
                         Optional.of("exec-id-00"),
                         Optional.of("busybox:1.0"),
                         Arrays.asList(
-                            ExecStatus.create(Instant.parse("2016-08-03T07:56:03.607Z"), "STARTED"),
-                            ExecStatus.create(Instant.parse("2016-08-03T07:57:03.607Z"), "RUNNING"),
-                            ExecStatus.create(Instant.parse("2016-08-03T07:58:03.607Z"), "FAILED")
+                            ExecStatus.create(Instant.parse("2016-08-03T07:56:03.607Z"), "STARTED", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T07:57:03.607Z"), "RUNNING", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T07:58:03.607Z"), "FAILED", Optional.empty())
                         )
                     ),
                     Execution.create(
                         Optional.of("exec-id-01"),
                         Optional.of("busybox:1.1"),
                         Arrays.asList(
-                            ExecStatus.create(Instant.parse("2016-08-03T08:56:03.607Z"), "STARTED"),
-                            ExecStatus.create(Instant.parse("2016-08-03T08:57:03.607Z"), "RUNNING"),
-                            ExecStatus.create(Instant.parse("2016-08-03T08:58:03.607Z"), "SUCCESS")
+                            ExecStatus.create(Instant.parse("2016-08-03T08:56:03.607Z"), "STARTED", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T08:57:03.607Z"), "RUNNING", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T08:58:03.607Z"), "SUCCESS", Optional.empty())
                         )
                     )
                 )
@@ -197,18 +197,18 @@ public class WorkflowInstanceExecutionDataTest {
                         Optional.of("exec-id-10"),
                         Optional.of("busybox:1.2"),
                         Arrays.asList(
-                            ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
-                            ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
-                            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED")
+                            ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED", Optional.empty())
                         )
                     ),
                     Execution.create(
                         Optional.of("exec-id-11"),
                         Optional.of("busybox:1.3"),
                         Arrays.asList(
-                            ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),
-                            ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING"),
-                            ExecStatus.create(Instant.parse("2016-08-03T10:58:03.607Z"), "SUCCESS")
+                            ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T10:58:03.607Z"), "SUCCESS", Optional.empty())
                         )
                     )
                 )

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
@@ -221,7 +221,7 @@ public class WorkflowInstanceExecutionDataTest {
 
   private String statusJson(String time, String status, Optional<String> message) {
     final String baseJson = "{\"timestamp\":\"2016-08-03T" + time + ":03.607Z\", \"status\":\"" + status + "\"";
-    return message.map(s -> baseJson + ", \"message\":\"" + s + "\"}").orElseGet(() -> baseJson + "}");
+    return message.map(s -> baseJson + ", \"message\":\"" + s + "\"}").orElse(baseJson + "}");
   }
 
   private String executionJson(String id, String image, String hour, String endStatus, Optional<String> endMessage) {

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
@@ -34,7 +34,7 @@ public class WorkflowInstanceExecutionDataTest {
 
   @Test
   public void shouldDeserializeExecStatus() throws Exception {
-    String json = statusJson("09:56", "STARTED");
+    String json = statusJson("09:56", "STARTED", Optional.empty());
     ExecStatus executionStatus = OBJECT_MAPPER.readValue(json, ExecStatus.class);
 
     assertThat(executionStatus.timestamp(), is(Instant.parse("2016-08-03T09:56:03.607Z")));
@@ -43,7 +43,7 @@ public class WorkflowInstanceExecutionDataTest {
 
   @Test
   public void shouldDeserializeExecution() throws Exception {
-    String json = executionJson("exec-id", "busybox:1.0", "09", "SUCCESS");
+    String json = executionJson("exec-id", "busybox:1.0", "09", "SUCCESS", Optional.empty());
 
     Execution execution = OBJECT_MAPPER.readValue(json, Execution.class);
     Execution expected = Execution.create(
@@ -62,7 +62,7 @@ public class WorkflowInstanceExecutionDataTest {
   public void shouldDeserializeExecutionNoOptionalFields() throws Exception {
     String json = "{"
                   + "\"statuses\":["
-                  + statusJson("16:56", "Error encountered")
+                  + statusJson("16:56", "HALTED", Optional.empty())
                   + "]}";
 
     Execution execution = OBJECT_MAPPER.readValue(json, Execution.class);
@@ -70,7 +70,7 @@ public class WorkflowInstanceExecutionDataTest {
         Optional.empty(),
         Optional.empty(),
         Arrays.asList(
-            ExecStatus.create(Instant.parse("2016-08-03T16:56:03.607Z"), "Error encountered", Optional.empty())
+            ExecStatus.create(Instant.parse("2016-08-03T16:56:03.607Z"), "HALTED", Optional.empty())
         )
     );
     assertThat(execution, is(expected));
@@ -78,8 +78,8 @@ public class WorkflowInstanceExecutionDataTest {
 
   @Test
   public void shouldDeserializeTrigger() throws Exception {
-    String jsonExec0 = executionJson("exec-id-0", "busybox:1.0", "09", "FAILED");
-    String jsonExec1 = executionJson("exec-id-1", "busybox:1.1", "10", "SUCCESS");
+    String jsonExec0 = executionJson("exec-id-0", "busybox:1.0", "09", "FAILED", Optional.of("Exit code 1"));
+    String jsonExec1 = executionJson("exec-id-1", "busybox:1.1", "10", "SUCCESS", Optional.empty());
 
     String json =
         "{"
@@ -102,7 +102,7 @@ public class WorkflowInstanceExecutionDataTest {
                 Arrays.asList(
                     ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
                     ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
-                    ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED", Optional.empty())
+                    ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED", Optional.of("Exit code 1"))
                 )
             ),
             Execution.create(
@@ -121,8 +121,8 @@ public class WorkflowInstanceExecutionDataTest {
 
   @Test
   public void shouldDeserializeExecutionData() throws Exception {
-    String jsonExec00 = executionJson("exec-id-00", "busybox:1.0", "07", "FAILED");
-    String jsonExec01 = executionJson("exec-id-01", "busybox:1.1", "08", "SUCCESS");
+    String jsonExec00 = executionJson("exec-id-00", "busybox:1.0", "07", "FAILED", Optional.of("Exit code 1"));
+    String jsonExec01 = executionJson("exec-id-01", "busybox:1.1", "08", "SUCCESS", Optional.empty());
 
     String jsonTrigger0 =
         "{"
@@ -133,8 +133,8 @@ public class WorkflowInstanceExecutionDataTest {
         + jsonExec00 + "," + jsonExec01
         + "]}";
 
-    String jsonExec10 = executionJson("exec-id-10", "busybox:1.2", "09", "FAILED");
-    String jsonExec11 = executionJson("exec-id-11", "busybox:1.3", "10", "SUCCESS");
+    String jsonExec10 = executionJson("exec-id-10", "busybox:1.2", "09", "FAILED", Optional.of("Exit code 1"));
+    String jsonExec11 = executionJson("exec-id-11", "busybox:1.3", "10", "SUCCESS", Optional.empty());
 
     String jsonTrigger1 =
         "{"
@@ -174,7 +174,7 @@ public class WorkflowInstanceExecutionDataTest {
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T07:56:03.607Z"), "STARTED", Optional.empty()),
                             ExecStatus.create(Instant.parse("2016-08-03T07:57:03.607Z"), "RUNNING", Optional.empty()),
-                            ExecStatus.create(Instant.parse("2016-08-03T07:58:03.607Z"), "FAILED", Optional.empty())
+                            ExecStatus.create(Instant.parse("2016-08-03T07:58:03.607Z"), "FAILED", Optional.of("Exit code 1"))
                         )
                     ),
                     Execution.create(
@@ -199,7 +199,7 @@ public class WorkflowInstanceExecutionDataTest {
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
                             ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
-                            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED", Optional.empty())
+                            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED", Optional.of("Exit code 1"))
                         )
                     ),
                     Execution.create(
@@ -219,14 +219,15 @@ public class WorkflowInstanceExecutionDataTest {
     assertThat(executionData, is(expected));
   }
 
-  private String statusJson(String time, String status) {
-    return "{\"timestamp\":\"2016-08-03T" + time + ":03.607Z\", \"status\":\"" + status + "\"}";
+  private String statusJson(String time, String status, Optional<String> message) {
+    final String baseJson = "{\"timestamp\":\"2016-08-03T" + time + ":03.607Z\", \"status\":\"" + status + "\"";
+    return message.map(s -> baseJson + ", \"message\":\"" + s + "\"}").orElseGet(() -> baseJson + "}");
   }
 
-  private String executionJson(String id, String image, String hour, String endStatus) {
-    String jsonStatus1 = statusJson(hour + ":56", "STARTED");
-    String jsonStatus2 = statusJson(hour + ":57", "RUNNING");
-    String jsonStatus3 = statusJson(hour + ":58", endStatus);
+  private String executionJson(String id, String image, String hour, String endStatus, Optional<String> endMessage) {
+    String jsonStatus1 = statusJson(hour + ":56", "STARTED", Optional.empty());
+    String jsonStatus2 = statusJson(hour + ":57", "RUNNING", Optional.empty());
+    String jsonStatus3 = statusJson(hour + ":58", endStatus, endMessage);
 
     return
         "{"

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertThat;
 import com.spotify.styx.model.WorkflowInstance;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Optional;
 import org.junit.Test;
 
 public class WorkflowInstanceExecutionDataTest {
@@ -46,12 +47,30 @@ public class WorkflowInstanceExecutionDataTest {
 
     Execution execution = OBJECT_MAPPER.readValue(json, Execution.class);
     Execution expected = Execution.create(
-        "exec-id",
-        "busybox:1.0",
+        Optional.of("exec-id"),
+        Optional.of("busybox:1.0"),
         Arrays.asList(
             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
             ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
             ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "SUCCESS")
+        )
+    );
+    assertThat(execution, is(expected));
+  }
+
+  @Test
+  public void shouldDeserializeExecutionNoOptionalFields() throws Exception {
+    String json = "{"
+                  + "\"statuses\":["
+                  + statusJson("16:56", "Error encountered")
+                  + "]}";
+
+    Execution execution = OBJECT_MAPPER.readValue(json, Execution.class);
+    Execution expected = Execution.create(
+        Optional.empty(),
+        Optional.empty(),
+        Arrays.asList(
+            ExecStatus.create(Instant.parse("2016-08-03T16:56:03.607Z"), "Error encountered")
         )
     );
     assertThat(execution, is(expected));
@@ -78,8 +97,8 @@ public class WorkflowInstanceExecutionDataTest {
         true,
         Arrays.asList(
             Execution.create(
-                "exec-id-0",
-                "busybox:1.0",
+                Optional.of("exec-id-0"),
+                Optional.of("busybox:1.0"),
                 Arrays.asList(
                     ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
                     ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
@@ -87,8 +106,8 @@ public class WorkflowInstanceExecutionDataTest {
                 )
             ),
             Execution.create(
-                "exec-id-1",
-                "busybox:1.1",
+                Optional.of("exec-id-1"),
+                Optional.of("busybox:1.1"),
                 Arrays.asList(
                     ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),
                     ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING"),
@@ -150,8 +169,8 @@ public class WorkflowInstanceExecutionDataTest {
                 true,
                 Arrays.asList(
                     Execution.create(
-                        "exec-id-00",
-                        "busybox:1.0",
+                        Optional.of("exec-id-00"),
+                        Optional.of("busybox:1.0"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T07:56:03.607Z"), "STARTED"),
                             ExecStatus.create(Instant.parse("2016-08-03T07:57:03.607Z"), "RUNNING"),
@@ -159,8 +178,8 @@ public class WorkflowInstanceExecutionDataTest {
                         )
                     ),
                     Execution.create(
-                        "exec-id-01",
-                        "busybox:1.1",
+                        Optional.of("exec-id-01"),
+                        Optional.of("busybox:1.1"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T08:56:03.607Z"), "STARTED"),
                             ExecStatus.create(Instant.parse("2016-08-03T08:57:03.607Z"), "RUNNING"),
@@ -175,8 +194,8 @@ public class WorkflowInstanceExecutionDataTest {
                 false,
                 Arrays.asList(
                     Execution.create(
-                        "exec-id-10",
-                        "busybox:1.2",
+                        Optional.of("exec-id-10"),
+                        Optional.of("busybox:1.2"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
                             ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
@@ -184,8 +203,8 @@ public class WorkflowInstanceExecutionDataTest {
                         )
                     ),
                     Execution.create(
-                        "exec-id-11",
-                        "busybox:1.3",
+                        Optional.of("exec-id-11"),
+                        Optional.of("busybox:1.3"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),
                             ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING"),

--- a/styx-common/src/test/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionDataTest.java
@@ -24,11 +24,11 @@ import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.data.ExecStatus;
 import com.spotify.styx.model.data.Execution;
 import com.spotify.styx.model.data.Trigger;
-import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
+import com.spotify.styx.model.deprecated.WorkflowId;
+import com.spotify.styx.model.deprecated.WorkflowInstance;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
@@ -38,78 +38,9 @@ import org.junit.Test;
 public class WorkflowInstanceExecutionDataTest {
 
   @Test
-  public void shouldDeserializeExecStatus() throws Exception {
-    String json = statusJson("09:56", "STARTED");
-    ExecStatus executionStatus = OBJECT_MAPPER.readValue(json, ExecStatus.class);
-
-    assertThat(executionStatus.timestamp(), is(Instant.parse("2016-08-03T09:56:03.607Z")));
-    assertThat(executionStatus.status(), is("STARTED"));
-  }
-
-  @Test
-  public void shouldDeserializeExecution() throws Exception {
-    String json = executionJson("exec-id", "busybox:1.0", "09", "SUCCESS");
-
-    Execution execution = OBJECT_MAPPER.readValue(json, Execution.class);
-    Execution expected = Execution.create(
-        Optional.of("exec-id"),
-        Optional.of("busybox:1.0"),
-        Arrays.asList(
-            ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
-            ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
-            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "SUCCESS", Optional.empty())
-        )
-    );
-    assertThat(execution, is(expected));
-  }
-
-  @Test
-  public void shouldDeserializeTrigger() throws Exception {
-    String jsonExec0 = executionJson("exec-id-0", "busybox:1.0", "09", "FAILED");
-    String jsonExec1 = executionJson("exec-id-1", "busybox:1.1", "10", "SUCCESS");
-
-    String json =
-        "{"
-        + "\"trigger_id\":\"trig-0\","
-        + "\"timestamp\":\"" + time("07:55") + "\","
-        + "\"complete\":true,"
-        + "\"executions\":["
-        + jsonExec0 + "," + jsonExec1
-        + "]}";
-
-    Trigger trigger = OBJECT_MAPPER.readValue(json, Trigger.class);
-    Trigger expected = Trigger.create(
-        "trig-0",
-        time("07:55"),
-        true,
-        Arrays.asList(
-            Execution.create(
-                Optional.of("exec-id-0"),
-                Optional.of("busybox:1.0"),
-                Arrays.asList(
-                    ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
-                    ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
-                    ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED", Optional.empty())
-                )
-            ),
-            Execution.create(
-                Optional.of("exec-id-1"),
-                Optional.of("busybox:1.1"),
-                Arrays.asList(
-                    ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED", Optional.empty()),
-                    ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING", Optional.empty()),
-                    ExecStatus.create(Instant.parse("2016-08-03T10:58:03.607Z"), "SUCCESS", Optional.empty())
-                )
-            )
-        )
-    );
-    assertThat(trigger, is(expected));
-  }
-
-  @Test
   public void shouldDeserializeExecutionData() throws Exception {
-    String jsonExec00 = executionJson("exec-id-00", "busybox:1.0", "07", "FAILED");
-    String jsonExec01 = executionJson("exec-id-01", "busybox:1.1", "08", "SUCCESS");
+    String jsonExec00 = executionJson("exec-id-00", "busybox:1.0", "07", "FAILED", Optional.of("Exit code 1"));
+    String jsonExec01 = executionJson("exec-id-01", "busybox:1.1", "08", "SUCCESS", Optional.empty());
 
     String jsonTrigger0 =
         "{"
@@ -120,8 +51,8 @@ public class WorkflowInstanceExecutionDataTest {
         + jsonExec00 + "," + jsonExec01
         + "]}";
 
-    String jsonExec10 = executionJson("exec-id-10", "busybox:1.2", "09", "FAILED");
-    String jsonExec11 = executionJson("exec-id-11", "busybox:1.3", "10", "SUCCESS");
+    String jsonExec10 = executionJson("exec-id-10", "busybox:1.2", "09", "FAILED", Optional.of("Exit code 1"));
+    String jsonExec11 = executionJson("exec-id-11", "busybox:1.3", "10", "SUCCESS", Optional.empty());
 
     String jsonTrigger1 =
         "{"
@@ -137,7 +68,7 @@ public class WorkflowInstanceExecutionDataTest {
         + "\"workflow_instance\":{"
           + "\"workflow_id\":{"
             + "\"component_id\":\"component1\","
-            + "\"id\":\"endpoint1\""
+            + "\"endpoint_id\":\"endpoint1\""
           + "},"
           + "\"parameter\":\"2016-08-03T06\""
         + "},"
@@ -145,11 +76,11 @@ public class WorkflowInstanceExecutionDataTest {
         + jsonTrigger0 + "," + jsonTrigger1
         + "]}";
 
-    com.spotify.styx.model.data.WorkflowInstanceExecutionData
+    WorkflowInstanceExecutionData
         executionData = OBJECT_MAPPER.readValue(json, WorkflowInstanceExecutionData.class);
-    com.spotify.styx.model.data.WorkflowInstanceExecutionData
+    WorkflowInstanceExecutionData
         expected = WorkflowInstanceExecutionData.create(
-        WorkflowInstance.parseKey("component1#endpoint1#2016-08-03T06"),
+        WorkflowInstance.create(WorkflowId.create("component1", "endpoint1"), "2016-08-03T06"),
         Arrays.asList(
             Trigger.create(
                 "trig-0",
@@ -162,7 +93,7 @@ public class WorkflowInstanceExecutionDataTest {
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T07:56:03.607Z"), "STARTED", Optional.empty()),
                             ExecStatus.create(Instant.parse("2016-08-03T07:57:03.607Z"), "RUNNING", Optional.empty()),
-                            ExecStatus.create(Instant.parse("2016-08-03T07:58:03.607Z"), "FAILED", Optional.empty())
+                            ExecStatus.create(Instant.parse("2016-08-03T07:58:03.607Z"), "FAILED", Optional.of("Exit code 1"))
                         )
                     ),
                     Execution.create(
@@ -187,7 +118,7 @@ public class WorkflowInstanceExecutionDataTest {
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
                             ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
-                            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED", Optional.empty())
+                            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED", Optional.of("Exit code 1"))
                         )
                     ),
                     Execution.create(
@@ -207,14 +138,15 @@ public class WorkflowInstanceExecutionDataTest {
     assertThat(executionData, is(expected));
   }
 
-  private String statusJson(String time, String status) {
-    return "{\"timestamp\":\"2016-08-03T" + time + ":03.607Z\", \"status\":\"" + status + "\"}";
+  private String statusJson(String time, String status, Optional<String> message) {
+    final String baseJson = "{\"timestamp\":\"2016-08-03T" + time + ":03.607Z\", \"status\":\"" + status + "\"";
+    return message.map(s -> baseJson + ", \"message\":\"" + s + "\"}").orElseGet(() -> baseJson + "}");
   }
 
-  private String executionJson(String id, String image, String hour, String endStatus) {
-    String jsonStatus1 = statusJson(hour + ":56", "STARTED");
-    String jsonStatus2 = statusJson(hour + ":57", "RUNNING");
-    String jsonStatus3 = statusJson(hour + ":58", endStatus);
+  private String executionJson(String id, String image, String hour, String endStatus, Optional<String> endMessage) {
+    String jsonStatus1 = statusJson(hour + ":56", "STARTED", Optional.empty());
+    String jsonStatus2 = statusJson(hour + ":57", "RUNNING", Optional.empty());
+    String jsonStatus3 = statusJson(hour + ":58", endStatus, endMessage);
 
     return
         "{"

--- a/styx-common/src/test/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionDataTest.java
@@ -31,6 +31,7 @@ import com.spotify.styx.model.data.Trigger;
 import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Optional;
 import org.junit.Test;
 
 @Deprecated
@@ -51,8 +52,8 @@ public class WorkflowInstanceExecutionDataTest {
 
     Execution execution = OBJECT_MAPPER.readValue(json, Execution.class);
     Execution expected = Execution.create(
-        "exec-id",
-        "busybox:1.0",
+        Optional.of("exec-id"),
+        Optional.of("busybox:1.0"),
         Arrays.asList(
             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
             ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
@@ -83,8 +84,8 @@ public class WorkflowInstanceExecutionDataTest {
         true,
         Arrays.asList(
             Execution.create(
-                "exec-id-0",
-                "busybox:1.0",
+                Optional.of("exec-id-0"),
+                Optional.of("busybox:1.0"),
                 Arrays.asList(
                     ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
                     ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
@@ -92,8 +93,8 @@ public class WorkflowInstanceExecutionDataTest {
                 )
             ),
             Execution.create(
-                "exec-id-1",
-                "busybox:1.1",
+                Optional.of("exec-id-1"),
+                Optional.of("busybox:1.1"),
                 Arrays.asList(
                     ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),
                     ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING"),
@@ -156,8 +157,8 @@ public class WorkflowInstanceExecutionDataTest {
                 true,
                 Arrays.asList(
                     Execution.create(
-                        "exec-id-00",
-                        "busybox:1.0",
+                        Optional.of("exec-id-00"),
+                        Optional.of("busybox:1.0"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T07:56:03.607Z"), "STARTED"),
                             ExecStatus.create(Instant.parse("2016-08-03T07:57:03.607Z"), "RUNNING"),
@@ -165,8 +166,8 @@ public class WorkflowInstanceExecutionDataTest {
                         )
                     ),
                     Execution.create(
-                        "exec-id-01",
-                        "busybox:1.1",
+                        Optional.of("exec-id-01"),
+                        Optional.of("busybox:1.1"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T08:56:03.607Z"), "STARTED"),
                             ExecStatus.create(Instant.parse("2016-08-03T08:57:03.607Z"), "RUNNING"),
@@ -181,8 +182,8 @@ public class WorkflowInstanceExecutionDataTest {
                 false,
                 Arrays.asList(
                     Execution.create(
-                        "exec-id-10",
-                        "busybox:1.2",
+                        Optional.of("exec-id-10"),
+                        Optional.of("busybox:1.2"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
                             ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
@@ -190,8 +191,8 @@ public class WorkflowInstanceExecutionDataTest {
                         )
                     ),
                     Execution.create(
-                        "exec-id-11",
-                        "busybox:1.3",
+                        Optional.of("exec-id-11"),
+                        Optional.of("busybox:1.3"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),
                             ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING"),

--- a/styx-common/src/test/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionDataTest.java
@@ -55,9 +55,9 @@ public class WorkflowInstanceExecutionDataTest {
         Optional.of("exec-id"),
         Optional.of("busybox:1.0"),
         Arrays.asList(
-            ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
-            ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
-            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "SUCCESS")
+            ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
+            ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
+            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "SUCCESS", Optional.empty())
         )
     );
     assertThat(execution, is(expected));
@@ -87,18 +87,18 @@ public class WorkflowInstanceExecutionDataTest {
                 Optional.of("exec-id-0"),
                 Optional.of("busybox:1.0"),
                 Arrays.asList(
-                    ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
-                    ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
-                    ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED")
+                    ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
+                    ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
+                    ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED", Optional.empty())
                 )
             ),
             Execution.create(
                 Optional.of("exec-id-1"),
                 Optional.of("busybox:1.1"),
                 Arrays.asList(
-                    ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),
-                    ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING"),
-                    ExecStatus.create(Instant.parse("2016-08-03T10:58:03.607Z"), "SUCCESS")
+                    ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED", Optional.empty()),
+                    ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING", Optional.empty()),
+                    ExecStatus.create(Instant.parse("2016-08-03T10:58:03.607Z"), "SUCCESS", Optional.empty())
                 )
             )
         )
@@ -160,18 +160,18 @@ public class WorkflowInstanceExecutionDataTest {
                         Optional.of("exec-id-00"),
                         Optional.of("busybox:1.0"),
                         Arrays.asList(
-                            ExecStatus.create(Instant.parse("2016-08-03T07:56:03.607Z"), "STARTED"),
-                            ExecStatus.create(Instant.parse("2016-08-03T07:57:03.607Z"), "RUNNING"),
-                            ExecStatus.create(Instant.parse("2016-08-03T07:58:03.607Z"), "FAILED")
+                            ExecStatus.create(Instant.parse("2016-08-03T07:56:03.607Z"), "STARTED", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T07:57:03.607Z"), "RUNNING", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T07:58:03.607Z"), "FAILED", Optional.empty())
                         )
                     ),
                     Execution.create(
                         Optional.of("exec-id-01"),
                         Optional.of("busybox:1.1"),
                         Arrays.asList(
-                            ExecStatus.create(Instant.parse("2016-08-03T08:56:03.607Z"), "STARTED"),
-                            ExecStatus.create(Instant.parse("2016-08-03T08:57:03.607Z"), "RUNNING"),
-                            ExecStatus.create(Instant.parse("2016-08-03T08:58:03.607Z"), "SUCCESS")
+                            ExecStatus.create(Instant.parse("2016-08-03T08:56:03.607Z"), "STARTED", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T08:57:03.607Z"), "RUNNING", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T08:58:03.607Z"), "SUCCESS", Optional.empty())
                         )
                     )
                 )
@@ -185,18 +185,18 @@ public class WorkflowInstanceExecutionDataTest {
                         Optional.of("exec-id-10"),
                         Optional.of("busybox:1.2"),
                         Arrays.asList(
-                            ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED"),
-                            ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING"),
-                            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED")
+                            ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T09:58:03.607Z"), "FAILED", Optional.empty())
                         )
                     ),
                     Execution.create(
                         Optional.of("exec-id-11"),
                         Optional.of("busybox:1.3"),
                         Arrays.asList(
-                            ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED"),
-                            ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING"),
-                            ExecStatus.create(Instant.parse("2016-08-03T10:58:03.607Z"), "SUCCESS")
+                            ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING", Optional.empty()),
+                            ExecStatus.create(Instant.parse("2016-08-03T10:58:03.607Z"), "SUCCESS", Optional.empty())
                         )
                     )
                 )

--- a/styx-common/src/test/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/deprecated/WorkflowInstanceExecutionDataTest.java
@@ -140,7 +140,7 @@ public class WorkflowInstanceExecutionDataTest {
 
   private String statusJson(String time, String status, Optional<String> message) {
     final String baseJson = "{\"timestamp\":\"2016-08-03T" + time + ":03.607Z\", \"status\":\"" + status + "\"";
-    return message.map(s -> baseJson + ", \"message\":\"" + s + "\"}").orElseGet(() -> baseJson + "}");
+    return message.map(s -> baseJson + ", \"message\":\"" + s + "\"}").orElse(baseJson + "}");
   }
 
   private String executionJson(String id, String image, String hour, String endStatus, Optional<String> endMessage) {

--- a/styx-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.apache.hadoop.hbase.client.Connection;
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,8 +86,8 @@ public class BigTableStorageTest {
 
     WorkflowInstanceExecutionData workflowInstanceExecutionData = storage.executionData(WFI1);
     assertThat(workflowInstanceExecutionData.triggers().get(0).triggerId(), is("triggerId"));
-    assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).executionId(), is("execId"));
-    assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).dockerImage(), is("img"));
+    assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).executionId(), is(Optional.of("execId")));
+    assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).dockerImage(), is(Optional.of("img")));
     assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).statuses().get(0), is(
         ExecStatus.create(Instant.ofEpochMilli(1L), "SUBMITTED")));
     assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).statuses().get(1), is(
@@ -110,15 +111,15 @@ public class BigTableStorageTest {
     assertThat(workflowInstanceExecutionData.size(), is(2));
 
     assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).triggerId(), is("triggerId1"));
-    assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).executionId(), is("execId1"));
-    assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).dockerImage(), is("img1"));
+    assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).executionId(), is(Optional.of("execId1")));
+    assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).dockerImage(), is(Optional.of("img1")));
     assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).statuses()
                    .get(0), is(ExecStatus.create(Instant.ofEpochMilli(1L), "SUBMITTED")));
     assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).statuses()
                    .get(1), is(ExecStatus.create(Instant.ofEpochMilli(2L), "STARTED")));
     assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).triggerId(), is("triggerId2"));
-    assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).executionId(), is("execId2"));
-    assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).dockerImage(), is("img2"));
+    assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).executionId(), is(Optional.of("execId2")));
+    assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).dockerImage(), is(Optional.of("img2")));
     assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).statuses()
                    .get(0), is(ExecStatus.create(Instant.ofEpochMilli(4L), "SUBMITTED")));
     assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).statuses()

--- a/styx-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
@@ -89,9 +89,9 @@ public class BigTableStorageTest {
     assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).executionId(), is(Optional.of("execId")));
     assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).dockerImage(), is(Optional.of("img")));
     assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).statuses().get(0), is(
-        ExecStatus.create(Instant.ofEpochMilli(1L), "SUBMITTED")));
+        ExecStatus.create(Instant.ofEpochMilli(1L), "SUBMITTED", Optional.empty())));
     assertThat(workflowInstanceExecutionData.triggers().get(0).executions().get(0).statuses().get(1), is(
-        ExecStatus.create(Instant.ofEpochMilli(2L), "STARTED")));
+        ExecStatus.create(Instant.ofEpochMilli(2L), "STARTED", Optional.empty())));
   }
 
   @Test
@@ -114,16 +114,16 @@ public class BigTableStorageTest {
     assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).executionId(), is(Optional.of("execId1")));
     assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).dockerImage(), is(Optional.of("img1")));
     assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).statuses()
-                   .get(0), is(ExecStatus.create(Instant.ofEpochMilli(1L), "SUBMITTED")));
+                   .get(0), is(ExecStatus.create(Instant.ofEpochMilli(1L), "SUBMITTED", Optional.empty())));
     assertThat(workflowInstanceExecutionData.get(0).triggers().get(0).executions().get(0).statuses()
-                   .get(1), is(ExecStatus.create(Instant.ofEpochMilli(2L), "STARTED")));
+                   .get(1), is(ExecStatus.create(Instant.ofEpochMilli(2L), "STARTED", Optional.empty())));
     assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).triggerId(), is("triggerId2"));
     assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).executionId(), is(Optional.of("execId2")));
     assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).dockerImage(), is(Optional.of("img2")));
     assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).statuses()
-                   .get(0), is(ExecStatus.create(Instant.ofEpochMilli(4L), "SUBMITTED")));
+                   .get(0), is(ExecStatus.create(Instant.ofEpochMilli(4L), "SUBMITTED", Optional.empty())));
     assertThat(workflowInstanceExecutionData.get(1).triggers().get(0).executions().get(0).statuses()
-                   .get(1), is(ExecStatus.create(Instant.ofEpochMilli(5L), "STARTED")));
+                   .get(1), is(ExecStatus.create(Instant.ofEpochMilli(5L), "STARTED", Optional.empty())));
   }
 
   @Test

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -70,7 +70,7 @@ public class ExecutionDescriptionHandler implements OutputHandler {
           try {
             stateManager.receive(submitEvent);
           } catch (StateManager.IsClosed isClosed) {
-            LOG.warn("Could not send 'created' event", isClosed);
+            LOG.warn("Could not send 'submit' event", isClosed);
           }
         } catch (ResourceNotFoundException e) {
           LOG.info("Workflow {} does not exist, halting {}", workflowInstance.workflowId(),


### PR DESCRIPTION
Even if a `runError` or `halt` events are issued before the `submitted` event, hence before the execution id and/or docker image are made available, the `WorkflowInstanceExecutionData` now reports the failed `Execution` and shows the related error message (in case of runError) or the HALTED status.