### PR TITLE
Enable V3 api

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
@@ -22,6 +22,7 @@ package com.spotify.styx.api;
 
 import static com.spotify.apollo.StatusType.Family.SUCCESSFUL;
 import static com.spotify.styx.api.Api.Version.V2;
+import static com.spotify.styx.api.Api.Version.V3;
 import static com.spotify.styx.serialization.Json.serialize;
 import static com.spotify.styx.util.ParameterUtil.rangeOfInstants;
 import static com.spotify.styx.util.ParameterUtil.toParameter;
@@ -118,8 +119,8 @@ public final class BackfillResource {
     );
 
     return cat(
-        Api.prefixRoutes(entityRoutes, V2),
-        Api.prefixRoutes(routes, V2)
+        Api.prefixRoutes(entityRoutes, V2, V3),
+        Api.prefixRoutes(routes, V2, V3)
     );
   }
 

--- a/styx-api-service/src/main/java/com/spotify/styx/api/ResourceResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/ResourceResource.java
@@ -22,6 +22,7 @@ package com.spotify.styx.api;
 
 import static com.spotify.styx.api.Api.Version.V1;
 import static com.spotify.styx.api.Api.Version.V2;
+import static com.spotify.styx.api.Api.Version.V3;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.base.Throwables;
@@ -80,7 +81,7 @@ public final class ResourceResource {
         .map(r -> r.withMiddleware(Middleware::syncToAsync))
         .collect(toList());
 
-    return Api.prefixRoutes(routes, V1, V2);
+    return Api.prefixRoutes(routes, V1, V2, V3);
   }
 
   private ResourcesPayload getResources() {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.api;
 
 import static com.spotify.styx.api.Api.Version.V2;
+import static com.spotify.styx.api.Api.Version.V3;
 
 import com.spotify.apollo.RequestContext;
 import com.spotify.apollo.Response;
@@ -66,7 +67,7 @@ public class SchedulerProxyResource {
             rc -> proxyToScheduler("/" + rc.pathArgs().get("endpoint"), rc))
     );
 
-    return Api.prefixRoutes(schedulerProxies, V2);
+    return Api.prefixRoutes(schedulerProxies, V2, V3);
   }
 
   private CompletionStage<Response<ByteString>> proxyToScheduler(String path, RequestContext rc) {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.api;
 
 import static com.spotify.styx.api.Api.Version.V2;
+import static com.spotify.styx.api.Api.Version.V3;
 import static com.spotify.styx.util.ReplayEvents.replayActiveStates;
 import static java.util.stream.Collectors.toList;
 
@@ -78,7 +79,7 @@ public class StatusResource {
         .map(r -> r.withMiddleware(Middleware::syncToAsync))
         .collect(toList());
 
-    return Api.prefixRoutes(routes, V2);
+    return Api.prefixRoutes(routes, V2, V3);
   }
 
   private static String arg(String name, RequestContext rc) {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/StyxConfigResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/StyxConfigResource.java
@@ -23,6 +23,7 @@ package com.spotify.styx.api;
 import static com.spotify.styx.api.Api.Version.V0;
 import static com.spotify.styx.api.Api.Version.V1;
 import static com.spotify.styx.api.Api.Version.V2;
+import static com.spotify.styx.api.Api.Version.V3;
 import static com.spotify.styx.api.Middlewares.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -62,7 +63,7 @@ public class StyxConfigResource {
             rc -> patchStyxConfig(rc.request()))
     );
 
-    return Api.prefixRoutes(routes, V0, V1, V2);
+    return Api.prefixRoutes(routes, V0, V1, V2, V3);
   }
 
   private Response<StyxConfig> styxConfig() {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.api;
 
 import static com.spotify.styx.api.Api.Version.V2;
+import static com.spotify.styx.api.Api.Version.V3;
 import static com.spotify.styx.api.Middlewares.json;
 import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
 
@@ -79,9 +80,8 @@ public final class WorkflowResource {
             rc -> patchState(arg("cid", rc), rc.request()))
     );
 
-    return Api.prefixRoutes(routes, V2);
+    return Api.prefixRoutes(routes, V2, V3);
   }
-
 
   public Response<WorkflowState> patchState(String componentId, String id, Request request) {
     final Optional<ByteString> payload = request.payload();

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx.client;
 
+import static com.spotify.styx.api.Api.Version.V3;
 import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
 import static com.spotify.styx.serialization.Json.serialize;
 
@@ -66,7 +67,7 @@ import okio.ByteString;
  * as {@link RuntimeException} instead.
  */
 class StyxApolloClient implements StyxClient {
-  private static final String STYX_API_VERSION = "v2";
+  private static final String STYX_API_VERSION = V3.name().toLowerCase();
   private static final String STYX_CLIENT_VERSION =
       "Styx Client " + StyxApolloClient.class.getPackage().getImplementationVersion();
   private static final Duration TTL = Duration.ofSeconds(90);

--- a/styx-common/src/main/java/com/spotify/styx/api/Api.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/Api.java
@@ -37,7 +37,7 @@ import okio.ByteString;
 public final class Api {
 
   public enum Version {
-    V0, V1, V2;
+    V0, V1, V2, V3;
 
     public String prefix() {
       return "/api/v" + ordinal();

--- a/styx-common/src/main/java/com/spotify/styx/api/Middlewares.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/Middlewares.java
@@ -161,15 +161,16 @@ public final class Middlewares {
       final Request request = requestContext.request();
 
       if (!"GET".equals(request.method())) {
-        final AuthContext authContext = auth(requestContext);
         LOG.info("[AUDIT] {} {} by {} with headers {} parameters {} and payload {}",
-            request.method(),
-            request.uri(),
-            authContext.user().map(idToken -> idToken.getPayload().getEmail()).orElse("anonymous"),
-            filterHeaders(request.headers()),
-            request.parameters(),
-            request.payload().map(ByteString::utf8).orElse("")
-                .replaceAll("\n", " "));
+                 request.method(),
+                 request.uri(),
+                 auth(requestContext).user().map(idToken -> idToken.getPayload()
+                     .getEmail())
+                     .orElse("anonymous"),
+                 filterHeaders(request.headers()),
+                 request.parameters(),
+                 request.payload().map(ByteString::utf8).orElse("")
+                     .replaceAll("\n", " "));
       }
       return innerHandler.invoke(requestContext);
     };

--- a/styx-common/src/test/java/com/spotify/styx/api/MiddlewaresTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/api/MiddlewaresTest.java
@@ -291,6 +291,31 @@ public class MiddlewaresTest {
     assertThat(response, hasStatus(withCode(Status.IM_A_TEAPOT)));
   }
 
+  @Test
+  public void testAuthValidatorForGet() throws Exception {
+    RequestContext requestContext = mock(RequestContext.class);
+    Request request = Request.forUri("/", "GET");
+    when(requestContext.request()).thenReturn(request);
+
+    Response<Object> response = awaitResponse(Middlewares.authValidator()
+                                                  .apply(mockInnerHandler(requestContext))
+                                                  .invoke(requestContext));
+    assertThat(response, hasStatus(withCode(Status.OK)));
+  }
+
+  @Test
+  public void testAuthValidatorForPut() throws Exception {
+    RequestContext requestContext = mock(RequestContext.class);
+    Request request = Request.forUri("/", "PUT")
+        .withPayload(ByteString.encodeUtf8("hello"));
+    when(requestContext.request()).thenReturn(request);
+
+    Response<Object> response = awaitResponse(Middlewares.authValidator()
+                                                  .apply(mockInnerHandler(requestContext))
+                                                  .invoke(requestContext));
+    assertThat(response, hasStatus(withCode(Status.UNAUTHORIZED)));
+  }
+
   public static <T> Response<T> awaitResponse(CompletionStage<Response<T>> completionStage)
       throws Exception {
     return completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);


### PR DESCRIPTION
Keep backward compatibility for older api versions while attaching
authValidator middleware to V3.