### PR TITLE
re-prioritize docker image specs if docker_image_override is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ A unique identifier for the workflow (lower-case-hyphenated). This identifier is
 #### `schedule[].docker_image` **[string]**:
 The Docker image that should be executed.
 
+####  `schedule[].docker_image_override` **boolean**:
+Whether the `docker_image` in the workflow schedule configuration has precedence over the
+`docker_image` in Datastore.
+
 #### `schedule[].docker_args` **[string]**
 The arguments passed to the Docker image.
 

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
@@ -45,6 +45,8 @@ public interface WorkflowConfiguration {
 
   Optional<String> dockerImage();
 
+  Optional<Boolean> dockerImageOverride();
+
   Optional<List<String>> dockerArgs();
 
   /**


### PR DESCRIPTION
This is based on the PR #60 from @TinaRanic but since we could not merge that easily without the possibility to break existing pipelines, I have added a `docker_image_override` flag in the workflow definition that toggles this behavior.

This PR changes the order in which a docker image specification takes precedence depending on the `docker_image_override` flag:

if `docker_image_override` is false:
1. docker image as part of state in workflow instance
2. docker image as part of state in component
3. docker image specified in workflow definition (yaml)

if `docker_image_override` is true:
1. docker image specified in workflow definition (yaml)
2. docker image as part of state in workflow instance
3. docker image as part of state in component

The reason for this is that many customers find it more intuitive that a docker image specification in the yaml file should override everything else.

ping @kanterov @Xeago @fabriziodemaria @bergman @honnix 