### PR TITLE
Add some more env variables

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -92,6 +92,8 @@ public interface DockerRunner extends Closeable {
 
     public abstract Optional<Trigger> trigger();
 
+    public abstract Optional<String> commitSha();
+
     public static RunSpec create(
         String executionId,
         String imageName,
@@ -99,14 +101,15 @@ public interface DockerRunner extends Closeable {
         boolean terminationLogging,
         Optional<Secret> secret,
         Optional<String> serviceAccount,
-        Optional<Trigger> trigger) {
+        Optional<Trigger> trigger,
+        Optional<String> commitSha) {
       return new AutoValue_DockerRunner_RunSpec(executionId, imageName, args, terminationLogging, secret,
-                                                serviceAccount, trigger);
+                                                serviceAccount, trigger, commitSha);
     }
 
     public static RunSpec simple(String executionId, String imageName, String... args) {
       return new AutoValue_DockerRunner_RunSpec(executionId, imageName, ImmutableList.copyOf(args),
-                                                false, empty(), empty(), empty());
+                                                false, empty(), empty(), empty(), empty());
     }
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -92,6 +92,10 @@ class KubernetesDockerRunner implements DockerRunner {
   // TODO: for backward compatibility, delete later
   private static final String ENDPOINT_ID = "STYX_ENDPOINT_ID";
   static final String WORKFLOW_ID = "STYX_WORKFLOW_ID";
+  static final String SERVICE_ACCOUNT = "STYX_SERVICE_ACCOUNT";
+  static final String DOCKER_ARGS = "STYX_DOCKER_ARGS";
+  static final String DOCKER_IMAGE = "STYX_DOCKER_IMAGE";
+  static final String COMMIT_SHA = "STYX_COMMIT_SHA";
   static final String PARAMETER = "STYX_PARAMETER";
   static final String EXECUTION_ID = "STYX_EXECUTION_ID";
   static final String TERMINATION_LOG = "STYX_TERMINATION_LOG";
@@ -263,7 +267,8 @@ class KubernetesDockerRunner implements DockerRunner {
     return podBuilder.build();
   }
 
-  private static EnvVar envVar(String name, String value) {
+  @VisibleForTesting
+  static EnvVar envVar(String name, String value) {
     return new EnvVarBuilder().withName(name).withValue(value).build();
   }
 
@@ -275,6 +280,10 @@ class KubernetesDockerRunner implements DockerRunner {
         envVar(ENDPOINT_ID,     workflowInstance.workflowId().id()),
         envVar(WORKFLOW_ID,     workflowInstance.workflowId().id()),
         envVar(PARAMETER,       workflowInstance.parameter()),
+        envVar(COMMIT_SHA,      runSpec.commitSha().orElse("")),
+        envVar(SERVICE_ACCOUNT, runSpec.serviceAccount().orElse("")),
+        envVar(DOCKER_ARGS,     String.join(" ", runSpec.args())),
+        envVar(DOCKER_IMAGE,    runSpec.imageName()),
         envVar(EXECUTION_ID,    runSpec.executionId()),
         envVar(TERMINATION_LOG, "/dev/termination-log"),
         envVar(TRIGGER_ID,      runSpec.trigger().map(TriggerUtil::triggerId).orElse(null)),

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -152,7 +152,8 @@ public class DockerRunnerHandler implements OutputHandler {
         executionDescription.dockerTerminationLogging(),
         executionDescription.secret(),
         executionDescription.serviceAccount(),
-        state.data().trigger());
+        state.data().trigger(),
+        state.data().executionDescription().flatMap(ExecutionDescription::commitSha));
   }
 
   private static List<String> argsReplace(List<String> template, String parameter) {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -96,13 +96,13 @@ public class SystemTest extends StyxSchedulerServiceFixture {
 
   private static RunSpec naturalRunSpec(String executionId, String imageName, ImmutableList<String> args) {
     return RunSpec.create(executionId, imageName, args, false, empty(), empty(),
-                          Optional.of(Trigger.natural()));
+                          Optional.of(Trigger.natural()), empty());
   }
 
   private static RunSpec unknownRunSpec(String executionId, String imageName, ImmutableList<String> args,
                                         String triggerId) {
     return RunSpec.create(executionId, imageName, args, false, empty(), empty(),
-                          Optional.of(Trigger.unknown(triggerId)));
+                          Optional.of(Trigger.unknown(triggerId)), empty());
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -100,12 +100,14 @@ public class KubernetesDockerRunnerTest {
                                                                      false,
                                                                      Optional.of(WorkflowConfiguration.Secret.create("secret1", "/etc/secret")),
                                                                      empty(),
+                                                                     empty(),
                                                                      empty());
   private static final RunSpec RUN_SPEC_WITH_SA = RunSpec.create("eid3", "busybox",
                                                                  ImmutableList.copyOf(new String[0]),
                                                                  false,
                                                                  empty(),
                                                                  Optional.of(SERVICE_ACCOUNT),
+                                                                 empty(),
                                                                  empty());
 
   private static final KubernetesSecretSpec SECRET_SPEC_WITH_SA = KubernetesSecretSpec.builder()
@@ -124,6 +126,7 @@ public class KubernetesDockerRunnerTest {
                                                                             false,
                                                                             Optional.of(WorkflowConfiguration.Secret.create("secret1", KubernetesDockerRunner.STYX_WORKFLOW_SA_SECRET_MOUNT_PATH)),
                                                                             Optional.of(SERVICE_ACCOUNT),
+                                                                            empty(),
                                                                             empty());
 
   private static final int NO_POLL = Integer.MAX_VALUE;
@@ -342,6 +345,7 @@ public class KubernetesDockerRunnerTest {
         false,
         Optional.of(WorkflowConfiguration.Secret.create(secret, "/foo/bar")),
         Optional.empty(),
+        empty(),
         empty()));
 
     verify(pods, never()).create(any(Pod.class));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
@@ -112,6 +112,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
       false,
       empty(),
       Optional.of(SERVICE_ACCOUNT),
+      empty(),
       empty());
 
   private static final String TEST_EXEC_ID = "test-exec-id";

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -335,6 +335,6 @@ public class KubernetesPodEventTranslatorTest {
     return KubernetesDockerRunner.createPod(
         WFI,
         DockerRunner.RunSpec.create("eid", "busybox", ImmutableList.of(), true,
-            Optional.empty(), Optional.empty(), Optional.empty()), SECRET_SPEC);
+            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()), SECRET_SPEC);
   }
 }


### PR DESCRIPTION
- commit sha
- docker image
- docker args
- service account

commit sha wasn't available in RunSpec so had to add it. Might be worthwhile to think about skipping the RunSpec and just pass the ExecutionDescription directly.