### PR TITLE
re-prioritize docker image specs if docker_image_override is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ schedules:
 - `schedule[].docker_image` **string**: The docker image that should be executed
  - The docker image that contains the workflow
 
+- `schedule[].docker_image_override` **boolean**: Whether the `docker_image` in
+the workflow schedule configuration has precedence over the `docker_image` in Datastore.
+
 - `schedule[].docker_args` **[string]**: The arguments passed to the docker image
  - This list should only contain strings. These will be passed as the arguments to the docker
 container. Any occurrences of the `"{}"` placeholder argument will be replaced with the current

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -136,18 +136,18 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeWorkflow(Workflow.create(
         BACKFILL_1.workflowId().componentId(), URI.create("http://example.com"),
         DataEndpoint.create(BACKFILL_1.workflowId().endpointId(), Partitioning.HOURS,
-                            Optional.empty(), Optional.empty(), Optional.empty(),
+                            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                             Collections.emptyList())));
     storage.storeWorkflow(Workflow.create(
         BACKFILL_2.workflowId().componentId(), URI.create("http://example.com"),
         DataEndpoint.create(BACKFILL_2.workflowId().endpointId(),
                             Partitioning.HOURS, Optional.empty(),
-                            Optional.empty(), Optional.empty(),
+                            Optional.empty(), Optional.empty(), Optional.empty(),
                             Collections.emptyList())));
     storage.storeWorkflow(Workflow.create(
         BACKFILL_3.workflowId().componentId(), URI.create("http://example.com"),
         DataEndpoint.create(BACKFILL_3.workflowId().endpointId(), Partitioning.HOURS,
-                            Optional.empty(), Optional.empty(), Optional.empty(),
+                            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                             Collections.emptyList())));
     storage.storeBackfill(BACKFILL_1);
   }

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -85,7 +85,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
   }
 
   private static final DataEndpoint DATA_ENDPOINT =
-      DataEndpoint.create("bar", Partitioning.DAYS, empty(), empty(), empty(), emptyList());
+      DataEndpoint.create("bar", Partitioning.DAYS, empty(), empty(), empty(), empty(), emptyList());
 
   private static final Workflow WORKFLOW =
       Workflow.create("foo", URI.create("/hejhej"), DATA_ENDPOINT);

--- a/styx-common/src/main/java/com/spotify/styx/model/DataEndpoint.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/DataEndpoint.java
@@ -45,6 +45,9 @@ public abstract class DataEndpoint {
   public abstract Optional<String> dockerImage();
 
   @JsonProperty
+  public abstract Optional<Boolean> dockerImageOverride();
+
+  @JsonProperty
   public abstract Optional<List<String>> dockerArgs();
 
   @JsonProperty
@@ -58,11 +61,12 @@ public abstract class DataEndpoint {
       @JsonProperty("id") String id,
       @JsonProperty("partitioning") Partitioning partitioning,
       @JsonProperty("docker_image") Optional<String> dockerImage,
+      @JsonProperty("docker_image_override") Optional<Boolean> dockerImageOverride,
       @JsonProperty("docker_args") Optional<List<String>> dockerArgs,
       @JsonProperty("secret") Optional<Secret> secret,
       @JsonProperty("resources") List<String> resources) {
 
-    return new AutoValue_DataEndpoint(id, partitioning, dockerImage, dockerArgs, secret,
+    return new AutoValue_DataEndpoint(id, partitioning, dockerImage, dockerImageOverride, dockerArgs, secret,
         resources == null ? Collections.emptyList() : resources);
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -359,19 +359,20 @@ class DatastoreStorage {
   }
 
   Optional<String> getDockerImage(WorkflowId workflowId) throws IOException {
+    Optional<String> dockerImage =
+        workflow(workflowId).flatMap(wf -> wf.schedule().dockerImage());
+    if (dockerImage.isPresent()) {
+      return dockerImage;
+    }
+
     final Key workflowKey = workflowKey(workflowId);
-    Optional<String> dockerImage = getOptStringProperty(datastore, workflowKey, PROPERTY_DOCKER_IMAGE);
+    dockerImage = getOptStringProperty(datastore, workflowKey, PROPERTY_DOCKER_IMAGE);
     if (dockerImage.isPresent()) {
       return dockerImage;
     }
 
     final Key componentKey = componentKeyFactory.newKey(workflowId.componentId());
-    dockerImage = getOptStringProperty(datastore, componentKey, PROPERTY_DOCKER_IMAGE);
-    if (dockerImage.isPresent()) {
-      return dockerImage;
-    }
-
-    return workflow(workflowId).flatMap(wf -> wf.schedule().dockerImage());
+    return getOptStringProperty(datastore, componentKey, PROPERTY_DOCKER_IMAGE);
   }
 
   public WorkflowState workflowState(WorkflowId workflowId) throws IOException {

--- a/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
+++ b/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
@@ -57,23 +57,23 @@ public final class TestData {
 
   public static final DataEndpoint HOURLY_DATA_ENDPOINT =
       DataEndpoint.create(
-          "styx.TestEndpoint", HOURS, empty(), empty(), empty(), emptyList());
+          "styx.TestEndpoint", HOURS, empty(), empty(), empty(), empty(), emptyList());
 
   public static final DataEndpoint DAILY_DATA_ENDPOINT =
       DataEndpoint.create(
-          "styx.TestEndpoint", DAYS, empty(), empty(), empty(), emptyList());
+          "styx.TestEndpoint", DAYS, empty(), empty(), empty(), empty(), emptyList());
 
   public static final DataEndpoint WEEKLY_DATA_ENDPOINT =
       DataEndpoint.create(
-          "styx.TestEndpoint", WEEKS, empty(), empty(), empty(), emptyList());
+          "styx.TestEndpoint", WEEKS, empty(), empty(), empty(), empty(), emptyList());
 
   public static final DataEndpoint MONTHLY_DATA_ENDPOINT =
       DataEndpoint.create(
-          "styx.TestEndpoint", MONTHS, empty(), empty(), empty(), emptyList());
+          "styx.TestEndpoint", MONTHS, empty(), empty(), empty(), empty(), emptyList());
 
   public static final DataEndpoint FULL_DATA_ENDPOINT =
       DataEndpoint.create(
-          "styx.TestEndpoint", DAYS, of("busybox"), of(asList("x", "y")),
+          "styx.TestEndpoint", DAYS, of("busybox"), empty(), of(asList("x", "y")),
           of(Secret.create("name", "/path")), emptyList());
 
   public static final ExecutionDescription EXECUTION_DESCRIPTION =

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -258,42 +258,34 @@ public class DatastoreStorageTest {
   }
 
   @Test
-  public void shouldNotOverwriteDockerImageFromWorkflowWhenUsingComponent() throws Exception {
+  public void shouldOverwriteDockerImageFromWorkflowWhenUsingComponent() throws Exception {
+    storage.store(WORKFLOW_WITH_DOCKER_IMAGE);
     WorkflowState state = patchDockerImage(DOCKER_IMAGE_COMPONENT);
-
-    storage.store(WORKFLOW_WITH_DOCKER_IMAGE);
     storage.patchState(WORKFLOW_WITH_DOCKER_IMAGE.id().componentId(), state);
-    Optional<String> retrieved = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
-    assertThat(retrieved, is(Optional.of(DOCKER_IMAGE_COMPONENT)));
 
-    storage.store(WORKFLOW_WITH_DOCKER_IMAGE);
-    retrieved  = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
-    assertThat(retrieved, is(Optional.of(DOCKER_IMAGE_COMPONENT)));
+    Optional<String> retrieved = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
+    assertThat(retrieved, is(WORKFLOW_WITH_DOCKER_IMAGE.schedule().dockerImage()));
   }
 
   @Test
-  public void shouldNotOverwriteDockerImageFromWorkflowWhenUsingWorkflowId() throws Exception {
+  public void shouldOverwriteDockerImageFromWorkflowWhenUsingWorkflowId() throws Exception {
     storage.store(WORKFLOW_WITH_DOCKER_IMAGE);
     storage.patchState(WORKFLOW_WITH_DOCKER_IMAGE.id(), patchDockerImage(DOCKER_IMAGE_WORKFLOW));
     Optional<String> retrieved = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
-    assertThat(retrieved, is(Optional.of(DOCKER_IMAGE_WORKFLOW)));
-
-    storage.store(WORKFLOW_WITH_DOCKER_IMAGE);
-    retrieved  = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
-    assertThat(retrieved, is(Optional.of(DOCKER_IMAGE_WORKFLOW)));
+    assertThat(retrieved, is(WORKFLOW_WITH_DOCKER_IMAGE.schedule().dockerImage()));
   }
 
   @Test
   public void shouldNotOverwriteDockerImageFromComponentWhenUsingWorkflowId() throws Exception {
     WorkflowState state = patchDockerImage(DOCKER_IMAGE_COMPONENT);
 
-    storage.store(WORKFLOW_WITH_DOCKER_IMAGE);
-    storage.patchState(WORKFLOW_WITH_DOCKER_IMAGE.id(), patchDockerImage(DOCKER_IMAGE_WORKFLOW));
-    Optional<String> retrieved = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
+    storage.store(WORKFLOW_NO_DOCKER_IMAGE);
+    storage.patchState(WORKFLOW_NO_DOCKER_IMAGE.id(), patchDockerImage(DOCKER_IMAGE_WORKFLOW));
+    Optional<String> retrieved = storage.getDockerImage(WORKFLOW_NO_DOCKER_IMAGE.id());
     assertThat(retrieved, is(Optional.of(DOCKER_IMAGE_WORKFLOW)));
 
-    storage.patchState(WORKFLOW_WITH_DOCKER_IMAGE.id().componentId(), state);
-    retrieved = storage.getDockerImage(WORKFLOW_WITH_DOCKER_IMAGE.id());
+    storage.patchState(WORKFLOW_NO_DOCKER_IMAGE.id().componentId(), state);
+    retrieved = storage.getDockerImage(WORKFLOW_NO_DOCKER_IMAGE.id());
     assertThat(retrieved, is(Optional.of(DOCKER_IMAGE_WORKFLOW)));
   }
 

--- a/styx-common/src/test/java/com/spotify/styx/storage/InMemoryStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/InMemoryStorageTest.java
@@ -34,6 +34,7 @@ import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowState;
 import java.io.IOException;
 import java.net.URI;
+
 import org.junit.Test;
 
 /**
@@ -78,6 +79,6 @@ public class InMemoryStorageTest {
     return Workflow.create(
         workflowId.componentId(),
         URI.create("http://foo"),
-        DataEndpoint.create(workflowId.endpointId(), HOURS, empty(), empty(), empty(), emptyList()));
+        DataEndpoint.create(workflowId.endpointId(), HOURS, empty(), empty(), empty(), empty(), emptyList()));
   }
 }

--- a/styx-local-files-source/src/test/java/com/spotify/styx/LocalFileScheduleSourceTest.java
+++ b/styx-local-files-source/src/test/java/com/spotify/styx/LocalFileScheduleSourceTest.java
@@ -203,6 +203,7 @@ public class LocalFileScheduleSourceTest {
             "foo",
             Partitioning.HOURS,
             empty(),
+            empty(),
             Optional.of(emptyList()),
             empty(),
             emptyList()));
@@ -216,6 +217,7 @@ public class LocalFileScheduleSourceTest {
         DataEndpoint.create(
             "foo",
             Partitioning.DAYS,
+            empty(),
             empty(),
             Optional.of(singletonList("foo")),
             empty(),
@@ -231,6 +233,7 @@ public class LocalFileScheduleSourceTest {
             "foo",
             Partitioning.HOURS,
             empty(),
+            empty(),
             Optional.of(Arrays.asList("foo", "bar")),
             empty(),
             emptyList()));
@@ -244,6 +247,7 @@ public class LocalFileScheduleSourceTest {
         DataEndpoint.create(
             "bar",
             Partitioning.DAYS,
+            empty(),
             empty(),
             Optional.of(Arrays.asList("baz", "bax")),
             empty(),

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -58,6 +58,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
 import org.junit.Test;
 
 public class SchedulerTest {
@@ -131,7 +132,7 @@ public class SchedulerTest {
         id.componentId(),
         URI.create("http://example.com"),
         DataEndpoint.create(
-            id.endpointId(), Partitioning.HOURS, empty(), empty(), empty(),
+            id.endpointId(), Partitioning.HOURS, empty(), empty(), empty(), empty(),
             Arrays.asList(resources)));
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StateInitializingTriggerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StateInitializingTriggerTest.java
@@ -147,6 +147,7 @@ public class StateInitializingTriggerTest {
         "styx.TestEndpoint",
         partitioning,
         Optional.of("busybox"),
+        empty(),
         Optional.of(Lists.newArrayList(args)),
         empty(),
         emptyList());

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -56,10 +56,10 @@ import org.junit.Test;
 public class SystemTest extends StyxSchedulerServiceFixture {
 
   private static final DataEndpoint DATA_ENDPOINT_HOURLY = DataEndpoint.create(
-      "styx.TestEndpoint", Partitioning.HOURS, of("busybox"), of(asList("--hour", "{}")),
+      "styx.TestEndpoint", Partitioning.HOURS, of("busybox"), empty(), of(asList("--hour", "{}")),
       empty(), emptyList());
   private static final DataEndpoint DATA_ENDPOINT_DAILY = DataEndpoint.create(
-      "styx.TestEndpoint", Partitioning.DAYS, of("busybox"), of(asList("--hour", "{}")),
+      "styx.TestEndpoint", Partitioning.DAYS, of("busybox"), empty(), of(asList("--hour", "{}")),
       empty(), emptyList());
   private static final String TEST_EXECUTION_ID_1 = "execution_1";
   private static final String TEST_DOCKER_IMAGE = "busybox:1.1";
@@ -302,7 +302,7 @@ public class SystemTest extends StyxSchedulerServiceFixture {
     workflowChanges(Workflow.create(DAILY_WORKFLOW.componentId(),
         DAILY_WORKFLOW.componentUri(),
         DataEndpoint.create(DATA_ENDPOINT_DAILY.id(), DATA_ENDPOINT_DAILY.partitioning(),
-            Optional.of("freebox"), DATA_ENDPOINT_DAILY.dockerArgs(),
+            Optional.of("freebox"), empty(), DATA_ENDPOINT_DAILY.dockerArgs(),
             DATA_ENDPOINT_DAILY.secret(), emptyList())));
     timePasses(StyxScheduler.SCHEDULER_TICK_INTERVAL_SECONDS, SECONDS);
     awaitNumberOfDockerRunsWontChange(1);
@@ -351,7 +351,7 @@ public class SystemTest extends StyxSchedulerServiceFixture {
 
     DataEndpoint changedDataEndpoint = DataEndpoint.create(
         DATA_ENDPOINT_HOURLY.id(), Partitioning.HOURS, of("busybox:v777"),
-        of(asList("other", "args")), empty(), emptyList());
+        empty(), of(asList("other", "args")), empty(), emptyList());
 
     Workflow changedWorkflow = Workflow.create(
         HOURLY_WORKFLOW.componentId(),

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
@@ -158,6 +158,7 @@ public class DockerRunnerHandlerTest {
         "styx.TestEndpoint",
         HOURS,
         Optional.of(TEST_DOCKER_IMAGE),
+        empty(),
         Optional.of(Lists.newArrayList(args)),
         empty(),
         emptyList());

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
@@ -173,6 +173,7 @@ public class ExecutionDescriptionHandlerTest {
         "styx.TestEndpoint",
         HOURS,
         Optional.of("legacy-docker-image"),
+        empty(),
         Optional.of(Lists.newArrayList("foo", "bar")),
         empty(),
         emptyList());
@@ -197,6 +198,7 @@ public class ExecutionDescriptionHandlerTest {
         "styx.TestEndpoint",
         HOURS,
         Optional.empty(),
+        empty(),
         Optional.of(Lists.newArrayList(args)),
         empty(),
         emptyList());


### PR DESCRIPTION
This is based on the PR #60 from @TinaRanic but since we could not merge that easily without the possibility to break existing pipelines, I have added a `docker_image_override` flag in the workflow definition that toggles this behavior.

This PR changes the order in which a docker image specification takes precedence depending on the `docker_image_override` flag:

if `docker_image_override` is false:
1. docker image as part of state in workflow instance
2. docker image as part of state in component
3. docker image specified in workflow definition (yaml)

if `docker_image_override` is true:
1. docker image specified in workflow definition (yaml)
2. docker image as part of state in workflow instance
3. docker image as part of state in component

The reason for this is that many customers find it more intuitive that a docker image specification in the yaml file should override everything else.

ping @kanterov @Xeago @fabriziodemaria @bergman @honnix 