### PR TITLE
factor Middlewares class to styx-common

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -20,8 +20,8 @@
 
 package com.spotify.styx;
 
-import static com.spotify.styx.api.Middlewares.auditLogging;
 import static com.spotify.styx.api.Middlewares.clientValidator;
+import static com.spotify.styx.api.Middlewares.tokenValidator;
 import static com.spotify.styx.util.Connections.createBigTableConnection;
 import static com.spotify.styx.util.Connections.createDatastore;
 import static java.util.Objects.requireNonNull;
@@ -128,39 +128,39 @@ public class StyxApi implements AppInit {
         .registerRoutes(deprecatedWorkflowResource.routes()
                             .map(r -> r
                                 .withMiddleware(clientValidator(clientBlacklistSupplier))
-                                .withMiddleware(auditLogging())))
+                                .withMiddleware(tokenValidator())))
         .registerRoutes(deprecatedBackfillResource.routes()
                             .map(r -> r
                                 .withMiddleware(clientValidator(clientBlacklistSupplier))
-                                .withMiddleware(auditLogging())))
+                                .withMiddleware(tokenValidator())))
         .registerRoutes(deprecatedCliResource.routes()
                             .map(r -> r
                                 .withMiddleware(clientValidator(clientBlacklistSupplier))
-                                .withMiddleware(auditLogging())))
+                                .withMiddleware(tokenValidator())))
         .registerRoutes(workflowResource.routes()
                             .map(r -> r
                                 .withMiddleware(clientValidator(clientBlacklistSupplier))
-                                .withMiddleware(auditLogging())))
+                                .withMiddleware(tokenValidator())))
         .registerRoutes(backfillResource.routes()
                             .map(r -> r
                                 .withMiddleware(clientValidator(clientBlacklistSupplier))
-                                .withMiddleware(auditLogging())))
+                                .withMiddleware(tokenValidator())))
         .registerRoutes(resourceResource.routes()
                             .map(r -> r
                                 .withMiddleware(clientValidator(clientBlacklistSupplier))
-                                .withMiddleware(auditLogging())))
+                                .withMiddleware(tokenValidator())))
         .registerRoutes(styxConfigResource.routes()
                             .map(r -> r
                                 .withMiddleware(clientValidator(clientBlacklistSupplier))
-                                .withMiddleware(auditLogging())))
+                                .withMiddleware(tokenValidator())))
         .registerRoutes(statusResource.routes()
                             .map(r -> r
                                 .withMiddleware(clientValidator(clientBlacklistSupplier))
-                                .withMiddleware(auditLogging())))
+                                .withMiddleware(tokenValidator())))
         .registerRoutes(schedulerProxyResource.routes()
                             .map(r -> r
                                 .withMiddleware(clientValidator(clientBlacklistSupplier))
-                                .withMiddleware(auditLogging())));
+                                .withMiddleware(tokenValidator())));
   }
 
   private static AggregateStorage storage(Environment environment) {

--- a/styx-common/pom.xml
+++ b/styx-common/pom.xml
@@ -91,6 +91,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>apollo-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/styx-common/src/main/java/com/spotify/styx/api/Middlewares.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/Middlewares.java
@@ -98,13 +98,15 @@ public final class Middlewares {
   }
 
   public static Middleware<AsyncHandler<? extends Response<?>>,
-      AsyncHandler<? extends Response<ByteString>>> auditLogging() {
+      AsyncHandler<? extends Response<ByteString>>> tokenValidator() {
     return innerHandler -> requestContext -> {
       final Request request = requestContext.request();
       if (!"GET".equals(request.method())) {
-        LOG.info("[AUDIT] {} {} with headers {} parameters {} and payload {}",
+        // TODO: validate token and log user account
+        LOG.info("[AUDIT] {} {} from {} with headers {} parameters {} and payload {}",
                  request.method(),
                  request.uri(),
+                 "anonymous",
                  request.headers(),
                  request.parameters(),
                  request.payload().map(ByteString::utf8).orElse("")

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -20,6 +20,8 @@
 
 package com.spotify.styx;
 
+import static com.spotify.styx.api.Middlewares.clientValidator;
+import static com.spotify.styx.api.Middlewares.tokenValidator;
 import static com.spotify.styx.monitoring.MeteredProxy.instrument;
 import static com.spotify.styx.util.Connections.createBigTableConnection;
 import static com.spotify.styx.util.Connections.createDatastore;
@@ -95,6 +97,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -351,10 +354,14 @@ public class StyxScheduler implements AppInit {
 
     final SchedulerResource schedulerResource = new SchedulerResource(stateManager, trigger,
                                                                       storage, time);
+    final Supplier<Optional<List<String>>> clientBlacklistSupplier =
+        new CachedSupplier<>(storage::clientBlacklist, Instant::now);
 
     environment.routingEngine()
         .registerAutoRoute(Route.sync("GET", "/ping", rc -> "pong"))
-        .registerRoutes(schedulerResource.routes());
+        .registerRoutes(schedulerResource.routes().map(r -> r
+            .withMiddleware(clientValidator(clientBlacklistSupplier))
+            .withMiddleware(tokenValidator())));
 
     this.stateManager = stateManager;
     this.scheduler = scheduler;


### PR DESCRIPTION
It can be shared by both styx-api and styx-scheduler.

Also rename the middleware a bit to preare for token validation.

@danielnorberg @bergman PTAL

As a starting point. Feel free to continue or close it.