### PR TITLE
Fix bug in delay of pod cleanup

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -427,12 +427,9 @@ class KubernetesDockerRunner implements DockerRunner {
       if (!workflowInstance.isPresent()) {
         continue;
       }
-      final Optional<RunState> runState = lookupPodRunState(pod, workflowInstance.get());
-      if (runState.isPresent()) {
-        emitPodEvents(Watcher.Action.MODIFIED, pod, runState.get());
-      } else {
-        cleanup(workflowInstance.get(), pod.getMetadata().getName());
-      }
+      lookupPodRunState(pod, workflowInstance.get())
+          .ifPresent(runState -> emitPodEvents(Watcher.Action.MODIFIED, pod, runState));
+      cleanup(workflowInstance.get(), pod.getMetadata().getName());
     }
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -512,6 +512,8 @@ public class KubernetesDockerRunnerTest {
 
   @Test
   public void shouldPollPodStatusAndEmitEventsOnRestore() throws Exception {
+    when(k8sClient.pods().withName(createdPod.getMetadata().getName())).thenReturn(namedPod);
+
     // Stop the runner and change the pod status to terminated while styx is "down"
     kdr.close();
     createdPod.setStatus(terminated("Succeeded", 20, null));
@@ -531,6 +533,8 @@ public class KubernetesDockerRunnerTest {
 
   @Test
   public void shouldRegularlyPollPodStatusAndEmitEvents() throws Exception {
+    when(k8sClient.pods().withName(createdPod.getMetadata().getName())).thenReturn(namedPod);
+
     createdPod.setStatus(running(/* ready= */ true));
 
     // Set up a runner with short poll interval to avoid this test having to wait a long time for the poll

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -222,29 +222,21 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
-  public void shouldCleanupRunningPodNotTrackedByStyx() throws Exception {
+  public void shouldNotDeletePodIfDebugEnabled() throws Exception {
+    when(debug.get()).thenReturn(true);
     final String name = createdPod.getMetadata().getName();
     when(k8sClient.pods().withName(name)).thenReturn(namedPod);
     when(namedPod.get()).thenReturn(createdPod);
 
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
-    
     when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
     when(containerStatus.getName()).thenReturn(KubernetesDockerRunner.STYX_RUN);
     when(containerStatus.getState()).thenReturn(containerState);
-    when(containerState.getRunning()).thenReturn(containerStateRunning);
+    when(containerState.getTerminated()).thenReturn(containerStateTerminated);
+    when(containerStateTerminated.getFinishedAt())
+        .thenReturn(FIXED_INSTANT.minus(Duration.ofMinutes(5)).toString());
 
-    kdr.cleanup(WORKFLOW_INSTANCE, name);
-    verify(namedPod).delete();
-  }
-
-  @Test
-  public void shouldNotCleanupPodIfDebugEnabled() throws Exception {
-    when(debug.get()).thenReturn(true);
-    final String name = createdPod.getMetadata().getName();
-    when(k8sClient.pods().withName(name)).thenReturn(namedPod);
-    when(namedPod.get()).thenReturn(createdPod);
     kdr.cleanup(WORKFLOW_INSTANCE, name);
     verify(k8sClient.pods(), never()).delete(any(Pod.class));
     verify(k8sClient.pods(), never()).delete(any(Pod[].class));
@@ -273,6 +265,23 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
+  public void shouldCleanupPodWhenMissingFinishedAt() {
+    final String name = createdPod.getMetadata().getName();
+    when(k8sClient.pods().withName(name)).thenReturn(namedPod);
+    when(namedPod.get()).thenReturn(createdPod);
+
+    // inject mock status in real instance
+    createdPod.setStatus(podStatus);
+    when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
+    when(containerStatus.getName()).thenReturn(KubernetesDockerRunner.STYX_RUN);
+    when(containerStatus.getState()).thenReturn(containerState);
+    when(containerState.getTerminated()).thenReturn(containerStateTerminated);
+
+    kdr.cleanup(WORKFLOW_INSTANCE, name);
+    verify(namedPod).delete();
+  }
+
+  @Test
   public void shouldNotCleanupPodBeforeNonDeletePeriod() {
     final String name = createdPod.getMetadata().getName();
     when(k8sClient.pods().withName(name)).thenReturn(namedPod);
@@ -291,6 +300,36 @@ public class KubernetesDockerRunnerTest {
     verify(namedPod, never()).delete();
   }
 
+  @Test
+  public void shouldNotCleanupPodIfNotTerminated() {
+    final String name = createdPod.getMetadata().getName();
+    when(k8sClient.pods().withName(name)).thenReturn(namedPod);
+    when(namedPod.get()).thenReturn(createdPod);
+
+    // inject mock status in real instance
+    createdPod.setStatus(podStatus);
+    when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
+    when(containerStatus.getName()).thenReturn(KubernetesDockerRunner.STYX_RUN);
+    when(containerStatus.getState()).thenReturn(containerState);
+
+    kdr.cleanup(WORKFLOW_INSTANCE, name);
+    verify(namedPod, never()).delete();
+  }
+
+  @Test
+  public void shouldNotCleanupPodIfNotStyxContainer() {
+    final String name = createdPod.getMetadata().getName();
+    when(k8sClient.pods().withName(name)).thenReturn(namedPod);
+    when(namedPod.get()).thenReturn(createdPod);
+
+    // inject mock status in real instance
+    createdPod.setStatus(podStatus);
+    when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
+    when(containerStatus.getName()).thenReturn("food");
+
+    kdr.cleanup(WORKFLOW_INSTANCE, name);
+    verify(namedPod, never()).delete();
+  }
 
   @Test(expected = InvalidExecutionException.class)
   public void shouldThrowIfSecretNotExist() throws IOException, StateManager.IsClosed {
@@ -554,5 +593,27 @@ public class KubernetesDockerRunnerTest {
     verify(stateManager, timeout(30_000)).receive(Event.terminate(WORKFLOW_INSTANCE, Optional.of(20)));
     await().timeout(30, SECONDS).until(() ->
         assertThat(stateManager.get(WORKFLOW_INSTANCE).data().lastExit(), hasValue(20)));
+  }
+
+  @Test
+  public void shouldPollPodStatusAndDeleteUntrackedPod() throws Exception {
+    when(k8sClient.pods().withName(createdPod.getMetadata().getName())).thenReturn(namedPod);
+
+    createdPod.setStatus(running(/* ready= */ true));
+
+    // Set up a new state manager without any state
+    StateManager stateManager = Mockito.spy(new SyncStateManager());
+
+    // Set up a runner with short poll interval to avoid this test having to wait a long time for the poll
+    kdr.close();
+    kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager,
+                                     debug, 1, 0, CLOCK);
+    kdr.init();
+    kdr.restore();
+
+    when(podList.getItems()).thenReturn(ImmutableList.of(createdPod));
+
+    // Verify that the runner eventually polls and deletes the pod
+    verify(namedPod, timeout(30_000)).delete();
   }
 }


### PR DESCRIPTION
Fix bug in positioning the cleanup within the state machine.
Also fix failing tests.

There are instances where the a workflowInstance's runState is still kept
in the stateManager even though the execution failed. For example, the runState is
removed from the stateManager only when the runState isTerminal (meaning, Done or Error),
whereas Failed and Terminated are not considered terminal states. In
the case of cleaning up pods, we want to clean the pods once a workflowInstance
enters one of all those 4 states (Failed/Terminated/Done/Error). Running cleanup(..) only
under the condition !runState.isPresent() prevented us to do so.

Now we try to cleanup the pod if runState isPresent or delete directly if the pod is not tracked by any runState. In `cleanup` we make sure deleting the pod that is in terminated state and stays after graceful period. `debug` flag still makes the final decision for deletion.