### PR TITLE
remove v0-v2 API endpoints

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -20,7 +20,6 @@
 
 package com.spotify.styx;
 
-import static com.spotify.styx.api.Api.Version.V3;
 import static com.spotify.styx.api.Middlewares.authValidator;
 import static com.spotify.styx.util.Connections.createBigTableConnection;
 import static com.spotify.styx.util.Connections.createDatastore;
@@ -108,8 +107,7 @@ public class StyxApi implements AppInit {
 
     final Storage storage = storageFactory.apply(environment);
 
-    final WorkflowResource workflowResource =
-        new WorkflowResource(storage, schedulerServiceBaseUrl);
+    final WorkflowResource workflowResource = new WorkflowResource(storage);
     final BackfillResource backfillResource = new BackfillResource(schedulerServiceBaseUrl,
                                                                    storage);
     final ResourceResource resourceResource = new ResourceResource(storage);
@@ -118,31 +116,17 @@ public class StyxApi implements AppInit {
     final SchedulerProxyResource schedulerProxyResource = new SchedulerProxyResource(
         schedulerServiceBaseUrl);
 
-    final com.spotify.styx.api.deprecated.WorkflowResource
-        deprecatedWorkflowResource =
-        new com.spotify.styx.api.deprecated.WorkflowResource(workflowResource);
-    final com.spotify.styx.api.deprecated.BackfillResource
-        deprecatedBackfillResource =
-        new com.spotify.styx.api.deprecated.BackfillResource(backfillResource);
-    final com.spotify.styx.api.deprecated.CliResource
-        deprecatedCliResource =
-        new com.spotify.styx.api.deprecated.CliResource(statusResource, schedulerServiceBaseUrl);
-
     final Supplier<Optional<List<String>>> clientBlacklistSupplier =
         new CachedSupplier<>(storage::clientBlacklist, Instant::now);
 
-    // TODO remove deprecated resources and remove V3 hack
     final Stream<Route<AsyncHandler<Response<ByteString>>>> routes = StreamUtil.cat(
-        deprecatedWorkflowResource.routes(),
-        deprecatedBackfillResource.routes(),
-        deprecatedCliResource.routes(),
         workflowResource.routes(),
         backfillResource.routes(),
         resourceResource.routes(),
         styxConfigResource.routes(),
         statusResource.routes(),
         schedulerProxyResource.routes()
-    ).map(r -> r.uri().startsWith(V3.prefix()) ? r.withMiddleware(authValidator()) : r);
+    ).map(r -> r.withMiddleware(authValidator()));
 
     environment.routingEngine()
         .registerAutoRoute(Route.sync("GET", "/ping", rc -> "pong"))

--- a/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
@@ -21,7 +21,6 @@
 package com.spotify.styx.api;
 
 import static com.spotify.apollo.StatusType.Family.SUCCESSFUL;
-import static com.spotify.styx.api.Api.Version.V2;
 import static com.spotify.styx.api.Api.Version.V3;
 import static com.spotify.styx.serialization.Json.serialize;
 import static com.spotify.styx.util.ParameterUtil.rangeOfInstants;
@@ -119,8 +118,8 @@ public final class BackfillResource {
     );
 
     return cat(
-        Api.prefixRoutes(entityRoutes, V2, V3),
-        Api.prefixRoutes(routes, V2, V3)
+        Api.prefixRoutes(entityRoutes, V3),
+        Api.prefixRoutes(routes, V3)
     );
   }
 

--- a/styx-api-service/src/main/java/com/spotify/styx/api/ResourceResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/ResourceResource.java
@@ -20,8 +20,6 @@
 
 package com.spotify.styx.api;
 
-import static com.spotify.styx.api.Api.Version.V1;
-import static com.spotify.styx.api.Api.Version.V2;
 import static com.spotify.styx.api.Api.Version.V3;
 import static java.util.stream.Collectors.toList;
 
@@ -81,7 +79,7 @@ public final class ResourceResource {
         .map(r -> r.withMiddleware(Middleware::syncToAsync))
         .collect(toList());
 
-    return Api.prefixRoutes(routes, V1, V2, V3);
+    return Api.prefixRoutes(routes, V3);
   }
 
   private ResourcesPayload getResources() {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
@@ -20,7 +20,6 @@
 
 package com.spotify.styx.api;
 
-import static com.spotify.styx.api.Api.Version.V2;
 import static com.spotify.styx.api.Api.Version.V3;
 
 import com.spotify.apollo.RequestContext;
@@ -67,7 +66,7 @@ public class SchedulerProxyResource {
             rc -> proxyToScheduler("/" + rc.pathArgs().get("endpoint"), rc))
     );
 
-    return Api.prefixRoutes(schedulerProxies, V2, V3);
+    return Api.prefixRoutes(schedulerProxies, V3);
   }
 
   private CompletionStage<Response<ByteString>> proxyToScheduler(String path, RequestContext rc) {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
@@ -20,7 +20,6 @@
 
 package com.spotify.styx.api;
 
-import static com.spotify.styx.api.Api.Version.V2;
 import static com.spotify.styx.api.Api.Version.V3;
 import static com.spotify.styx.util.ReplayEvents.replayActiveStates;
 import static java.util.stream.Collectors.toList;
@@ -79,7 +78,7 @@ public class StatusResource {
         .map(r -> r.withMiddleware(Middleware::syncToAsync))
         .collect(toList());
 
-    return Api.prefixRoutes(routes, V2, V3);
+    return Api.prefixRoutes(routes, V3);
   }
 
   private static String arg(String name, RequestContext rc) {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/StyxConfigResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/StyxConfigResource.java
@@ -20,9 +20,6 @@
 
 package com.spotify.styx.api;
 
-import static com.spotify.styx.api.Api.Version.V0;
-import static com.spotify.styx.api.Api.Version.V1;
-import static com.spotify.styx.api.Api.Version.V2;
 import static com.spotify.styx.api.Api.Version.V3;
 import static com.spotify.styx.api.Middlewares.json;
 
@@ -63,7 +60,7 @@ public class StyxConfigResource {
             rc -> patchStyxConfig(rc.request()))
     );
 
-    return Api.prefixRoutes(routes, V0, V1, V2, V3);
+    return Api.prefixRoutes(routes, V3);
   }
 
   private Response<StyxConfig> styxConfig() {

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -182,7 +182,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldListBackfillsNoStatus() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("GET", path("")));
@@ -194,7 +194,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldListBackfillsWithStatus() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("GET", path("?status=true")));
@@ -206,7 +206,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldFilterBackfillsOnComponentEvenWhenInactive() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     storage.storeBackfill(BACKFILL_3.builder().allTriggered(true).build());
 
@@ -221,7 +221,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldFilterBackfillsOnComponent() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     storage.storeBackfill(BACKFILL_3);
 
@@ -236,7 +236,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldFilterBackfillsOnWorkflow() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     storage.storeBackfill(BACKFILL_2);
     storage.storeBackfill(BACKFILL_3);
@@ -253,7 +253,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldFilterBackfillsOnComponentWorkflow() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     storage.storeBackfill(BACKFILL_2);
     storage.storeBackfill(BACKFILL_3);
@@ -271,7 +271,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldListActiveBackfillsByDefault() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     storage.storeBackfill(BACKFILL_2.builder().allTriggered(true).build());
     Response<ByteString> response =
@@ -283,7 +283,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldListAllBackfillsWithFlag() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     storage.storeBackfill(BACKFILL_2.builder().halted(true).build());
     Response<ByteString> response =
@@ -294,7 +294,7 @@ public class BackfillResourceTest extends VersionedApiTest {
   }
    @Test
   public void shouldListMultipleBackfills() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     storage.storeBackfill(BACKFILL_2);
     Response<ByteString> response =
@@ -306,7 +306,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldGetBackfillStatus() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     WorkflowInstance wfi = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T01");
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T02:00:00Z")).build());
@@ -331,7 +331,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldPostBackfill() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     final String json = "{\"start\":\"2017-01-01T00:00:00Z\"," +
                         "\"end\":\"2017-02-01T00:00:00Z\"," +
@@ -359,7 +359,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldFailOnMisalignedRange() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     final String json = "{\"start\":\"2017-01-01T00:00:01Z\"," +
                         "\"end\":\"2017-02-01T00:00:00Z\"," +
@@ -376,7 +376,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldFailOnAlreadyActiveWithinRange() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     final BackfillInput backfillInput = BackfillInput.create(
         BACKFILL_1.start(),
@@ -396,7 +396,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldUpdateBackfill() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     assertThat(storage.backfill(BACKFILL_1.id()).get().concurrency(), equalTo(1));
 
@@ -417,7 +417,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldHaltBackfill() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     serviceHelper.stubClient()
         .respond(Response.forStatus(Status.ACCEPTED))
@@ -443,7 +443,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldNotHaltWaitingInstanceInBackfill() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     serviceHelper.stubClient()
         .respond(Response.forStatus(Status.ACCEPTED))
@@ -471,7 +471,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldReturnServerErrorIfFailedToSend() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     serviceHelper.stubClient().respond(Responses.sequence(ImmutableList.of(ResponseWithDelay
                                                                                .forResponse(Response
@@ -513,7 +513,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldOnlyUpdateBackfillIfSameId() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     final Backfill updatedBackfill = BACKFILL_1.builder().concurrency(4).build();
     final String json = Json.OBJECT_MAPPER.writeValueAsString(updatedBackfill);

--- a/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
@@ -113,7 +113,7 @@ public class ResourceResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldListResources() throws Exception {
-    sinceVersion(Api.Version.V1);
+    sinceVersion(Api.Version.V3);
 
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("GET", path("")));
@@ -125,7 +125,7 @@ public class ResourceResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldListMultipleResources() throws Exception {
-    sinceVersion(Api.Version.V1);
+    sinceVersion(Api.Version.V3);
 
     storage.storeResource(RESOURCE_2);
     Response<ByteString> response =
@@ -141,7 +141,7 @@ public class ResourceResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldGetResource() throws Exception {
-    sinceVersion(Api.Version.V1);
+    sinceVersion(Api.Version.V3);
 
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("GET", path("/resource1")));
@@ -153,7 +153,7 @@ public class ResourceResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldPostResource() throws Exception {
-    sinceVersion(Api.Version.V1);
+    sinceVersion(Api.Version.V3);
 
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("POST", path(""),
@@ -168,7 +168,7 @@ public class ResourceResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldUpdateResource() throws Exception {
-    sinceVersion(Api.Version.V1);
+    sinceVersion(Api.Version.V3);
 
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("PUT", path("/resource1"),
@@ -183,7 +183,7 @@ public class ResourceResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldDeleteResource() throws Exception {
-    sinceVersion(Api.Version.V1);
+    sinceVersion(Api.Version.V3);
 
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("DELETE", path("/resource1")));
@@ -195,7 +195,7 @@ public class ResourceResourceTest extends VersionedApiTest {
 
   @Test
   public void shouldHandleMultipleResourcesIndependently() throws Exception {
-    sinceVersion(Api.Version.V1);
+    sinceVersion(Api.Version.V3);
 
     // add resource2
     awaitResponse(serviceHelper.request("POST", path(""),

--- a/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
@@ -49,7 +49,7 @@ public class SchedulerProxyResourceTest extends VersionedApiTest {
 
   @Test
   public void testEventInjectionProxy() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     serviceHelper.stubClient()
         .respond(Response.forStatus(Status.ACCEPTED))
@@ -63,7 +63,7 @@ public class SchedulerProxyResourceTest extends VersionedApiTest {
 
   @Test
   public void testTriggerWorkflowInstanceProxy() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     serviceHelper.stubClient()
         .respond(Response.forStatus(Status.ACCEPTED))

--- a/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
@@ -71,7 +71,7 @@ public class StatusResourceTest extends VersionedApiTest {
 
   @Test
   public void testEventsRoundtrip() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI, TRIGGER), 0L, 0L));
     storage.writeEvent(SequenceEvent.create(Event.created(WFI, "exec0", "img0"), 1L, 1L));
@@ -91,7 +91,7 @@ public class StatusResourceTest extends VersionedApiTest {
 
   @Test
   public void testGetAllActiveStates() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     storage.writeActiveState(WFI, 42L);
     storage.writeActiveState(OTHER_WFI, 84L);
@@ -111,7 +111,7 @@ public class StatusResourceTest extends VersionedApiTest {
 
   @Test
   public void testFilterActiveStatesOnComponent() throws Exception {
-    sinceVersion(Api.Version.V2);
+    sinceVersion(Api.Version.V3);
 
     WorkflowInstance OTHER_WFI =
         WorkflowInstance.create(WorkflowId.create(COMPONENT_ID + "-other", ID), PARAMETER);

--- a/styx-api-service/src/test/java/com/spotify/styx/api/deprecated/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/deprecated/WorkflowResourceTest.java
@@ -75,8 +75,6 @@ import org.junit.Test;
 @Deprecated
 public class WorkflowResourceTest extends VersionedApiTest {
 
-  private static final String SCHEDULER_BASE = "http://localhost:12345";
-
   private static LocalDatastoreHelper localDatastore;
 
   private Datastore datastore = localDatastore.getOptions().getService();
@@ -129,8 +127,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
   protected void init(Environment environment) {
     WorkflowResource
         workflowResource =
-        new WorkflowResource(new com.spotify.styx.api.WorkflowResource(storage,
-                                                                       SCHEDULER_BASE));
+        new WorkflowResource(new com.spotify.styx.api.WorkflowResource(storage));
 
     environment.routingEngine().registerRoutes(workflowResource.routes());
   }


### PR DESCRIPTION
Deprecated Java classes are still there. We either remove them
completely or keep them there, but will address that in a different PR.
