### PR TITLE
cli: fix slow startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.20</version>
+        <version>1.7.25</version>
       </dependency>
 
       <!-- cli -->
@@ -193,6 +193,11 @@
         <groupId>net.sourceforge.argparse4j</groupId>
         <artifactId>argparse4j</artifactId>
         <version>0.7.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>1.7.25</version>
       </dependency>
 
       <!-- styx client libs -->

--- a/styx-cli/pom.xml
+++ b/styx-cli/pom.xml
@@ -58,8 +58,8 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
     </dependency>
 
     <dependency>

--- a/styx-cli/src/main/resources/logback.xml
+++ b/styx-cli/src/main/resources/logback.xml
@@ -1,3 +1,0 @@
-<configuration>
-   <!-- empty config to disable apollo client logging -->
-</configuration>

--- a/styx-cli/src/main/resources/simplelogger.properties
+++ b/styx-cli/src/main/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=off


### PR DESCRIPTION
Turns out logback tries to look up the host name of the machine by making a DNS query. That is usually quick on machines in a datacenter but all too often fails (slowly) on workstations.

By replacing logback with slf4j-simple in the cli we can eliminate the above host name lookup and gain a 5s speedup 🎆 🍾 🍻 🎉 🎈 

**Before: ~5.5s startup**
```
$ time STYX_CLI_HOST=% styx e foo bar 2017-06-01 &>/dev/null
0.63s user 0.09s system 12% cpu 5.583 total
```

**After: ~0.5s startup**
```
$ time STYX_CLI_HOST=% java -Xnoclassgc -Xmx128m -Xms64m -Xverify:none -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -jar styx-cli/target/styx-cli.jar e foo bar 2017-06-01 &>/dev/null
0.52s user 0.06s system 126% cpu 0.460 total
```

Setting `STYX_CLI_HOST=%` ensures that we only measure time until `java.lang.IllegalArgumentException: unexpected host: %`, so not including actual server roundtrip.

Real request roundtrip timings from my Tokyo workstation to EU over VPN are also much better however.

**Before: ~6.5s roundtrip**
```
$ time styx e foo bar 2017-06-01 &>/dev/null
0.94s user 0.12s system 15% cpu 6.704 total
```
**After: ~1.5s roundtrip**
```
$ time STYX_CLI_HOST=styx.spotify.net java -Xnoclassgc -Xmx128m -Xms64m -Xverify:none -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -jar styx-cli/target/styx-cli.jar e foo bar 2017-06-01 &>/dev/null
0.85s user 0.09s system 65% cpu 1.421 total
```

