### PR TITLE
treat iam 403s as 404

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
@@ -64,7 +64,8 @@ public class ServiceAccountKeyManager {
           .execute();
       return true;
     } catch (GoogleJsonResponseException e) {
-      if (e.getStatusCode() == 404) {
+      // TODO: handle 403 correctly once google fixes their API
+      if (e.getStatusCode() == 403 || e.getStatusCode() == 404) {
         return false;
       }
       throw e;
@@ -85,7 +86,8 @@ public class ServiceAccountKeyManager {
           .delete(keyName)
           .execute();
     } catch (GoogleJsonResponseException e) {
-      if (e.getStatusCode() == 404) {
+      // TODO: handle 403 correctly once google fixes their API
+      if (e.getStatusCode() == 403 || e.getStatusCode() == 404) {
         return;
       }
       throw e;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/ServiceAccountKeyManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/ServiceAccountKeyManagerTest.java
@@ -1,0 +1,116 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.services.iam.v1.Iam;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceAccountKeyManagerTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  Iam iam;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  Iam.Projects.ServiceAccounts serviceAccounts;
+
+  @Mock
+  Iam.Projects.ServiceAccounts.Keys.Delete delete;
+
+  @Mock
+  Iam.Projects.ServiceAccounts.Keys.Get get;
+
+  ServiceAccountKeyManager sakm;
+
+  private static final GoogleJsonResponseException INTERNAL_SERVER_ERROR =
+      new GoogleJsonResponseException(
+          new HttpResponseException.Builder(500, "Internal Server Error", new HttpHeaders()),
+          new GoogleJsonError().set("status", "INTERNAL_SERVER_ERROR"));
+
+  private static final GoogleJsonResponseException PERMISSION_DENIED =
+      new GoogleJsonResponseException(
+          new HttpResponseException.Builder(403, "Forbidden", new HttpHeaders()),
+          new GoogleJsonError().set("status", "PERMISSION_DENIED"));
+
+  private static final GoogleJsonResponseException NOT_FOUND =
+      new GoogleJsonResponseException(
+          new HttpResponseException.Builder(404, "Not found", new HttpHeaders()),
+          new GoogleJsonError().set("status", "NOT_FOUND"));
+
+  @Before
+  public void setup() throws Exception {
+    when(iam.projects().serviceAccounts()).thenReturn(serviceAccounts);
+    when(serviceAccounts.keys().get(any())).thenReturn(get);
+    when(serviceAccounts.keys().delete(any())).thenReturn(delete);
+
+    sakm = new ServiceAccountKeyManager(iam);
+  }
+
+  @Test
+  public void keyExistsTreatsPermissionDeniedAsNotFound() throws Exception {
+    when(get.execute()).thenThrow(PERMISSION_DENIED);
+    assertThat(sakm.keyExists("foo"), is(false));
+  }
+
+  @Test
+  public void keyExistsReturnsFalseForNotFound() throws Exception {
+    when(get.execute()).thenThrow(NOT_FOUND);
+    assertThat(sakm.keyExists("foo"), is(false));
+  }
+
+  @Test(expected = GoogleJsonResponseException.class)
+  public void keyExistsShouldThrowUnknownExceptions() throws Exception {
+    when(get.execute()).thenThrow(INTERNAL_SERVER_ERROR);
+    sakm.keyExists("foo");
+  }
+
+  @Test(expected = GoogleJsonResponseException.class)
+  public void deleteKeyShouldThrowUnknownExceptions() throws Exception {
+    when(delete.execute()).thenThrow(INTERNAL_SERVER_ERROR);
+    sakm.deleteKey("foo");
+  }
+
+  @Test
+  public void deleteKeyShouldIgnorePermissionDenied() throws Exception {
+    when(delete.execute()).thenThrow(PERMISSION_DENIED);
+    sakm.deleteKey("foo");
+  }
+
+  @Test
+  public void deleteKeyShouldIgnoreNotFound() throws Exception {
+    when(delete.execute()).thenThrow(NOT_FOUND);
+    sakm.deleteKey("foo");
+  }
+}


### PR DESCRIPTION
It seems Google's IAM API is returning 403's even though the service account used to make the call has ServiceAccountKeyAdmin permission on the service account. Not sure if this is new but haven't seen this problem before.