### PR TITLE
Revert "log k8s events at debug level"

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -455,7 +455,7 @@ class KubernetesDockerRunner implements DockerRunner {
         .getOrDefault(KubernetesDockerRunner.STYX_WORKFLOW_INSTANCE_ANNOTATION, "N/A");
     final String status = readStatus(pod);
 
-    LOG.debug("{}Pod event for {} at resource version {}, action: {}, workflow instance: {}, status: {}",
+    LOG.info("{}Pod event for {} at resource version {}, action: {}, workflow instance: {}, status: {}",
              polled ? "Polled: " : "", podName, resourceVersion, action, workflowInstance, status);
   }
 


### PR DESCRIPTION
Reverts spotify/styx#221

Log persisting for debug level is not yet set up. I was unaware that the PR was not ready to merge.