### PR TITLE
Increase key rotation epoch to weekly

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
@@ -64,15 +64,15 @@ class KubernetesGCPServiceAccountSecretManager {
   private static final String STYX_WORKFLOW_SA_JSON_KEY = "styx-wf-sa.json";
   private static final String STYX_WORKFLOW_SA_P12_KEY = "styx-wf-sa.p12";
 
-  static final Duration DEFAULT_SECRET_EPOCH_PERIOD = Duration.ofDays(7);
-  static final EpochProvider DEFAULT_SECRET_EPOCH_PROVIDER =
+  private static final Duration DEFAULT_SECRET_EPOCH_PERIOD = Duration.ofDays(7);
+  private static final EpochProvider DEFAULT_SECRET_EPOCH_PROVIDER =
       KubernetesGCPServiceAccountSecretManager::smearedEpoch;
 
   private static final Clock DEFAULT_CLOCK = Clock.systemUTC();
 
   // epoch period + timeout of "running" state
   // todo: use config value instead of hardcoded 24 hour timeout
-  static final Duration SECRET_GC_GRACE_PERIOD = DEFAULT_SECRET_EPOCH_PERIOD.plusHours(24);
+  private static final Duration SECRET_GC_GRACE_PERIOD = DEFAULT_SECRET_EPOCH_PERIOD.plusHours(24);
 
   private final KubernetesClient client;
   private final ServiceAccountKeyManager keyManager;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
@@ -20,6 +20,8 @@
 
 package com.spotify.styx.docker;
 
+import static com.spotify.styx.docker.KubernetesGCPServiceAccountSecretManager.DEFAULT_SECRET_EPOCH_PERIOD;
+import static com.spotify.styx.docker.KubernetesGCPServiceAccountSecretManager.SECRET_GC_GRACE_PERIOD;
 import static com.spotify.styx.testdata.TestData.WORKFLOW_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Optional.empty;
@@ -103,7 +105,8 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
 
   private final static Clock CLOCK = Clock.fixed(Instant.now(), ZoneOffset.UTC);
 
-  private static final Instant EXPIRED_CREATION_TIMESTAMP = CLOCK.instant().minus(Duration.ofHours(48).plusSeconds(1));
+  private static final Instant EXPIRED_CREATION_TIMESTAMP =
+      CLOCK.instant().minus(SECRET_GC_GRACE_PERIOD.plusSeconds(1));
 
   private static final WorkflowInstance WORKFLOW_INSTANCE = WorkflowInstance.create(WORKFLOW_ID, "foo");
 
@@ -480,13 +483,14 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
 
   @Test
   public void shouldSmearRotation() throws Exception {
-    final int[] rotationsPerHour = new int[24];
-    final int n = 1000;
+    final long hours = DEFAULT_SECRET_EPOCH_PERIOD.toHours();
+    final int[] rotationsPerHour = new int[(int) hours];
+    final int n = 10000;
     for (int i = 0; i < n; i++) {
       long prevEpoch = 0;
-      for (int hour = 0; hour < 24; hour++) {
+      for (int hour = 0; hour < hours; hour++) {
         final long nowMillis = TimeUnit.HOURS.toMillis(hour);
-        final long epoch = KubernetesGCPServiceAccountSecretManager.smearedDailyEpoch(
+        final long epoch = KubernetesGCPServiceAccountSecretManager.smearedEpoch(
             nowMillis, "sa" + i + "@example.com");
         if (prevEpoch != epoch) {
           prevEpoch = epoch;
@@ -495,7 +499,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
       }
     }
     final IntSummaryStatistics stats = IntStream.of(rotationsPerHour).summaryStatistics();
-    final double expectedMeanRotationsPerHour = n / 24;
+    final double expectedMeanRotationsPerHour = n / hours;
     assertThat(stats.getAverage(), is(closeTo(expectedMeanRotationsPerHour, expectedMeanRotationsPerHour / 2)));
     assertThat((double) stats.getMax(), is(lessThan(expectedMeanRotationsPerHour * 2)));
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
@@ -20,8 +20,6 @@
 
 package com.spotify.styx.docker;
 
-import static com.spotify.styx.docker.KubernetesGCPServiceAccountSecretManager.DEFAULT_SECRET_EPOCH_PERIOD;
-import static com.spotify.styx.docker.KubernetesGCPServiceAccountSecretManager.SECRET_GC_GRACE_PERIOD;
 import static com.spotify.styx.testdata.TestData.WORKFLOW_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Optional.empty;
@@ -106,7 +104,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
   private final static Clock CLOCK = Clock.fixed(Instant.now(), ZoneOffset.UTC);
 
   private static final Instant EXPIRED_CREATION_TIMESTAMP =
-      CLOCK.instant().minus(SECRET_GC_GRACE_PERIOD.plusSeconds(1));
+      CLOCK.instant().minus(Duration.ofDays(7).plusHours(24).plusSeconds(1));
 
   private static final WorkflowInstance WORKFLOW_INSTANCE = WorkflowInstance.create(WORKFLOW_ID, "foo");
 
@@ -482,8 +480,8 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
   }
 
   @Test
-  public void shouldSmearRotation() throws Exception {
-    final long hours = DEFAULT_SECRET_EPOCH_PERIOD.toHours();
+  public void shouldSmearRotationWeekly() throws Exception {
+    final long hours = Duration.ofDays(7).toHours();
     final int[] rotationsPerHour = new int[(int) hours];
     final int n = 10000;
     for (int i = 0; i < n; i++) {


### PR DESCRIPTION
GCP Service Accounts have a low limit of number of keys. Having the rotation epoch greater than the timeout of "running" state (24 hours) means there is no chance of having three epochs of keys active at the same time. This means no more warnings about number of keys being too high.