### PR TITLE
fix checkstyle config warning

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -234,6 +234,5 @@
     <!-- http://checkstyle.sourceforge.net/config_filters.html#SuppressionFilter -->
     <module name="SuppressionFilter">
         <property name="file" value="suppressions.xml"/>
-        <property name="optional" value="true"/>
     </module>
 </module>


### PR DESCRIPTION
"optional" flag was added in 6.15 (we use 6.11.2)