### PR TITLE
client: nicer connection error message

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/Main.java
@@ -30,6 +30,7 @@ import com.spotify.styx.api.BackfillsPayload;
 import com.spotify.styx.api.ResourcesPayload;
 import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.client.ApiErrorException;
+import com.spotify.styx.client.ClientErrorException;
 import com.spotify.styx.client.StyxClient;
 import com.spotify.styx.client.StyxClientFactory;
 import com.spotify.styx.model.Backfill;
@@ -236,14 +237,16 @@ public final class Main {
       parser.parser.handleError(e);
       System.exit(EXIT_CODE_ARGUMENT_ERROR);
     } catch (ExecutionException e) {
-      Throwable cause = e.getCause();
+      final Throwable cause = e.getCause();
       if (cause instanceof ApiErrorException) {
         System.err.println("API error: " + cause.getMessage());
+      } else if (cause instanceof ClientErrorException) {
+        System.err.println(cause.getMessage());
       } else {
         cause.printStackTrace();
       }
       System.exit(EXIT_CODE_CLIENT_ERROR);
-    } catch (InterruptedException | IOException e) {
+    } catch (Exception e) {
       e.printStackTrace();
       System.exit(EXIT_CODE_UNKNOWN_ERROR);
     }

--- a/styx-client/src/main/java/com/spotify/styx/client/ClientErrorException.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/ClientErrorException.java
@@ -1,0 +1,30 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.client;
+
+import java.net.URI;
+
+public class ClientErrorException extends RuntimeException {
+
+  public ClientErrorException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.spotify.apollo.Client;
 import com.spotify.apollo.Request;
@@ -51,6 +52,7 @@ import com.spotify.styx.util.EventUtil;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.HttpUrl.Builder;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
@@ -364,13 +366,22 @@ class StyxApolloClient implements StyxClient {
   }
 
   private CompletionStage<Response<ByteString>> executeRequest(final Request request) {
-    return client.send(decorateRequest(request)).thenApply(response -> {
-      switch (response.status().family()) {
-        case SUCCESSFUL:
-          return response;
-        default:
-          final String message = response.status().code() + " " + response.status().reasonPhrase();
-          throw new ApiErrorException(message, response.status().code());
+    return client.send(decorateRequest(request)).handle((response, e) -> {
+      if (e != null) {
+        final Throwable rootCause = Throwables.getRootCause(e);
+        if (rootCause instanceof SocketTimeoutException) {
+          throw new ClientErrorException("Connection failed: " + rootCause.getMessage() + ": " + apiHost, e);
+        } else {
+          throw new ClientErrorException("Request failed: " + request, e);
+        }
+      } else {
+        switch (response.status().family()) {
+          case SUCCESSFUL:
+            return response;
+          default:
+            final String message = response.status().code() + " " + response.status().reasonPhrase();
+            throw new ApiErrorException(message, response.status().code());
+        }
       }
     });
   }


### PR DESCRIPTION
Print `Connection failed: connect timed out: https://styx.spotify.net` instead of full exception stack traces like: 
```
java.io.IOException: Request Request{method=POST, url=https://styx.spotify.net/api/v3/scheduler/trigger, tag=Request{method=POST, url=https://styx.spotify.net/api/v3/scheduler/trigger, tag=null}} failed
	at com.spotify.apollo.http.client.TransformingCallback.onFailure(TransformingCallback.java:57)
	at com.squareup.okhttp.Call$AsyncCall.execute(Call.java:185)
	at com.squareup.okhttp.internal.NamedRunnable.run(NamedRunnable.java:33)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.net.SocketTimeoutException: connect timed out
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:589)
	at com.squareup.okhttp.internal.Platform.connectSocket(Platform.java:120)
	at com.squareup.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:141)
	at com.squareup.okhttp.internal.io.RealConnection.connect(RealConnection.java:112)
	at com.squareup.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:184)
	at com.squareup.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
	at com.squareup.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
	at com.squareup.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
	at com.squareup.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
	at com.squareup.okhttp.Call.getResponse(Call.java:286)
	at com.squareup.okhttp.Call$ApplicationInterceptorChain.proceed(Call.java:243)
	at com.squareup.okhttp.Call.getResponseWithInterceptorChain(Call.java:205)
	at com.squareup.okhttp.Call.access$100(Call.java:35)
	at com.squareup.okhttp.Call$AsyncCall.execute(Call.java:171)
	... 4 more
```