### PR TITLE
check for dependencies before executing wf

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/model/StyxConfig.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/StyxConfig.java
@@ -42,6 +42,12 @@ public interface StyxConfig {
   boolean debugEnabled();
 
   /**
+   * Controls whether workflow instance execution gating should be performed. If set to false,
+   * instances will be executed without checking for blockers.
+   */
+  boolean executionGatingEnabled();
+
+  /**
    * Get the global concurrency for Styx.
    */
   Optional<Long> globalConcurrency();

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -91,6 +91,7 @@ class DatastoreStorage {
   public static final String PROPERTY_CONFIG_DOCKER_RUNNER_ID = "dockerRunnerId";
   public static final String PROPERTY_CONFIG_CONCURRENCY = "concurrency";
   public static final String PROPERTY_CONFIG_CLIENT_BLACKLIST = "clientBlacklist";
+  public static final String PROPERTY_CONFIG_EXECUTION_GATING = "executionGating";
 
   public static final String PROPERTY_WORKFLOW_JSON = "json";
   public static final String PROPERTY_WORKFLOW_ENABLED = "enabled";
@@ -117,6 +118,7 @@ class DatastoreStorage {
   public static final String DEFAULT_CONFIG_DOCKER_RUNNER_ID = "default";
   public static final boolean DEFAULT_WORKFLOW_ENABLED = false;
   public static final boolean DEFAULT_CONFIG_DEBUG_ENABLED = false;
+  public static final boolean DEFAULT_CONFIG_EXECUTION_GATING_ENABLED = false;
 
   public static final int MAX_RETRIES = 100;
 
@@ -151,6 +153,8 @@ class DatastoreStorage {
             read(entity, PROPERTY_CONFIG_DOCKER_RUNNER_ID, DEFAULT_CONFIG_DOCKER_RUNNER_ID))
         .clientBlacklist(this.<String>readStream(entity, PROPERTY_CONFIG_CLIENT_BLACKLIST)
             .collect(toList()))
+        .executionGatingEnabled(
+            read(entity, PROPERTY_CONFIG_EXECUTION_GATING, DEFAULT_CONFIG_EXECUTION_GATING_ENABLED))
         .build();
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -91,7 +91,7 @@ class DatastoreStorage {
   public static final String PROPERTY_CONFIG_DOCKER_RUNNER_ID = "dockerRunnerId";
   public static final String PROPERTY_CONFIG_CONCURRENCY = "concurrency";
   public static final String PROPERTY_CONFIG_CLIENT_BLACKLIST = "clientBlacklist";
-  public static final String PROPERTY_CONFIG_EXECUTION_GATING = "executionGating";
+  public static final String PROPERTY_CONFIG_EXECUTION_GATING_ENABLED = "executionGatingEnabled";
 
   public static final String PROPERTY_WORKFLOW_JSON = "json";
   public static final String PROPERTY_WORKFLOW_ENABLED = "enabled";
@@ -154,7 +154,7 @@ class DatastoreStorage {
         .clientBlacklist(this.<String>readStream(entity, PROPERTY_CONFIG_CLIENT_BLACKLIST)
             .collect(toList()))
         .executionGatingEnabled(
-            read(entity, PROPERTY_CONFIG_EXECUTION_GATING, DEFAULT_CONFIG_EXECUTION_GATING_ENABLED))
+            read(entity, PROPERTY_CONFIG_EXECUTION_GATING_ENABLED, DEFAULT_CONFIG_EXECUTION_GATING_ENABLED))
         .build();
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -242,7 +242,8 @@ public class Scheduler {
       LOG.debug("Interrupted");
       return false;
     } catch (ExecutionException | TimeoutException e) {
-      LOG.warn("Failed to check execution blockers for {}", instance.workflowInstance(), e);
+      LOG.warn("Failed to check execution blocker for {}, assuming there is no blocker",
+          instance.workflowInstance(), e);
     }
 
     if (blocker.isPresent()) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -236,15 +236,14 @@ public class Scheduler {
       CompletionStage<Optional<ExecutionBlocker>> executionBlockerFuture) {
 
     // Check for execution blockers
-    final Optional<ExecutionBlocker> blocker;
+    Optional<ExecutionBlocker> blocker = Optional.empty();
     try {
       blocker = executionBlockerFuture.toCompletableFuture().get(30, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       LOG.debug("Interrupted");
       return false;
     } catch (ExecutionException | TimeoutException e) {
-      LOG.error("Failed to check for missing dependencies", e);
-      return true;
+      LOG.warn("Failed to check execution blockers for {}", instance.workflowInstance(), e);
     }
 
     if (blocker.isPresent()) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -113,7 +113,7 @@ public class Scheduler {
     this.resourceDecorator = Objects.requireNonNull(resourceDecorator);
     this.stats = Objects.requireNonNull(stats);
     this.dequeueRateLimiter = Objects.requireNonNull(dequeueRateLimiter, "dequeueRateLimiter");
-    this.gate = Objects.requireNonNull(gate, "gate");;
+    this.gate = Objects.requireNonNull(gate, "gate");
   }
 
   void tick() {
@@ -234,7 +234,7 @@ public class Scheduler {
       Map<String, Long> currentResourceUsage, InstanceState instance,
       CompletionStage<Optional<ExecutionBlocker>> executionBlockerFuture) {
 
-    // Check for execution blockers
+    // Check for execution blocker
     Optional<ExecutionBlocker> blocker = Optional.empty();
     try {
       blocker = executionBlockerFuture.toCompletableFuture().get(30, TimeUnit.SECONDS);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -241,7 +241,7 @@ public class Scheduler {
       blocker = executionBlockerFuture.toCompletableFuture().get(30, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       LOG.debug("Interrupted");
-      return true;
+      return false;
     } catch (ExecutionException | TimeoutException e) {
       LOG.error("Failed to check for missing dependencies", e);
       return true;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -202,7 +202,7 @@ public class Scheduler {
         final boolean proceed = limitAndDequeue(resources, workflowResourceReferences,
             currentResourceUsage, batch.get(i), blockers.get(i));
 
-        // Stop processing if rate limit was hit
+        // Stop processing if rate limit was hit or thread was interrupted
         if (!proceed) {
           return;
         }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -141,6 +141,26 @@ public class StyxScheduler implements AppInit {
 
   private static final Logger LOG = LoggerFactory.getLogger(StyxScheduler.class);
 
+  private final Time time;
+  private final StorageFactory storageFactory;
+  private final DockerRunnerFactory dockerRunnerFactory;
+  private final StatsFactory statsFactory;
+  private final ExecutorFactory executorFactory;
+  private final PublisherFactory publisherFactory;
+  private final RetryUtil retryUtil;
+  private final WorkflowResourceDecorator resourceDecorator;
+  private final EventConsumerFactory eventConsumerFactory;
+  private final WorkflowConsumerFactory workflowConsumerFactory;
+  private final WorkflowExecutionGateFactory executionGateFactory;
+
+  private StateManager stateManager;
+  private Scheduler scheduler;
+  private TriggerManager triggerManager;
+  private BackfillTriggerManager backfillTriggerManager;
+
+  private Consumer<Workflow> workflowRemoveListener;
+  private Consumer<Workflow> workflowChangeListener;
+
   // === Type aliases for dependency injectors ====================================================
   public interface StateFactory extends Function<WorkflowInstance, RunState> { }
   public interface StatsFactory extends Function<Environment, Stats> { }
@@ -251,27 +271,6 @@ public class StyxScheduler implements AppInit {
   }
 
   // ==============================================================================================
-
-  private final Time time;
-  private final StorageFactory storageFactory;
-  private final DockerRunnerFactory dockerRunnerFactory;
-  private final StatsFactory statsFactory;
-  private final ExecutorFactory executorFactory;
-  private final PublisherFactory publisherFactory;
-  private final RetryUtil retryUtil;
-  private final WorkflowResourceDecorator resourceDecorator;
-  private final EventConsumerFactory eventConsumerFactory;
-  private final WorkflowConsumerFactory workflowConsumerFactory;
-  private final WorkflowExecutionGateFactory executionGateFactory;
-
-
-  private StateManager stateManager;
-  private Scheduler scheduler;
-  private TriggerManager triggerManager;
-  private BackfillTriggerManager backfillTriggerManager;
-
-  private Consumer<Workflow> workflowRemoveListener;
-  private Consumer<Workflow> workflowChangeListener;
 
   private StyxScheduler(Builder builder) {
     this.time = requireNonNull(builder.time);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/WorkflowExecutionGate.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/WorkflowExecutionGate.java
@@ -1,0 +1,81 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx;
+
+
+import com.spotify.styx.model.WorkflowInstance;
+import io.norberg.automatter.AutoMatter;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A gating mechanism that can block workflow instance execution. Can be implemented in order to
+ * look up execution preconditions and e.g. delay workflow execution when input dependencies are
+ * missing.
+ */
+public interface WorkflowExecutionGate {
+
+  CompletableFuture<Optional<ExecutionBlocker>> NO_BLOCKER =
+      CompletableFuture.completedFuture(Optional.empty());
+
+  /**
+   * A nop {@link WorkflowExecutionGate} that never returns any missing dependencies. I.e., the
+   * execution can always proceed.
+   */
+  WorkflowExecutionGate NOOP = wfi -> NO_BLOCKER;
+
+  /**
+   * Check if there is a blocker for the execution of a workflow instance. This method is called
+   * before the workflow instance is dequeued. If an {@link ExecutionBlocker} is returned, execution
+   * of the workflow instance is delayed. Implementations of this method should be careful to
+   * consider whether information gathered e.g. from previous executions has been invalidated by
+   * docker image and/or args changes, etc.
+   *
+   * <p>This method must not block.
+   *
+   * @param instance The workflow instance to check.
+   * @return A future with an optional blocker.
+   */
+  CompletionStage<Optional<ExecutionBlocker>> executionBlocker(WorkflowInstance instance);
+
+  @AutoMatter
+  interface ExecutionBlocker {
+
+    /**
+     * The reason for this execution to be blocked.
+     */
+    String reason();
+
+    /**
+     * How long to wait before attempting to execute the worklow instance again.
+     */
+    Duration delay();
+
+    static ExecutionBlocker of(String reason, Duration delay) {
+      return new ExecutionBlockerBuilder()
+          .reason(reason)
+          .delay(delay)
+          .build();
+    }
+  }
+}


### PR DESCRIPTION
Add a `WorkflowExecutionGate` scheduler plugin interface that can be used to implement blocking of workflow executions e.g. due to missing dependencies or other unfulfilled preconditions.
