### PR TITLE
[HOLD] workflow container memory requests & limits

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/model/ExecutionDescription.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/ExecutionDescription.java
@@ -20,52 +20,45 @@
 
 package com.spotify.styx.model;
 
-import static java.util.Collections.emptyList;
-import static java.util.Optional.empty;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.auto.value.AutoValue;
+import io.norberg.automatter.AutoMatter;
 import java.util.List;
 import java.util.Optional;
 
-@AutoValue
+@AutoMatter
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract class ExecutionDescription {
+public interface ExecutionDescription {
 
-  @JsonProperty
-  public abstract String dockerImage();
+  @JsonProperty("docker_image")
+  String dockerImage();
 
-  @JsonProperty
-  public abstract List<String> dockerArgs();
+  @JsonProperty("docker_args")
+  List<String> dockerArgs();
 
-  @JsonProperty
-  public abstract boolean dockerTerminationLogging();
+  @JsonProperty("docker_termination_logging")
+  boolean dockerTerminationLogging();
 
-  @JsonProperty
-  public abstract Optional<WorkflowConfiguration.Secret> secret();
+  @JsonProperty("secret")
+  Optional<WorkflowConfiguration.Secret> secret();
 
-  @JsonProperty
-  public abstract Optional<String> serviceAccount();
+  @JsonProperty("service_account")
+  Optional<String> serviceAccount();
 
-  @JsonProperty
-  public abstract Optional<String> commitSha();
+  @JsonProperty("commit_sha")
+  Optional<String> commitSha();
 
-  @JsonCreator
-  public static ExecutionDescription create(
-      @JsonProperty("docker_image") String dockerImage,
-      @JsonProperty("docker_args") List<String> dockerArgs,
-      @JsonProperty("docker_termination_logging") boolean dockerTerminationLogging,
-      @JsonProperty("secret") Optional<WorkflowConfiguration.Secret> secret,
-      @JsonProperty("service_account") Optional<String> serviceAccount,
-      @JsonProperty("commit_sha") Optional<String> commitSha) {
-    return new AutoValue_ExecutionDescription(dockerImage, dockerArgs, dockerTerminationLogging,
-                                              secret, serviceAccount, commitSha);
+  @JsonProperty("mem_request")
+  Optional<String> memRequest();
+
+  @JsonProperty("mem_limits")
+  Optional<String> memLimit();
+
+  static ExecutionDescriptionBuilder builder() {
+    return new ExecutionDescriptionBuilder();
   }
 
-  public static ExecutionDescription forImage(String dockerImage) {
-    return new AutoValue_ExecutionDescription(dockerImage, emptyList(), false, empty(), empty(),
-                                              empty());
+  static ExecutionDescription forImage(String dockerImage) {
+    return builder().dockerImage(dockerImage).build();
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.styx.model.Schedule.WellKnown;
 import com.spotify.styx.util.TimeUtil;
 import io.norberg.automatter.AutoMatter;
@@ -60,6 +61,10 @@ public interface WorkflowConfiguration {
   Optional<String> serviceAccount();
 
   List<String> resources();
+
+  Optional<String> memRequest();
+
+  Optional<String> memLimit();
 
   default Instant addOffset(Instant next) {
     final String offset = offset().orElseGet(this::defaultOffset);

--- a/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
+++ b/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
@@ -24,7 +24,6 @@ import static com.spotify.styx.model.Schedule.DAYS;
 import static com.spotify.styx.model.Schedule.HOURS;
 import static com.spotify.styx.model.Schedule.MONTHS;
 import static com.spotify.styx.model.Schedule.WEEKS;
-import static java.util.Optional.empty;
 
 import com.google.common.collect.ImmutableList;
 import com.spotify.styx.model.ExecutionDescription;
@@ -32,8 +31,6 @@ import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowConfiguration.Secret;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
-import java.util.Arrays;
-import java.util.Optional;
 
 public final class TestData {
 
@@ -84,11 +81,10 @@ public final class TestData {
           .build();
 
   public static final ExecutionDescription EXECUTION_DESCRIPTION =
-      ExecutionDescription.create(
-          "busybox:1.1",
-          Arrays.asList("foo", "bar"),
-          false,
-          Optional.of(WorkflowConfiguration.Secret.create("secret", "/dev/null")),
-          empty(),
-          Optional.of("00000ef508c1cb905e360590ce3e7e9193f6b370"));
+      ExecutionDescription.builder()
+          .dockerImage("busybox:1.1")
+          .dockerArgs("foo", "bar")
+          .secret(WorkflowConfiguration.Secret.create("secret", "/dev/null"))
+          .commitSha("00000ef508c1cb905e360590ce3e7e9193f6b370")
+          .build();
 }

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
@@ -52,8 +52,9 @@ public class WFIExecutionBuilderTest {
 
 
   private ExecutionDescription desc(String dockerImage) {
-    return ExecutionDescription.create(
-        dockerImage, Collections.emptyList(), false, empty(), empty(), empty());
+    return ExecutionDescription.builder()
+        .dockerImage(dockerImage)
+        .build();
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
@@ -51,13 +51,12 @@ public class PersistentEventTest {
   private static final String POD_NAME = "test-event";
   private static final String DOCKER_IMAGE = "busybox:1.1";
   private static final String COMMIT_SHA = "00000ef508c1cb905e360590ce3e7e9193f6b370";
-  private static final ExecutionDescription EXECUTION_DESCRIPTION = ExecutionDescription.create(
-      DOCKER_IMAGE,
-      Arrays.asList("foo", "bar"),
-      false,
-      Optional.of(WorkflowConfiguration.Secret.create("secret", "/dev/null")),
-      Optional.empty(),
-      Optional.of(COMMIT_SHA));
+  private static final ExecutionDescription EXECUTION_DESCRIPTION = ExecutionDescription.builder()
+      .dockerImage(DOCKER_IMAGE)
+      .dockerArgs("foo", "bar")
+      .secret(WorkflowConfiguration.Secret.create("secret", "/dev/null"))
+      .commitSha(COMMIT_SHA)
+      .build();
 
   @Test
   public void testRoundtripAllEvents() throws Exception {

--- a/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
@@ -30,7 +30,6 @@ import static com.spotify.styx.state.RunState.State.RUNNING;
 import static com.spotify.styx.state.RunState.State.SUBMITTED;
 import static com.spotify.styx.state.RunState.State.SUBMITTING;
 import static com.spotify.styx.state.RunState.State.TERMINATED;
-import static java.util.Optional.empty;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -40,7 +39,6 @@ import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.testdata.TestData;
 import com.spotify.styx.util.TriggerUtil;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -56,9 +54,10 @@ public class RunStateTest {
   private static final String TEST_EXECUTION_ID_2 = "execution_2";
 
   private static final String DOCKER_IMAGE = "busybox:1.1";
-  private static final ExecutionDescription EXECUTION_DESCRIPTION = ExecutionDescription.create(
-      DOCKER_IMAGE, Arrays.asList("--date", "{}", "--bar"), false,
-      empty(), empty(), empty());
+  private static final ExecutionDescription EXECUTION_DESCRIPTION = ExecutionDescription.builder()
+      .dockerImage(DOCKER_IMAGE)
+      .dockerArgs("--date", "{}", "--bar")
+      .build();
 
   private static final Trigger UNKNOWN_TRIGGER = Trigger.unknown("trig");
   private static final Trigger NATURAL_TRIGGER1 = Trigger.natural();

--- a/styx-common/src/test/java/com/spotify/styx/state/StateDataSerializationTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/StateDataSerializationTest.java
@@ -33,8 +33,6 @@ import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.serialization.Json;
 import com.spotify.styx.util.TriggerUtil;
-import java.util.Arrays;
-import java.util.Optional;
 import org.junit.Test;
 
 public class StateDataSerializationTest {
@@ -103,16 +101,12 @@ public class StateDataSerializationTest {
       .retryCost(0.4)
       .lastExit(20)
       .executionId("styx-run-12172683-c62f-4f32-899a-63a9741b73f9")
-      .executionDescription(
-          ExecutionDescription.create(
-              "pipeline-core:474339e",
-              Arrays.asList("echo", "hello", "world"),
-              false,
-              Optional.of(WorkflowConfiguration.Secret.create("pipeline-core-secret", "/etc/keys")),
-              Optional.empty(),
-              Optional.of("474339ec18d3d04d5d513856bc8ca1d4f1aed03f")
-          )
-      )
+      .executionDescription(ExecutionDescription.builder()
+          .dockerImage("pipeline-core:474339e")
+          .dockerArgs("echo", "hello", "world")
+          .secret(WorkflowConfiguration.Secret.create("pipeline-core-secret", "/etc/keys"))
+          .commitSha("474339ec18d3d04d5d513856bc8ca1d4f1aed03f")
+          .build())
       .addMessage(Message.info("Message 1"))
       .addMessage(Message.warning("Message 2"))
       .build();

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -22,6 +22,7 @@ package com.spotify.styx.docker;
 
 import static java.util.Optional.empty;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.spotify.styx.ServiceAccountKeyManager;
@@ -33,8 +34,10 @@ import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.util.Debug;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.norberg.automatter.AutoMatter;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
@@ -75,41 +78,39 @@ public interface DockerRunner extends Closeable {
    */
   void cleanup(WorkflowInstance workflowInstance, String executionId);
 
-  @AutoValue
-  abstract class RunSpec {
+  @AutoMatter
+  interface RunSpec {
 
-    public abstract String executionId();
+    String executionId();
 
-    public abstract String imageName();
+    String imageName();
 
-    public abstract ImmutableList<String> args();
+    List<String> args();
 
-    public abstract boolean terminationLogging();
+    boolean terminationLogging();
 
-    public abstract Optional<WorkflowConfiguration.Secret> secret();
+    Optional<WorkflowConfiguration.Secret> secret();
 
-    public abstract Optional<String> serviceAccount();
+    Optional<String> serviceAccount();
 
-    public abstract Optional<Trigger> trigger();
+    Optional<Trigger> trigger();
 
-    public abstract Optional<String> commitSha();
+    Optional<String> commitSha();
 
-    public static RunSpec create(
-        String executionId,
-        String imageName,
-        ImmutableList<String> args,
-        boolean terminationLogging,
-        Optional<Secret> secret,
-        Optional<String> serviceAccount,
-        Optional<Trigger> trigger,
-        Optional<String> commitSha) {
-      return new AutoValue_DockerRunner_RunSpec(executionId, imageName, args, terminationLogging, secret,
-                                                serviceAccount, trigger, commitSha);
+    Optional<String> memRequest();
+
+    Optional<String> memLimit();
+
+    static RunSpecBuilder builder() {
+      return new RunSpecBuilder();
     }
 
-    public static RunSpec simple(String executionId, String imageName, String... args) {
-      return new AutoValue_DockerRunner_RunSpec(executionId, imageName, ImmutableList.copyOf(args),
-                                                false, empty(), empty(), empty(), empty());
+    static RunSpec simple(String executionId, String imageName, String... args) {
+      return builder()
+          .executionId(executionId)
+          .imageName(imageName)
+          .args(args)
+          .build();
     }
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -22,7 +22,6 @@ package com.spotify.styx.state.handlers;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.ImmutableList;
 import com.spotify.styx.docker.DockerRunner;
 import com.spotify.styx.docker.DockerRunner.RunSpec;
 import com.spotify.styx.docker.InvalidExecutionException;
@@ -132,15 +131,16 @@ public class DockerRunnerHandler implements OutputHandler {
     final List<String> dockerArgs = executionDescription.dockerArgs();
     final String parameter = state.workflowInstance().parameter();
     final List<String> command = argsReplace(dockerArgs, parameter);
-    return RunSpec.create(
-        executionId,
-        dockerImage,
-        ImmutableList.copyOf(command),
-        executionDescription.dockerTerminationLogging(),
-        executionDescription.secret(),
-        executionDescription.serviceAccount(),
-        state.data().trigger(),
-        state.data().executionDescription().flatMap(ExecutionDescription::commitSha));
+    return RunSpec.builder()
+        .executionId(executionId)
+        .imageName(dockerImage)
+        .args(command)
+        .terminationLogging(executionDescription.dockerTerminationLogging())
+        .secret(executionDescription.secret())
+        .serviceAccount(executionDescription.serviceAccount())
+        .trigger(state.data().trigger())
+        .commitSha(state.data().executionDescription().flatMap(ExecutionDescription::commitSha))
+        .build();
   }
 
   private static List<String> argsReplace(List<String> template, String parameter) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -54,6 +54,10 @@ public class ExecutionDescriptionHandler implements OutputHandler {
   private final StateManager stateManager;
   private final DockerImageValidator dockerImageValidator;
 
+  // TODO: make runtime overridable (i.e. Storage.config())
+  private static final String DEFAULT_MEM_REQUEST = "512Mi";
+  private static final String DEFAULT_MEM_LIMIT =  "1024Mi";
+
   public ExecutionDescriptionHandler(
       Storage storage,
       StateManager stateManager,
@@ -132,13 +136,16 @@ public class ExecutionDescriptionHandler implements OutputHandler {
           workflowId, workflowInstance, errors));
     }
 
-    return ExecutionDescription.create(
-        dockerImageOpt.get(),
-        dockerArgsOpt.get(),
-        workflow.configuration().dockerTerminationLogging(),
-        workflow.configuration().secret(),
-        workflow.configuration().serviceAccount(),
-        workflowState.commitSha());
+    return ExecutionDescription.builder()
+        .dockerImage(dockerImageOpt.get())
+        .dockerArgs(dockerArgsOpt.get())
+        .dockerTerminationLogging(workflow.configuration().dockerTerminationLogging())
+        .secret(workflow.configuration().secret())
+        .serviceAccount(workflow.configuration().serviceAccount())
+        .commitSha(workflowState.commitSha())
+        .memLimit(workflow.configuration().memLimit().orElse(DEFAULT_MEM_LIMIT))
+        .memRequest(workflow.configuration().memRequest().orElse(DEFAULT_MEM_REQUEST))
+        .build();
   }
 
   static String createExecutionId() {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -22,7 +22,6 @@ package com.spotify.styx;
 
 import static com.spotify.styx.model.WorkflowInstance.create;
 import static java.util.Arrays.asList;
-import static java.util.Optional.empty;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -48,7 +47,7 @@ import com.spotify.styx.state.handlers.TerminationHandler;
 import com.spotify.styx.util.TriggerInstantSpec;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -85,9 +84,10 @@ public class SystemTest extends StyxSchedulerServiceFixture {
       "styx",
       WORKFLOW_CONFIGURATION_HOURLY_WITH_ZERO_OFFSET);
   private static final ExecutionDescription TEST_EXECUTION_DESCRIPTION =
-      ExecutionDescription.create(
-          TEST_DOCKER_IMAGE, Arrays.asList("--date", "{}", "--bar"),
-          false, empty(), empty(), empty());
+      ExecutionDescription.builder()
+      .dockerImage(TEST_DOCKER_IMAGE)
+      .dockerArgs("--date", "{}", "--bar")
+      .build();
   private static final Workflow DAILY_WORKFLOW = Workflow.create(
       "styx",
       WORKFLOW_CONFIGURATION_DAILY);
@@ -103,15 +103,23 @@ public class SystemTest extends StyxSchedulerServiceFixture {
       .schedule(Schedule.HOURS)
       .build();
 
-  private static RunSpec naturalRunSpec(String executionId, String imageName, ImmutableList<String> args) {
-    return RunSpec.create(executionId, imageName, args, false, empty(), empty(),
-                          Optional.of(Trigger.natural()), empty());
+  private static RunSpec naturalRunSpec(String executionId, String imageName, List<String> args) {
+    return RunSpec.builder()
+        .executionId(executionId)
+        .imageName(imageName)
+        .args(args)
+        .trigger(Trigger.natural())
+        .build();
   }
 
-  private static RunSpec unknownRunSpec(String executionId, String imageName, ImmutableList<String> args,
-                                        String triggerId) {
-    return RunSpec.create(executionId, imageName, args, false, empty(), empty(),
-                          Optional.of(Trigger.unknown(triggerId)), empty());
+  private static RunSpec unknownRunSpec(String executionId, String imageName, List<String> args, String triggerId) {
+    return RunSpec
+        .builder()
+        .executionId(executionId)
+        .imageName(imageName)
+        .args(args)
+        .trigger(Trigger.unknown(triggerId))
+        .build();
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
@@ -22,7 +22,6 @@ package com.spotify.styx.docker;
 
 import static com.spotify.styx.testdata.TestData.WORKFLOW_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Optional.empty;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
@@ -70,7 +69,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.IntSummaryStatistics;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -108,13 +106,11 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
 
   private static final WorkflowInstance WORKFLOW_INSTANCE = WorkflowInstance.create(WORKFLOW_ID, "foo");
 
-  private static final RunSpec RUN_SPEC_WITH_SA = RunSpec.create("eid", "busybox",
-      ImmutableList.copyOf(new String[0]),
-      false,
-      empty(),
-      Optional.of(SERVICE_ACCOUNT),
-      empty(),
-      empty());
+  private static final RunSpec RUN_SPEC_WITH_SA = RunSpec.builder()
+      .executionId("eid")
+      .imageName("busybox")
+      .serviceAccount(SERVICE_ACCOUNT)
+      .build();
 
   private ExecutorService executor;
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.spotify.styx.docker.KubernetesDockerRunner.KubernetesSecretSpec;
 import com.spotify.styx.model.Event;
@@ -334,7 +333,10 @@ public class KubernetesPodEventTranslatorTest {
   private Pod podWithTerminationLogging() {
     return KubernetesDockerRunner.createPod(
         WFI,
-        DockerRunner.RunSpec.create("eid", "busybox", ImmutableList.of(), true,
-            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()), SECRET_SPEC);
+        DockerRunner.RunSpec.builder()
+            .executionId("eid")
+            .imageName("busybox")
+            .terminationLogging(true).build(),
+        SECRET_SPEC);
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
@@ -327,9 +327,7 @@ public class QueuedStateManagerTest {
 
     Consumer<WorkflowInstance> sendEvents = instance -> {
       try {
-        stateManager.receive(Event.submit(instance, ExecutionDescription.create(
-            "", Collections.emptyList(), false, Optional.empty(),
-            Optional.empty(), Optional.empty()), "id"));
+        stateManager.receive(Event.submit(instance, ExecutionDescription.forImage(""), "id"));
         stateManager.receive(Event.submitted(instance, "id"));
         stateManager.receive(Event.started(instance));
         stateManager.receive(Event.terminate(instance, Optional.of(20)));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
@@ -21,7 +21,6 @@
 package com.spotify.styx.state.handlers;
 
 import static com.spotify.styx.model.Schedule.HOURS;
-import static java.util.Optional.empty;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -47,7 +46,6 @@ import com.spotify.styx.state.StateManager.IsClosed;
 import com.spotify.styx.state.SyncStateManager;
 import com.spotify.styx.state.Trigger;
 import java.io.IOException;
-import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -65,9 +63,10 @@ public class DockerRunnerHandlerTest {
 
   private static final String TEST_EXECUTION_ID = "execution_1";
   private static final String TEST_DOCKER_IMAGE = "busybox:1.1";
-  private static final ExecutionDescription EXECUTION_DESCRIPTION = ExecutionDescription.create(
-      TEST_DOCKER_IMAGE, Arrays.asList("--date", "{}", "--bar"),
-      false, empty(), empty(), empty());
+  private static final ExecutionDescription EXECUTION_DESCRIPTION = ExecutionDescription.builder()
+      .dockerImage(TEST_DOCKER_IMAGE)
+      .dockerArgs("--date", "{}", "--bar")
+      .build();
   private static final Trigger TRIGGER = Trigger.unknown("trig");
 
   @Captor ArgumentCaptor<WorkflowInstance> instanceCaptor;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/PublisherHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/PublisherHandlerTest.java
@@ -53,9 +53,10 @@ public class PublisherHandlerTest {
 
   @Test
   public void testPublishesRollingOutStateOnSubmitted() throws Exception {
-    ExecutionDescription executionDescription =
-        ExecutionDescription.create(DOCKER_IMAGE, emptyList(), false, empty(),
-                                    empty(), Optional.of(COMMIT_SHA));
+    ExecutionDescription executionDescription = ExecutionDescription.builder()
+        .dockerImage(DOCKER_IMAGE)
+        .commitSha(COMMIT_SHA)
+        .build();
     RunState runState = RunState.create(
         WORKFLOW_INSTANCE,
         RunState.State.SUBMITTED,
@@ -70,9 +71,11 @@ public class PublisherHandlerTest {
 
   @Test
   public void testPublishesDoneStateOnRunning() throws Exception {
-    ExecutionDescription executionDescription =
-        ExecutionDescription.create("busybox:1.1", emptyList(),
-                                    false, empty(), empty(), Optional.of(COMMIT_SHA));
+    ExecutionDescription executionDescription = ExecutionDescription.builder()
+        .dockerImage(DOCKER_IMAGE)
+        .commitSha(COMMIT_SHA)
+        .build();
+
     RunState runState = RunState.create(
         WORKFLOW_INSTANCE,
         RunState.State.RUNNING,
@@ -89,9 +92,10 @@ public class PublisherHandlerTest {
   public void shouldRetryPublishesOnSubmitted() throws Exception {
     outputHandler = new PublisherHandler(new FailingPublisher(publisher, 2));
 
-    ExecutionDescription executionDescription =
-        ExecutionDescription.create(DOCKER_IMAGE, emptyList(), false, empty(),
-                                    empty(), Optional.of(COMMIT_SHA));
+    ExecutionDescription executionDescription = ExecutionDescription.builder()
+        .dockerImage(DOCKER_IMAGE)
+        .commitSha(COMMIT_SHA)
+        .build();
     RunState runState = RunState.create(
         WORKFLOW_INSTANCE,
         RunState.State.SUBMITTED,
@@ -108,9 +112,10 @@ public class PublisherHandlerTest {
   public void shouldRetryPublishesOnRunning() throws Exception {
     outputHandler = new PublisherHandler(new FailingPublisher(publisher, 2));
 
-    ExecutionDescription executionDescription =
-        ExecutionDescription.create(DOCKER_IMAGE, emptyList(), false, empty(),
-                                    empty(), Optional.of(COMMIT_SHA));
+    ExecutionDescription executionDescription = ExecutionDescription.builder()
+        .dockerImage(DOCKER_IMAGE)
+        .commitSha(COMMIT_SHA)
+        .build();
     RunState runState = RunState.create(
         WORKFLOW_INSTANCE,
         RunState.State.RUNNING,


### PR DESCRIPTION
Memory requests & limits are useful in k8s clusters to limit the impact of non well-behaved containers on the node and other containers.

* Configure k8s memory requests and limits for WFI containers
* Default to `512Mi` request and `1024Mi` limit
* TODO: make global default mem req/lims runtime configurable