### PR TITLE
move rate limiting to scheduler

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -160,9 +160,9 @@ public class Scheduler {
     timedOutInstances.forEach(this::sendTimeout);
 
     for (InstanceState eligibleInstance : eligibleInstances) {
-      final boolean stop = limitAndDequeue(
+      final boolean proceed = limitAndDequeue(
           resources, workflowResourceReferences, currentResourceUsage, eligibleInstance);
-      if (stop) {
+      if (!proceed) {
         break;
       }
     }
@@ -222,14 +222,14 @@ public class Scheduler {
     } else {
       if (!dequeueRateLimiter.tryAcquire()) {
         LOG.debug("Dequeue rate limited");
-        return true;
+        return false;
       }
       instanceResourceRefs.forEach(id -> currentResourceUsage.computeIfAbsent(id, id_ -> 0L));
       instanceResourceRefs.forEach(id -> currentResourceUsage.compute(id, (id_, l) -> l + 1));
       sendDequeue(instance);
     }
 
-    return false;
+    return true;
   }
 
   private Stream<ResourceWithInstance> pairWithResources(Optional<Long> globalConcurrency,

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -278,11 +278,6 @@ public class StyxScheduler implements AppInit {
         .setNameFormat("styx-event-worker-%d")
         .setUncaughtExceptionHandler(uncaughtExceptionHandler)
         .build();
-    final ThreadFactory dockerRunnerTf = new ThreadFactoryBuilder()
-        .setDaemon(true)
-        .setNameFormat("styx-docker-runner-%d")
-        .setUncaughtExceptionHandler(uncaughtExceptionHandler)
-        .build();
 
     final Publisher publisher = publisherFactory.apply(environment);
     closer.register(publisher);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -289,10 +289,8 @@ public class StyxScheduler implements AppInit {
 
     final ScheduledExecutorService executor = executorFactory.create(3, schedulerTf);
     final ExecutorService eventWorker = Executors.newFixedThreadPool(16, eventTf);
-    final ExecutorService dockerRunnerExecutor = Executors.newSingleThreadExecutor(dockerRunnerTf);
     closer.register(executorCloser("scheduler", executor));
     closer.register(executorCloser("event-worker", eventWorker));
-    closer.register(executorCloser("docker-runner", dockerRunnerExecutor));
 
     final Stats stats = statsFactory.apply(environment);
     final WorkflowCache workflowCache = new InMemWorkflowCache();

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -50,64 +50,53 @@ public class DockerRunnerHandler implements OutputHandler {
 
   private final DockerRunner dockerRunner;
   private final StateManager stateManager;
-  private final RateLimiter rateLimiter;
-  private final ExecutorService executor;
 
   public DockerRunnerHandler(
       DockerRunner dockerRunner,
-      StateManager stateManager,
-      RateLimiter rateLimiter,
-      ExecutorService executor) {
+      StateManager stateManager) {
     this.dockerRunner = requireNonNull(dockerRunner);
     this.stateManager = requireNonNull(stateManager);
-    this.rateLimiter = requireNonNull(rateLimiter, "rateLimiter");
-    this.executor = requireNonNull(executor, "executor");
   }
 
   @Override
   public void transitionInto(RunState state) {
     switch (state.state()) {
       case SUBMITTING:
-        // Perform rate limited submission on a separate thread pool to avoid blocking the caller.
-        executor.submit(() -> {
-          rateLimiter.acquire();
+        final RunSpec runSpec;
+        try {
+          runSpec = createRunSpec(state);
+        } catch (ResourceNotFoundException e) {
+          LOG.error("Unable to start docker procedure.", e);
+          stateManager.receiveIgnoreClosed(Event.halt(state.workflowInstance()));
+          return;
+        }
 
-          final RunSpec runSpec;
-          try {
-            runSpec = createRunSpec(state);
-          } catch (ResourceNotFoundException e) {
-            LOG.error("Unable to start docker procedure.", e);
-            stateManager.receiveIgnoreClosed(Event.halt(state.workflowInstance()));
-            return;
-          }
+        // Emit submitted event first to guarantee it is observed before events from the pod
+        final Event submitted = Event.submitted(state.workflowInstance(), runSpec.executionId());
+        try {
+          stateManager.receive(submitted);
+        } catch (StateManager.IsClosed isClosed) {
+          LOG.warn("Could not emit 'submitted' event", isClosed);
+          return;
+        }
 
-          // Emit submitted event first to guarantee it is observed before events from the pod
-          final Event submitted = Event.submitted(state.workflowInstance(), runSpec.executionId());
+        try {
+          LOG.info("running:{} image:{} args:{} termination_logging:{}", state.workflowInstance().toKey(),
+              runSpec.imageName(), runSpec.args(), runSpec.terminationLogging());
+          dockerRunner.start(state.workflowInstance(), runSpec);
+        } catch (Throwable e) {
           try {
-            stateManager.receive(submitted);
-          } catch (StateManager.IsClosed isClosed) {
-            LOG.warn("Could not emit 'submitted' event", isClosed);
-            return;
-          }
-
-          try {
-            LOG.info("running:{} image:{} args:{} termination_logging:{}", state.workflowInstance().toKey(),
-                runSpec.imageName(), runSpec.args(), runSpec.terminationLogging());
-            dockerRunner.start(state.workflowInstance(), runSpec);
-          } catch (Throwable e) {
-            try {
-              final String msg = "Failed the docker starting procedure for " + state.workflowInstance().toKey();
-              if (isUserError(e)) {
-                LOG.info("{}: {}", msg, e.getMessage());
-              } else {
-                LOG.error(msg, e);
-              }
-              stateManager.receive(Event.runError(state.workflowInstance(), e.getMessage()));
-            } catch (StateManager.IsClosed isClosed) {
-              LOG.warn("Failed to send 'runError' event", isClosed);
+            final String msg = "Failed the docker starting procedure for " + state.workflowInstance().toKey();
+            if (isUserError(e)) {
+              LOG.info("{}: {}", msg, e.getMessage());
+            } else {
+              LOG.error(msg, e);
             }
+            stateManager.receive(Event.runError(state.workflowInstance(), e.getMessage()));
+          } catch (StateManager.IsClosed isClosed) {
+            LOG.warn("Failed to send 'runError' event", isClosed);
           }
-        });
+        }
         break;
 
       case TERMINATED:

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -73,6 +73,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
@@ -105,6 +106,11 @@ public class SchedulerTest {
   @Mock WorkflowResourceDecorator resourceDecorator;
 
   @Mock RateLimiter rateLimiter;
+
+  @Before
+  public void setUp() throws Exception {
+    when(rateLimiter.tryAcquire()).thenReturn(true);
+  }
 
   @After
   public void tearDown() throws Exception {


### PR DESCRIPTION
Avoid WFI's timing out waiting on submission rate limiting.

This can cause a long backlog of duplicate pod submissions to build up, produce a lot of duplicate executions and delayed executions.