### PR TITLE
Remove docker image requirement

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -134,11 +134,6 @@ public final class WorkflowResource {
           Response.forStatus(Status.BAD_REQUEST.withReasonPhrase("Invalid payload.")));
     }
 
-    if (!workflowConfig.dockerImage().isPresent()) {
-      return CompletableFuture.completedFuture(
-          Response.forStatus(Status.BAD_REQUEST.withReasonPhrase("docker_image is required")));
-    }
-
     final Workflow workflow = Workflow.create(componentId,
                                               Optional.empty(),
                                               Optional.of(V3),

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -585,18 +585,6 @@ public class WorkflowResourceTest extends VersionedApiTest {
     assertThat(response, hasNoPayload());
   }
 
-  @Test
-  public void shouldReturnBadRequestWhenMissingDockerImage() throws Exception {
-    sinceVersion(Api.Version.V3);
-
-    Response<ByteString> response =
-        awaitResponse(
-            serviceHelper.request("POST", path("/foo"), serialize(WORKFLOW_CONFIGURATION)));
-
-    assertThat(response, hasStatus(withCode(Status.BAD_REQUEST)));
-    assertThat(response.status(), withReasonPhrase(equalTo("docker_image is required")));
-  }
-
   private long ms(String time) {
     return Instant.parse("2016-08-10T" + time + "Z").toEpochMilli();
   }


### PR DESCRIPTION
Users should be able to create workflows without specifying a docker image.