### PR TITLE
Handle max number of keys created nicer

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/GcpUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/GcpUtil.java
@@ -38,8 +38,21 @@ public class GcpUtil {
   }
 
   public static boolean isPermissionDenied(GoogleJsonError error) {
-    return Optional.ofNullable(error.get("status"))
-        .map("PERMISSION_DENIED"::equals)
+    return "PERMISSION_DENIED".equals(error.get("status"));
+  }
+
+  public static boolean isResourceExhausted(Throwable t) {
+    return t instanceof GoogleJsonResponseException
+           && isResourceExhausted((GoogleJsonResponseException) t);
+  }
+
+  public static boolean isResourceExhausted(GoogleJsonResponseException e) {
+    return e.getStatusCode() == 429 && Optional.ofNullable(e.getDetails())
+        .map(GcpUtil::isResourceExhausted)
         .orElse(false);
+  }
+
+  public static boolean isResourceExhausted(GoogleJsonError error) {
+    return "RESOURCE_EXHAUSTED".equals(error.get("status"));
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/util/GcpUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/GcpUtilTest.java
@@ -34,9 +34,12 @@ public class GcpUtilTest {
   private static final GoogleJsonError PERMISSION_DENIED_ERROR = new GoogleJsonError()
       .set("status", "PERMISSION_DENIED");
 
+  private static final GoogleJsonError RESOURCE_EXHAUSTED_ERROR = new GoogleJsonError()
+      .set("status", "RESOURCE_EXHAUSTED");
+
   @Test
   public void responseIsPermissionDenied() throws Exception {
-    final GoogleJsonResponseException permissionDenied = new GoogleJsonResponseException(
+    final Throwable permissionDenied = new GoogleJsonResponseException(
         new Builder(403, "Forbidden", new HttpHeaders()), PERMISSION_DENIED_ERROR);
     assertThat(GcpUtil.isPermissionDenied(permissionDenied), is(true));
   }
@@ -58,5 +61,31 @@ public class GcpUtilTest {
   public void errorIsNotPermissionDenied() throws Exception {
     assertThat(GcpUtil.isPermissionDenied(new GoogleJsonError()), is(false));
     assertThat(GcpUtil.isPermissionDenied(new GoogleJsonError().set("status", "foo failed")), is(false));
+  }
+
+  @Test
+  public void responseIsResourceExhausted() throws Exception {
+    final Throwable resourceExhausted = new GoogleJsonResponseException(
+        new Builder(429, "Too Many Requests", new HttpHeaders()), RESOURCE_EXHAUSTED_ERROR);
+    assertThat(GcpUtil.isResourceExhausted(resourceExhausted), is(true));
+  }
+
+  @Test
+  public void notFoundResponseIsNotPResourceExhausted() throws Exception {
+    assertThat(GcpUtil.isResourceExhausted(new GoogleJsonResponseException(
+        new Builder(404, "Not Found", new HttpHeaders()), new GoogleJsonError())), is(false));
+    assertThat(GcpUtil.isResourceExhausted(new GoogleJsonResponseException(
+        new Builder(404, "Not Found", new HttpHeaders()), null)), is(false));
+  }
+
+  @Test
+  public void errorIsResourceExhausted() throws Exception {
+    assertThat(GcpUtil.isResourceExhausted(RESOURCE_EXHAUSTED_ERROR), is(true));
+  }
+
+  @Test
+  public void errorIsNotResourceExhausted() throws Exception {
+    assertThat(GcpUtil.isResourceExhausted(new GoogleJsonError()), is(false));
+    assertThat(GcpUtil.isResourceExhausted(new GoogleJsonError().set("status", "foo failed")), is(false));
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -155,14 +155,14 @@ class KubernetesDockerRunner implements DockerRunner {
     serviceAccountSecretManager.cleanup();
   }
 
-  private KubernetesSecretSpec ensureSecrets(WorkflowInstance workflowInstance, RunSpec runSpec)
-      throws IOException {
+  private KubernetesSecretSpec ensureSecrets(WorkflowInstance workflowInstance, RunSpec runSpec) {
     return KubernetesSecretSpec.builder()
         .customSecret(ensureCustomSecret(workflowInstance, runSpec))
-        .serviceAccountSecret(runSpec.serviceAccount().isPresent()
-            ? Optional.of(serviceAccountSecretManager.ensureServiceAccountKeySecret(
-                workflowInstance.workflowId().toString(), runSpec.serviceAccount().get()))
-            : Optional.empty())
+        .serviceAccountSecret(runSpec.serviceAccount().map(
+            serviceAccount ->
+                serviceAccountSecretManager.ensureServiceAccountKeySecret(
+                    workflowInstance.workflowId().toString(),
+                    serviceAccount)))
         .build();
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -96,8 +97,7 @@ class KubernetesGCPServiceAccountSecretManager {
     this(client, keyManager, DEFAULT_SECRET_EPOCH_PROVIDER, DEFAULT_CLOCK);
   }
 
-  String ensureServiceAccountKeySecret(String workflowId,
-      String serviceAccount) throws IOException {
+  String ensureServiceAccountKeySecret(String workflowId, String serviceAccount) {
     final long epoch = epochProvider.epoch(clock.millis(), serviceAccount);
     final String secretName = buildSecretName(serviceAccount, epoch);
 
@@ -107,7 +107,7 @@ class KubernetesGCPServiceAccountSecretManager {
     try {
       return serviceAccountSecretCache.get(serviceAccount, () ->
           getOrCreateSecret(workflowId, serviceAccount, epoch, secretName));
-    } catch (Exception e) {
+    } catch (ExecutionException e) {
       final Throwable cause = e.getCause();
       if (cause instanceof InvalidExecutionException) {
         throw (InvalidExecutionException) cause;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.googleapis.json.GoogleJsonError;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.http.HttpResponseException.Builder;
+import com.google.api.client.http.HttpResponseException;
 import com.google.api.services.iam.v1.model.ServiceAccountKey;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -338,6 +338,23 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
   }
 
   @Test
+  public void shouldHandleTooManyKeysCreated() throws IOException {
+    when(serviceAccountKeyManager.serviceAccountExists(anyString())).thenReturn(true);
+
+    final GoogleJsonResponseException resourceExhausted = new GoogleJsonResponseException(
+        new HttpResponseException.Builder(429, "RESOURCE_EXHAUSTED", new HttpHeaders()),
+        new GoogleJsonError().set("status", "RESOURCE_EXHAUSTED"));
+
+    doThrow(resourceExhausted).when(serviceAccountKeyManager).createJsonKey(any());
+    doThrow(resourceExhausted).when(serviceAccountKeyManager).createP12Key(any());
+
+    exception.expect(InvalidExecutionException.class);
+    exception.expectMessage("Maximum number of keys on service account reached: " + SERVICE_ACCOUNT);
+
+    sut.ensureServiceAccountKeySecret(WORKFLOW_ID.toString(), SERVICE_ACCOUNT);
+  }
+
+  @Test
   public void shouldHandlePermissionDeniedErrorsWhenDeletingServiceAccountKeys() throws Exception {
     final Secret secret = fakeServiceAccountKeySecret(
         SERVICE_ACCOUNT, SECRET_EPOCH, "json-key", "p12-key", EXPIRED_CREATION_TIMESTAMP.toString());
@@ -349,8 +366,8 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
 
     // Verify that the secret is delete even if we get permission denied errors on deleting the keys
     final GoogleJsonResponseException permissionDenied = new GoogleJsonResponseException(
-        new Builder(403, "Forbidden", new HttpHeaders()), new GoogleJsonError()
-        .set("status", "PERMISSION_DENIED"));
+        new HttpResponseException.Builder(403, "Forbidden", new HttpHeaders()),
+        new GoogleJsonError().set("status", "PERMISSION_DENIED"));
     doThrow(permissionDenied).when(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "json-key"));
     doThrow(permissionDenied).when(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "p12-key"));
 


### PR DESCRIPTION
This kind of exception isn't handled properly hence if it happens users will see Google related exception as event description, which is not so friendly.