### PR TITLE
silence spam for /status/activeStates replay

### DIFF
--- a/styx-common/pom.xml
+++ b/styx-common/pom.xml
@@ -115,5 +115,10 @@
       <artifactId>json-path-assert</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
@@ -76,8 +76,10 @@ public final class ReplayEvents {
         // Thus, we don't expect any event in the sequence to be later than the last consumed
         // event. We will treat this as an error for now and skip the rest of the events.
         if (sequenceEvent.counter() > lastConsumedEvent) {
-          LOG.error("Got unexpected newer event than the last consumed event {} > {} for {}",
-                    sequenceEvent.counter(), lastConsumedEvent, workflowInstance.toKey());
+          if (printLogs) {
+            LOG.error("Got unexpected newer event than the last consumed event {} > {} for {}",
+                sequenceEvent.counter(), lastConsumedEvent, workflowInstance.toKey());
+          }
           break;
         }
 

--- a/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.util;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresent;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.newTreeSet;
 import static com.spotify.styx.state.RunState.State.DONE;
 import static com.spotify.styx.state.RunState.State.RUNNING;
@@ -35,15 +36,20 @@ import com.google.common.collect.ImmutableMap;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.SequenceEvent;
 import com.spotify.styx.state.RunState;
+import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.Storage;
-import com.spotify.styx.testdata.TestData;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.SortedSet;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(JUnitParamsRunner.class)
 public class ReplayEventsTest {
   Storage storage;
 
@@ -114,4 +120,36 @@ public class ReplayEventsTest {
 
     assertThat(restoredRunState, is(Optional.empty()));
   }
+
+  @Test
+  @Parameters({
+      "3, SUBMITTED, true",
+      "3, SUBMITTED, false",
+      "4, RUNNING, true",
+      "4, RUNNING, false",
+  })
+  public void restoreRunStateForActiveInstance(long counter, State expectedState, boolean printLogs) throws Exception {
+    SortedSet<SequenceEvent> events = newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
+    events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.natural()),        0L, 0L));
+    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE),                                    1L, 1L));
+    events.add(SequenceEvent.create(Event.submit(WORKFLOW_INSTANCE, EXECUTION_DESCRIPTION, "exec-1"),    2L, 2L));
+    events.add(SequenceEvent.create(Event.submitted(WORKFLOW_INSTANCE, "exec-1"),                        3L, 3L));
+    events.add(SequenceEvent.create(Event.started(WORKFLOW_INSTANCE),                                    4L, 4L));
+
+    when(storage.readEvents(WORKFLOW_INSTANCE)).thenReturn(events);
+
+    Map<RunState, Long> runStates = ReplayEvents.replayActiveStates(
+        ImmutableMap.of(WORKFLOW_INSTANCE, counter), storage, printLogs);
+
+    assertThat(runStates.size(), is(1));
+
+    RunState restoredRunState = getOnlyElement(runStates.keySet());
+    long restoredCounter = getOnlyElement(runStates.values());
+
+    assertThat(restoredCounter, is(counter));
+    assertThat(restoredRunState.state(), is(expectedState));
+    assertThat(restoredRunState.data().trigger(), isPresent());
+    assertThat(restoredRunState.data().trigger().get(), is(Trigger.natural()));
+  }
+
 }


### PR DESCRIPTION
This "error" is expected and harmless while styx is up and getting api requests, so silence it. The `/status/activeStates` handler calls `replayActiveStates` with `printLogs=false`.

The error will still be logged during startup state restore replay, which is desirable it is not expected to happen then. `restoreState` calls `replayActiveStates` with `printLogs=true`.

These are the only two call sites.