### PR TITLE
racing between poller and watcher

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -437,7 +437,7 @@ class KubernetesDockerRunner implements DockerRunner {
   }
 
   private void examineRunningWFISandAssociatedPods(Set<WorkflowInstance> runningWorkflowInstances,
-                                           PodList podList) {
+                                                   PodList podList) {
     final Set<WorkflowInstance> workflowInstancesForPods = podList.getItems().stream()
         .filter(pod -> pod.getMetadata().getAnnotations()
             .containsKey(STYX_WORKFLOW_INSTANCE_ANNOTATION))

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.docker;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.hasValue;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.podStatusNoContainer;
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.running;
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.terminated;
@@ -711,5 +712,29 @@ public class KubernetesDockerRunnerTest {
 
     // Verify that the runner eventually polls and deletes the pod
     verify(namedPod, timeout(30_000)).delete();
+  }
+
+  @Test
+  public void shouldPollPodAndTransitToFailedIfPodNotFound() throws Exception {
+    when(k8sClient.pods().withName(createdPod.getMetadata().getName())).thenReturn(namedPod);
+
+    createdPod.setStatus(running(/* ready= */ true));
+
+    // Set up a runner with short poll interval to avoid this test having to wait a long time for the poll
+    kdr.close();
+    kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager,
+                                     debug, 1, 0, CLOCK);
+    kdr.init();
+    kdr.restore();
+
+    // return empty pod list
+    when(podList.getItems()).thenReturn(ImmutableList.of());
+
+    // Verify that the runner eventually polls and finds out that the pod is gone
+    verify(stateManager, timeout(30_000))
+        .receive(Event.runError(WORKFLOW_INSTANCE, "No pod associated with this instance"));
+    await().timeout(30, SECONDS).until(() ->
+                                           assertThat(stateManager.get(WORKFLOW_INSTANCE).data()
+                                                          .lastExit(), isEmpty()));
   }
 }


### PR DESCRIPTION
We have observed cases that pod is not seen for running state. That
happens after poller has fetched a list of pods, then styx creates a
new pod, that pod transits into running and the state machine transits
into running as well. So we end up with having a running state but no
pod.

To fix this, first get a snapshot of running states and then fetch pod
list. If the state is running, the associated pod should be in the list;
while if the state is not running yet, we will not take any action.

@danielnorberg PTAL

We may just stop using watcher at all, but that has bigger impact.