### PR TITLE
Add support for consuming internal events asynchronously

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/IsClosedException.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/IsClosedException.java
@@ -1,8 +1,8 @@
-/*
+/*-
  * -\-\-
- * Spotify Styx Scheduler Service
+ * Spotify Styx Common
  * --
- * Copyright (C) 2017 Spotify AB
+ * Copyright (C) 2016 - 2017 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@
  * -/-/-
  */
 
-package com.spotify.styx.client;
+package com.spotify.styx.util;
 
-public class ClientErrorException extends RuntimeException {
+/**
+ * Exception that signals a closed state.
+ */
+public class IsClosedException extends Exception {
 
-  public ClientErrorException(String message, Throwable cause) {
-    super(message, cause);
-  }
 }

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
@@ -20,7 +20,6 @@
 
 package com.spotify.styx.model.data;
 
-import static java.util.Optional.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;

--- a/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
@@ -32,7 +32,6 @@ import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.Trigger;
-import java.util.Arrays;
 import java.util.Optional;
 import okio.ByteString;
 import org.junit.Assert;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StateInitializingTrigger.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StateInitializingTrigger.java
@@ -32,6 +32,7 @@ import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.Storage;
+import com.spotify.styx.util.IsClosedException;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -71,10 +72,10 @@ final class StateInitializingTrigger implements TriggerListener {
       stateManager.initialize(initialState);
       return stateManager.receive(
           Event.triggerExecution(workflowInstance, trigger));
-    } catch (StateManager.IsClosed isClosed) {
+    } catch (IsClosedException isClosedException) {
       LOG.warn("State receiver is closed when processing workflow {} for trigger {} at {}",
-               workflow, trigger, instant, isClosed);
-      return exceptionallyCompletedFuture(isClosed);
+               workflow, trigger, instant, isClosedException);
+      return exceptionallyCompletedFuture(isClosedException);
     }
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
@@ -42,6 +42,7 @@ import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.DockerImageValidator;
+import com.spotify.styx.util.IsClosedException;
 import com.spotify.styx.util.RandomGenerator;
 import com.spotify.styx.util.Time;
 import java.io.IOException;
@@ -148,7 +149,7 @@ public class SchedulerResource {
 
     try {
       stateManager.receive(event);
-    } catch (StateManager.IsClosed isClosed) {
+    } catch (IsClosedException isClosedException) {
       return Response.forStatus(INTERNAL_SERVER_ERROR);
     }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -20,14 +20,8 @@
 
 package com.spotify.styx.docker;
 
-import static java.util.Optional.empty;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
 import com.spotify.styx.ServiceAccountKeyManager;
 import com.spotify.styx.model.WorkflowConfiguration;
-import com.spotify.styx.model.WorkflowConfiguration.Secret;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.StateManager;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -35,7 +35,6 @@ import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.EventVisitor;
@@ -48,6 +47,7 @@ import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.util.Debug;
+import com.spotify.styx.util.IsClosedException;
 import com.spotify.styx.util.TriggerUtil;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -548,9 +548,9 @@ class KubernetesDockerRunner implements DockerRunner {
 
       try {
         stateManager.receive(event);
-      } catch (StateManager.IsClosed isClosed) {
-        LOG.warn("Could not receive kubernetes event", isClosed);
-        throw Throwables.propagate(isClosed);
+      } catch (IsClosedException isClosedException) {
+        LOG.warn("Could not receive kubernetes event", isClosedException);
+        throw new RuntimeException(isClosedException);
       }
     }
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -31,6 +31,7 @@ import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.AlreadyInitializedException;
+import com.spotify.styx.util.IsClosedException;
 import com.spotify.styx.util.Time;
 import java.io.IOException;
 import java.util.Map;
@@ -45,6 +46,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,8 +73,10 @@ public class QueuedStateManager implements StateManager {
   static final long NO_EVENTS_PROCESSED = -1L;
 
   private final Time time;
-  private final Executor workerPool;
+  private final Executor outputHandlerExecutor;
   private final Storage storage;
+  private final Consumer<SequenceEvent> eventConsumer;
+  private final Executor eventConsumerExecutor;
 
   private final ConcurrentMap<WorkflowInstance, InstanceState> states = Maps.newConcurrentMap();
 
@@ -82,18 +86,24 @@ public class QueuedStateManager implements StateManager {
   private AtomicInteger activeEvents = new AtomicInteger(0);
   private volatile boolean running = true;
 
-  public QueuedStateManager(Time time, Executor workerPool, Storage storage) {
+  public QueuedStateManager(
+      Time time,
+      Executor outputHandlerExecutor,
+      Storage storage,
+      Consumer<SequenceEvent> eventConsumer,
+      Executor eventConsumerExecutor) {
     this.time = Objects.requireNonNull(time);
-    this.workerPool = Objects.requireNonNull(workerPool);
+    this.outputHandlerExecutor = Objects.requireNonNull(outputHandlerExecutor);
     this.storage = Objects.requireNonNull(storage);
-
+    this.eventConsumer = Objects.requireNonNull(eventConsumer);
+    this.eventConsumerExecutor = Objects.requireNonNull(eventConsumerExecutor);
     this.dispatcherThread = new Thread(this::dispatch);
     dispatcherThread.setName(DISPATCHER_THREAD_NAME);
     dispatcherThread.start();
   }
 
   @Override
-  public void initialize(RunState runState) throws IsClosed {
+  public void initialize(RunState runState) throws IsClosedException {
     ensureRunning();
 
     final WorkflowInstance workflowInstance = runState.workflowInstance();
@@ -124,7 +134,7 @@ public class QueuedStateManager implements StateManager {
   }
 
   @Override
-  public CompletionStage<Void> receive(Event event) throws IsClosed {
+  public CompletionStage<Void> receive(Event event) throws IsClosedException {
     ensureRunning();
 
     final InstanceState state = states.get(event.workflowInstance());
@@ -242,9 +252,9 @@ public class QueuedStateManager implements StateManager {
     }
   }
 
-  private void ensureRunning() throws IsClosed {
+  private void ensureRunning() throws IsClosedException {
     if (!running) {
-      throw new IsClosed();
+      throw new IsClosedException();
     }
   }
 
@@ -288,8 +298,14 @@ public class QueuedStateManager implements StateManager {
       throw t;
     }
 
+    try {
+      eventConsumerExecutor.execute(() -> eventConsumer.accept(sequenceEvent));
+    } catch (Exception e) {
+      LOG.warn("Error while consuming event {}", sequenceEvent, e);
+    }
+
     activeEvents.incrementAndGet();
-    workerPool.execute(() -> {
+    outputHandlerExecutor.execute(() -> {
       try {
         state.outputHandler().transitionInto(state);
         processed.complete(null);
@@ -380,14 +396,14 @@ public class QueuedStateManager implements StateManager {
 
     /**
      * Poll the next {@link Runnable} off the {@link #queue} and invoke it on the
-     * {@link #workerPool}, or do nothing if the queue is empty.
+     * {@link #outputHandlerExecutor}, or do nothing if the queue is empty.
      *
      * <p>The whole operation is guarded with a mutex, so concurrent calls are safe. Only one
      * queued {@link Runnable} will be invoked at any point time, effectively making the queue
      * consumed in a synchronized fashion.
      *
-     * <p>After each invocation has completed, the task on the {@link #workerPool} will call
-     * {@code mutexPoll()} again to ensure immediate consequent consumption of the queue.
+     * <p>After each invocation has completed, the task on the {@link #outputHandlerExecutor} will
+     * call {@code mutexPoll()} again to ensure immediate consequent consumption of the queue.
      */
     void mutexPoll() {
       if (queue.isEmpty()) {
@@ -397,7 +413,7 @@ public class QueuedStateManager implements StateManager {
       if (mutex.tryAcquire()) {
         try {
           // poll and invoke on executor pool
-          workerPool.execute(() -> {
+          outputHandlerExecutor.execute(() -> {
             try {
               final Runnable poll = queue.poll();
               if (poll != null) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/StateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/StateManager.java
@@ -23,6 +23,7 @@ package com.spotify.styx.state;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.util.IsClosedException;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
@@ -38,9 +39,9 @@ public interface StateManager extends Closeable {
    * Initializes a {@link RunState} which makes it actively tracked.
    *
    * @param runState The state to initialize
-   * @throws IsClosed if the state receiver is closed and can not handle events
+   * @throws IsClosedException if the state receiver is closed and can not handle events
    */
-  void initialize(RunState runState) throws IsClosed;
+  void initialize(RunState runState) throws IsClosedException;
 
   /**
    * Restore a {@link RunState} and track it from the given sequence count.
@@ -55,9 +56,9 @@ public interface StateManager extends Closeable {
    * the {@link Event#workflowInstance()} key of the event.
    *
    * @param event The event to receive
-   * @throws IsClosed if the state receiver is closed and can not handle events
+   * @throws IsClosedException if the state receiver is closed and can not handle events
    */
-  CompletionStage<Void> receive(Event event) throws IsClosed;
+  CompletionStage<Void> receive(Event event) throws IsClosedException;
 
   /**
    * Get a map of all active {@link WorkflowInstance} states.
@@ -89,15 +90,15 @@ public interface StateManager extends Closeable {
   boolean isActiveWorkflowInstance(WorkflowInstance workflowInstance);
 
   /**
-   * Like {@link #receive(Event)} but ignoring the {@link IsClosed} exception.
+   * Like {@link #receive(Event)} but ignoring the {@link IsClosedException} exception.
    *
    * @param event The event to receive
    */
   default void receiveIgnoreClosed(Event event) {
     try {
       receive(event);
-    } catch (IsClosed isClosed) {
-      LOG.info("Ignored event, state receiver closed", isClosed);
+    } catch (IsClosedException isClosedException) {
+      LOG.info("Ignored event, state receiver closed", isClosedException);
     }
   }
 
@@ -108,13 +109,6 @@ public interface StateManager extends Closeable {
    * @return The RunState associated with the workflow instance
    */
   RunState get(WorkflowInstance workflowInstance);
-
-  /**
-   * Exception that signals that the {@link StateManager} is in a closed state.
-   */
-  class IsClosed extends Exception {
-
-  }
 
   Logger LOG = LoggerFactory.getLogger(StateManager.class);
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -30,6 +30,7 @@ import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.state.OutputHandler;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
+import com.spotify.styx.util.IsClosedException;
 import com.spotify.styx.util.ResourceNotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -72,8 +73,8 @@ public class DockerRunnerHandler implements OutputHandler {
         final Event submitted = Event.submitted(state.workflowInstance(), runSpec.executionId());
         try {
           stateManager.receive(submitted);
-        } catch (StateManager.IsClosed isClosed) {
-          LOG.warn("Could not emit 'submitted' event", isClosed);
+        } catch (IsClosedException isClosedException) {
+          LOG.warn("Could not emit 'submitted' event", isClosedException);
           return;
         }
 
@@ -90,8 +91,8 @@ public class DockerRunnerHandler implements OutputHandler {
               LOG.error(msg, e);
             }
             stateManager.receive(Event.runError(state.workflowInstance(), e.getMessage()));
-          } catch (StateManager.IsClosed isClosed) {
-            LOG.warn("Failed to send 'runError' event", isClosed);
+          } catch (IsClosedException isClosedException) {
+            LOG.warn("Failed to send 'runError' event", isClosedException);
           }
         }
         break;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -34,6 +34,7 @@ import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.DockerImageValidator;
+import com.spotify.styx.util.IsClosedException;
 import com.spotify.styx.util.MissingRequiredPropertyException;
 import com.spotify.styx.util.ResourceNotFoundException;
 import java.io.IOException;
@@ -74,8 +75,8 @@ public class ExecutionDescriptionHandler implements OutputHandler {
               state.workflowInstance(), getExecDescription(workflowInstance), createExecutionId());
           try {
             stateManager.receive(submitEvent);
-          } catch (StateManager.IsClosed isClosed) {
-            LOG.warn("Could not send 'submit' event", isClosed);
+          } catch (IsClosedException isClosedException) {
+            LOG.warn("Could not send 'submit' event", isClosedException);
           }
         } catch (ResourceNotFoundException e) {
           LOG.info("Workflow {} does not exist, halting {}", workflowInstance.workflowId(),
@@ -89,8 +90,8 @@ public class ExecutionDescriptionHandler implements OutputHandler {
           try {
             LOG.error("Failed to retrieve execution description for " + state.workflowInstance().toKey(), e);
             stateManager.receive(Event.runError(state.workflowInstance(), e.getMessage()));
-          } catch (StateManager.IsClosed isClosed) {
-            LOG.warn("Failed to send 'runError' event", isClosed);
+          } catch (IsClosedException isClosedException) {
+            LOG.warn("Failed to send 'runError' event", isClosedException);
           }
         }
         break;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -22,7 +22,6 @@ package com.spotify.styx;
 
 import static com.spotify.styx.state.TimeoutConfig.createWithDefaultTtl;
 import static java.time.Duration.ofSeconds;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -55,6 +54,7 @@ import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.SyncStateManager;
 import com.spotify.styx.state.TimeoutConfig;
 import com.spotify.styx.storage.Storage;
+import com.spotify.styx.util.IsClosedException;
 import com.spotify.styx.util.Time;
 import java.io.IOException;
 import java.time.Instant;
@@ -111,7 +111,7 @@ public class SchedulerTest {
     executor.shutdownNow();
   }
 
-  private void setUp(int timeoutSeconds) throws StateManager.IsClosed, IOException {
+  private void setUp(int timeoutSeconds) throws IsClosedException, IOException {
     workflowCache = new InMemWorkflowCache();
     TimeoutConfig timeoutConfig = createWithDefaultTtl(ofSeconds(timeoutSeconds));
 
@@ -137,7 +137,7 @@ public class SchedulerTest {
     workflowCache.store(workflow);
   }
 
-  private void init(RunState runState) throws StateManager.IsClosed {
+  private void init(RunState runState) throws IsClosedException {
     stateManager.initialize(runState);
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -37,6 +37,7 @@ import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.Schedule;
+import com.spotify.styx.model.SequenceEvent;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowId;
@@ -161,6 +162,37 @@ public class SystemTest extends StyxSchedulerServiceFixture {
     workflowInstance = dockerRuns.get(1)._1;
     assertThat(workflowInstance.workflowId(), is(HOURLY_WORKFLOW.id()));
     assertThat(workflowInstance.parameter(), is("2016-03-14T15:15:00Z"));
+  }
+
+  @Test
+  public void shouldEnqueuEventsForConsumption() throws Exception {
+    Workflow customWorkflow = Workflow.create(
+        "styx",
+        WorkflowConfiguration.builder()
+            .id("styx.TestEndpoint")
+            .schedule(Schedule.parse("15,45 12,15 * * *"))
+            .dockerImage("busybox")
+            .dockerArgs(ImmutableList.of())
+            .build());
+
+    givenTheTimeIs("2016-03-14T15:30:00Z");
+    givenTheGlobalEnableFlagIs(true);
+    givenWorkflow(customWorkflow);
+    givenWorkflowEnabledStateIs(customWorkflow, true);
+    givenNextNaturalTrigger(customWorkflow, "2016-03-14T12:45:00Z");
+
+    WorkflowInstance wfi =
+        WorkflowInstance.create(customWorkflow.id(), "2016-03-14T12:45:00Z");
+    styxStarts();
+    tickTriggerManager();
+
+    final SequenceEvent expectedEvent =
+        SequenceEvent.create(
+            Event.triggerExecution(wfi, Trigger.natural()),
+            0,
+            Instant.parse("2016-03-14T15:30:00Z").toEpochMilli());
+
+    awaitUntilConsumedEvent(expectedEvent);
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
@@ -66,9 +66,6 @@ import okio.ByteString;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 /**
  * API endpoints for interacting directly with the scheduler

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -51,6 +51,7 @@ import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.SyncStateManager;
 import com.spotify.styx.testdata.TestData;
 import com.spotify.styx.util.Debug;
+import com.spotify.styx.util.IsClosedException;
 import io.fabric8.kubernetes.api.model.ContainerState;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -208,7 +209,7 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
-  public void shouldUseExecutionIdForPodName() throws IOException, StateManager.IsClosed {
+  public void shouldUseExecutionIdForPodName() throws IOException, IsClosedException {
     kdr.start(WORKFLOW_INSTANCE, RUN_SPEC);
     verify(pods).create(podCaptor.capture());
     Pod submittedPod = podCaptor.getValue();
@@ -421,7 +422,7 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test(expected = InvalidExecutionException.class)
-  public void shouldThrowIfSecretNotExist() throws IOException, StateManager.IsClosed {
+  public void shouldThrowIfSecretNotExist() throws IOException, IsClosedException {
     when(secrets.withName(any(String.class))).thenReturn(namedResource);
     when(namedResource.get()).thenReturn(null);
     when(k8sClient.secrets()).thenReturn(secrets);
@@ -430,7 +431,7 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test(expected = InvalidExecutionException.class)
-  public void shouldThrowIfMountToReservedPath() throws IOException, StateManager.IsClosed {
+  public void shouldThrowIfMountToReservedPath() throws IOException, IsClosedException {
     when(secrets.withName(any(String.class))).thenReturn(namedResource);
     when(namedResource.get()).thenReturn(null);
     when(k8sClient.secrets()).thenReturn(secrets);
@@ -439,7 +440,7 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
-  public void shouldMountSecret() throws IOException, StateManager.IsClosed {
+  public void shouldMountSecret() throws IOException, IsClosedException {
     final Pod pod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC_WITH_SECRET,
         SECRET_SPEC_WITH_CUSTOM_SECRET);
     assertThat(pod.getSpec().getVolumes().size(), is(1));
@@ -452,7 +453,7 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
-  public void shouldMountServiceAccount() throws IOException, StateManager.IsClosed {
+  public void shouldMountServiceAccount() throws IOException, IsClosedException {
     final Pod pod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RUN_SPEC_WITH_SA, SECRET_SPEC_WITH_SA);
     assertThat(pod.getSpec().getVolumes().size(), is(1));
     assertThat(pod.getSpec().getVolumes().get(0).getName(),
@@ -466,7 +467,7 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
-  public void shouldConfigureResourceRequirements() throws IOException, StateManager.IsClosed {
+  public void shouldConfigureResourceRequirements() throws IOException, IsClosedException {
     final String memRequest = "17Mi";
     final String memLimit = "4711Mi";
     final Pod pod = KubernetesDockerRunner.createPod(WORKFLOW_INSTANCE, RunSpec.builder()
@@ -484,7 +485,7 @@ public class KubernetesDockerRunnerTest {
 
 
   @Test
-  public void shouldRunIfSecretExists() throws IOException, StateManager.IsClosed {
+  public void shouldRunIfSecretExists() throws IOException, IsClosedException {
     when(secrets.withName(any(String.class))).thenReturn(namedResource);
     when(namedResource.get()).thenReturn(new SecretBuilder().build());
     when(k8sClient.secrets()).thenReturn(secrets);
@@ -501,7 +502,7 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
-  public void shouldEnsureAndMountServiceAccountSecret() throws StateManager.IsClosed, IOException {
+  public void shouldEnsureAndMountServiceAccountSecret() throws IsClosedException, IOException {
     when(secrets.withName(any(String.class))).thenReturn(namedResource);
     when(namedResource.get()).thenReturn(null);
     when(k8sClient.secrets()).thenReturn(secrets);
@@ -531,7 +532,7 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
-  public void shouldNotRunIfServiceAccountSecretEnsureFails() throws StateManager.IsClosed, IOException {
+  public void shouldNotRunIfServiceAccountSecretEnsureFails() throws IsClosedException, IOException {
     final InvalidExecutionException error = new InvalidExecutionException("SA not found");
     when(serviceAccountSecretManager.ensureServiceAccountKeySecret(
         WORKFLOW_INSTANCE.workflowId().toString(), SERVICE_ACCOUNT)).thenThrow(error);
@@ -542,7 +543,8 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
-  public void shouldNotRunIfSecretHasManagedServiceAccountKeySecretNamePrefix() throws StateManager.IsClosed, IOException {
+  public void shouldNotRunIfSecretHasManagedServiceAccountKeySecretNamePrefix() throws
+                                                                                IsClosedException, IOException {
     final String secret = "styx-wf-sa-keys-foo";
 
     exception.expect(InvalidExecutionException.class);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
@@ -48,7 +48,7 @@ import com.spotify.styx.ServiceAccountKeyManager;
 import com.spotify.styx.docker.DockerRunner.RunSpec;
 import com.spotify.styx.docker.KubernetesDockerRunner.KubernetesSecretSpec;
 import com.spotify.styx.model.WorkflowInstance;
-import com.spotify.styx.state.StateManager;
+import com.spotify.styx.util.IsClosedException;
 import io.fabric8.kubernetes.api.model.DoneablePod;
 import io.fabric8.kubernetes.api.model.DoneableSecret;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -153,7 +153,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
   }
 
   @Test
-  public void shouldCreateServiceAccountKeysAndSecret() throws StateManager.IsClosed, IOException {
+  public void shouldCreateServiceAccountKeysAndSecret() throws IsClosedException, IOException {
 
     when(serviceAccountKeyManager.serviceAccountExists(SERVICE_ACCOUNT)).thenReturn(true);
 
@@ -180,7 +180,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
 
   @Test
   public void shouldNotConcurrentlyCreateServiceAccountKeysAndSecrets()
-      throws StateManager.IsClosed, IOException, ExecutionException, InterruptedException {
+      throws IsClosedException, IOException, ExecutionException, InterruptedException {
 
     final ServiceAccountKey jsonKey = new ServiceAccountKey();
     jsonKey.setName("key.json");
@@ -407,7 +407,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
   }
 
   @Test
-  public void shouldUseExistingServiceAccountSecret() throws StateManager.IsClosed, IOException {
+  public void shouldUseExistingServiceAccountSecret() throws IsClosedException, IOException {
 
     final String jsonKeyId = "json-key";
     final String p12KeyId = "p12-key";
@@ -433,7 +433,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
   }
 
   @Test
-  public void shouldFailIfServiceAccountDoesNotExist() throws StateManager.IsClosed, IOException {
+  public void shouldFailIfServiceAccountDoesNotExist() throws IsClosedException, IOException {
     when(serviceAccountKeyManager.serviceAccountExists(SERVICE_ACCOUNT)).thenReturn(false);
 
     exception.expect(InvalidExecutionException.class);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
@@ -42,9 +42,9 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
-import com.spotify.styx.state.StateManager.IsClosed;
 import com.spotify.styx.state.SyncStateManager;
 import com.spotify.styx.state.Trigger;
+import com.spotify.styx.util.IsClosedException;
 import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -132,7 +132,8 @@ public class DockerRunnerHandlerTest {
     shouldFailIfDockerRunnerRaisesException(new InvalidExecutionException("PEBKAC"));
   }
 
-  void shouldFailIfDockerRunnerRaisesException(Throwable throwable) throws IOException, IsClosed {
+  void shouldFailIfDockerRunnerRaisesException(Throwable throwable)
+      throws IOException, IsClosedException {
     doThrow(throwable).when(dockerRunner)
         .start(any(WorkflowInstance.class), any(RunSpec.class));
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
@@ -54,6 +54,7 @@ import com.spotify.styx.storage.InMemStorage;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.testdata.TestData;
 import com.spotify.styx.util.DockerImageValidator;
+import com.spotify.styx.util.IsClosedException;
 import java.io.IOException;
 import java.util.Collections;
 import org.hamcrest.Matchers;
@@ -236,7 +237,7 @@ public class ExecutionDescriptionHandlerTest {
 
     doCallRealMethod()
         .doCallRealMethod()
-        .doThrow(StateManager.IsClosed.class)
+        .doThrow(IsClosedException.class)
         .when(stateManager).receive(any(Event.class));
 
     storage.storeWorkflow(workflow);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/PublisherHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/PublisherHandlerTest.java
@@ -21,8 +21,6 @@
 package com.spotify.styx.state.handlers;
 
 import static com.spotify.styx.testdata.TestData.WORKFLOW_INSTANCE;
-import static java.util.Collections.emptyList;
-import static java.util.Optional.empty;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -33,7 +31,6 @@ import com.spotify.styx.state.OutputHandler;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateData;
 import java.io.IOException;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
This allows to asynchronously consume the processed internal events. A possible application for this is to publish such events to third-party services by implementing the `EventInterceptor` interface.

EDIT: In the latest implementation the `EventInterceptor` interface has been removed in favour of the standard Java `Consumer` interface.