### PR TITLE
restore workflow crud api

### DIFF
--- a/doc/api.apib
+++ b/doc/api.apib
@@ -104,14 +104,14 @@ Resources related to the Workflows registered in Styx.
 
 ### Delete Workflow [DELETE]
 
-Returns 200 OK if the Workflow was found an deleted, 404 Not Found otherwise.
+Returns 204 No Content if the Workflow was found and deleted, 404 Not Found otherwise.
 
 + Parameters
     + version: `v3` (enum[string]) - API version
         + Members
             + `v3`
 
-+ Response 200
++ Response 204
 + Response 404
 
 ## Workflows [/{version}/workflows/{component_id}]

--- a/doc/api.apib
+++ b/doc/api.apib
@@ -102,6 +102,75 @@ Resources related to the Workflows registered in Styx.
               }
         }
 
+### Delete Workflow [DELETE]
+
+Returns 200 OK if the Workflow was found an deleted, 404 Not Found otherwise.
+
++ Parameters
+    + version: `v3` (enum[string]) - API version
+        + Members
+            + `v3`
+
++ Response 200
++ Response 404
+
+## Workflows [/{version}/workflows/{component_id}]
+
+Accepts a Workflow definition as a JSON object. Returns 200 OK if the Workflow was registered
+or updated. Note that a non-null value is required for docker_image.
+
++ Parameters
+    + version: `v3` (enum[string]) - API version
+        + Members
+            + `v3`
+    + component_id: `styx-canary` (string) - Workflow Component
+
+### Create or update Workflow [POST]
+
++ Request (application/json)
+
+        {
+          "id": "StyxCanary",
+          "schedule": "days",
+          "offset": null,
+          "docker_image": "styx-canary-dummy:dummy",
+          "docker_args": [
+            "luigi",
+            "--module",
+            "canary_job",
+            "CanaryJob"
+          ],
+          "docker_termination_logging": false,
+          "secret": null,
+          "service_account": null,
+          "resources": []
+        }
+
++ Response 200 (application/json)
+
+        {
+          "component_id": "styx-canary",
+          "workflow_id": "StyxCanary",
+          "component_uri": "file:///etc/styx/schedule.yaml",
+          "configuration": {
+            "id": "StyxCanary",
+            "schedule": "days",
+            "offset": null,
+            "docker_image": "styx-canary-dummy:dummy",
+            "docker_args": [
+              "luigi",
+              "--module",
+              "canary_job",
+              "CanaryJob"
+            ],
+            "docker_termination_logging": false,
+            "secret": null,
+            "service_account": null,
+            "resources": []
+          },
+          "__from_api": "V3"
+        }
+
 ## Workflow Instances [/{version}/workflows/{component_id}/{workflow_id}/instances{?offset,limit,start,stop}]
 
 Query can be done in two different styles: `offset+limit` or `start+stop`.

--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -109,6 +109,7 @@ public class StyxApi implements AppInit {
     final Storage storage = storageFactory.apply(environment);
 
     final WorkflowResource workflowResource = new WorkflowResource(storage,
+                                                                   schedulerServiceBaseUrl,
                                                                    new DockerImageValidator());
     final BackfillResource backfillResource = new BackfillResource(schedulerServiceBaseUrl,
                                                                    storage);

--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -143,19 +143,9 @@ public final class WorkflowResource {
       }
     }
 
-    final Workflow workflow = Workflow.create(componentId, workflowConfig);
-
-    final ByteString requestPayload;
-    try {
-      requestPayload = serialize(workflow);
-    } catch (JsonProcessingException e) {
-      return CompletableFuture.completedFuture(Response.forStatus(
-          Status.INTERNAL_SERVER_ERROR.withReasonPhrase("Failed to serialize proxy payload.")));
-    }
-
     // TODO: handle workflow crud directly in api service instead of proxying to scheduler
     return rc.requestScopedClient()
-        .send(rc.request().withPayload(requestPayload).withUri(schedulerApiUrl("workflows")));
+        .send(rc.request().withPayload(payload.get()).withUri(schedulerApiUrl("workflows", componentId)));
   }
 
   private Response<List<Workflow>> workflows(String componentId) {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -23,8 +23,10 @@ package com.spotify.styx.api;
 import static com.spotify.styx.api.Api.Version.V3;
 import static com.spotify.styx.api.Middlewares.json;
 import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
+import static com.spotify.styx.serialization.Json.serialize;
 import static com.spotify.styx.util.StreamUtil.cat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.spotify.apollo.Request;
@@ -34,6 +36,7 @@ import com.spotify.apollo.Status;
 import com.spotify.apollo.route.AsyncHandler;
 import com.spotify.apollo.route.Route;
 import com.spotify.styx.model.Workflow;
+import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
@@ -47,6 +50,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 import okio.ByteString;
 
@@ -54,14 +59,17 @@ public final class WorkflowResource {
 
   static final String BASE = "/workflows";
   public static final int DEFAULT_PAGE_LIMIT = 24 * 7;
+  private static final String SCHEDULER_BASE_PATH = "/api/v0";
   private final DockerImageValidator dockerImageValidator;
 
+  private final String schedulerServiceBaseUrl;
   private final Storage storage;
 
 
-  public WorkflowResource(Storage storage, DockerImageValidator dockerImageValidator) {
+  public WorkflowResource(Storage storage, String schedulerServiceBaseUrl, DockerImageValidator dockerImageValidator) {
     this.storage = Objects.requireNonNull(storage);
     this.dockerImageValidator = Objects.requireNonNull(dockerImageValidator, "dockerImageValidator");
+    this.schedulerServiceBaseUrl = Objects.requireNonNull(schedulerServiceBaseUrl);
   }
 
   public Stream<Route<AsyncHandler<Response<ByteString>>>> routes() {
@@ -86,9 +94,59 @@ public final class WorkflowResource {
             rc -> patchState(arg("cid", rc), arg("wfid", rc), rc.request()))
     );
 
-    return cat(
-        Api.prefixRoutes(routes, V3)
+    final List<Route<AsyncHandler<Response<ByteString>>>> forwardedRoutes = Arrays.asList(
+        Route.async(
+            "POST", BASE + "/<cid>",
+            rc -> createOrUpdateWorkflow(arg("cid", rc), rc)
+        ),
+        Route.async(
+            "DELETE", BASE + "/<cid>/<wfid>",
+            rc -> deleteWorkflow(arg("cid", rc), arg("wfid", rc), rc)
+        )
     );
+
+    return cat(
+        Api.prefixRoutes(routes, V3),
+        Api.prefixRoutes(forwardedRoutes, V3)
+    );
+  }
+
+  private CompletionStage<Response<ByteString>> deleteWorkflow(String cid, String wfid,
+                                                               RequestContext rc) {
+    // TODO: handle workflow crud directly in api service instead of proxying to scheduler
+    return rc.requestScopedClient()
+        .send(rc.request().withUri(schedulerApiUrl("workflows", cid, wfid)));
+  }
+
+  private CompletionStage<Response<ByteString>> createOrUpdateWorkflow(String componentId,
+                                                                       RequestContext rc) {
+    final Optional<ByteString> payload = rc.request().payload();
+    if (!payload.isPresent()) {
+      return CompletableFuture.completedFuture(
+          Response.forStatus(Status.BAD_REQUEST.withReasonPhrase("Missing payload.")));
+    }
+    final WorkflowConfiguration workflowConfig;
+    try {
+      workflowConfig = OBJECT_MAPPER
+          .readValue(payload.get().toByteArray(), WorkflowConfiguration.class);
+    } catch (IOException e) {
+      return CompletableFuture.completedFuture(
+          Response.forStatus(Status.BAD_REQUEST.withReasonPhrase("Invalid payload.")));
+    }
+
+    final Workflow workflow = Workflow.create(componentId, workflowConfig);
+
+    final ByteString requestPayload;
+    try {
+      requestPayload = serialize(workflow);
+    } catch (JsonProcessingException e) {
+      return CompletableFuture.completedFuture(Response.forStatus(
+          Status.INTERNAL_SERVER_ERROR.withReasonPhrase("Failed to serialize proxy payload.")));
+    }
+
+    // TODO: handle workflow crud directly in api service instead of proxying to scheduler
+    return rc.requestScopedClient()
+        .send(rc.request().withPayload(requestPayload).withUri(schedulerApiUrl("workflows")));
   }
 
   private Response<List<Workflow>> workflows(String componentId) {
@@ -203,6 +261,10 @@ public final class WorkflowResource {
       return Response.forStatus(
           Status.INTERNAL_SERVER_ERROR.withReasonPhrase("Couldn't fetch execution info."));
     }
+  }
+
+  private String schedulerApiUrl(CharSequence... parts) {
+    return schedulerServiceBaseUrl + SCHEDULER_BASE_PATH + "/" + String.join("/", parts);
   }
 
   private static boolean isValidSHA1(String s) {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -134,6 +134,15 @@ public final class WorkflowResource {
           Response.forStatus(Status.BAD_REQUEST.withReasonPhrase("Invalid payload.")));
     }
 
+    final Optional<String> dockerImage = workflowConfig.dockerImage();
+    if (dockerImage.isPresent()) {
+      final Collection<String> errors = dockerImageValidator.validateImageReference(dockerImage.get());
+      if (!errors.isEmpty()) {
+        return CompletableFuture.completedFuture(
+            Response.forStatus(Status.BAD_REQUEST.withReasonPhrase("Invalid docker image: " + errors)));
+      }
+    }
+
     final Workflow workflow = Workflow.create(componentId, workflowConfig);
 
     final ByteString requestPayload;

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -29,6 +29,8 @@ import static com.spotify.styx.api.JsonMatchers.assertJson;
 import static com.spotify.styx.api.JsonMatchers.assertNoJson;
 import static com.spotify.styx.model.SequenceEvent.create;
 import static com.spotify.styx.model.WorkflowState.patchDockerImage;
+import static com.spotify.styx.serialization.Json.deserialize;
+import static com.spotify.styx.serialization.Json.serialize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -62,6 +64,7 @@ import com.spotify.styx.storage.BigtableStorage;
 import com.spotify.styx.util.DockerImageValidator;
 import com.spotify.styx.util.TriggerUtil;
 import java.io.IOException;
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
@@ -80,6 +83,8 @@ import org.mockito.MockitoAnnotations;
 
 public class WorkflowResourceTest extends VersionedApiTest {
 
+  private static final String SCHEDULER_BASE = "http://localhost:12345";
+
   private static LocalDatastoreHelper localDatastore;
 
   private Datastore datastore = localDatastore.getOptions().getService();
@@ -97,8 +102,18 @@ public class WorkflowResourceTest extends VersionedApiTest {
           .schedule(Schedule.DAYS)
           .build();
 
+  private static final WorkflowConfiguration WORKFLOW_CONFIGURATION_WITH_IMAGE =
+      WorkflowConfiguration.builder()
+          .id("bar")
+          .schedule(Schedule.DAYS)
+          .dockerImage("bar-dummy:dummy")
+          .build();
+
   private static final Workflow WORKFLOW =
       Workflow.create("foo", WORKFLOW_CONFIGURATION);
+
+  private static final Workflow WORKFLOW_WITH_IMAGE =
+      Workflow.create("foo", WORKFLOW_CONFIGURATION_WITH_IMAGE);
 
   private static final String VALID_SHA = "470a229b49a14e7682af2abfdac3b881a8aacdf9";
   private static final String INVALID_SHA = "XXXXXX9b49a14e7682af2abfdac3b881a8aacdf9";
@@ -135,7 +150,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
   @Override
   protected void init(Environment environment) {
     when(dockerImageValidator.validateImageReference(Mockito.anyString())).thenReturn(Collections.emptyList());
-    WorkflowResource workflowResource = new WorkflowResource(storage, dockerImageValidator);
+    WorkflowResource workflowResource = new WorkflowResource(storage, SCHEDULER_BASE, dockerImageValidator);
 
     environment.routingEngine()
         .registerRoutes(Api.withCommonMiddleware(
@@ -511,6 +526,81 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     assertJson(response, "[*]", hasSize(1));
     assertJson(response, "[0].workflow_instance.parameter", is("2016-08-12"));
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenNoPayloadIsSentWorkflow() throws Exception {
+    sinceVersion(Api.Version.V3);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("POST", path("/foo")));
+
+    assertThat(response, hasStatus(withCode(Status.BAD_REQUEST)));
+    assertThat(response, hasNoPayload());
+    assertThat(response, hasStatus(withReasonPhrase(equalTo("Missing payload."))));
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenMalformedStatePayloadIsSentWorkflow() throws Exception {
+    sinceVersion(Api.Version.V3);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("POST", path("/foo"),
+                                            STATEPAYLOAD_BAD));
+
+    assertThat(response, hasStatus(withCode(Status.BAD_REQUEST)));
+    assertThat(response, hasNoPayload());
+    assertThat(response, hasStatus(withReasonPhrase(equalTo("Invalid payload."))));
+  }
+
+  @Test
+  public void shouldReturnOkWhenSchedulerReturnsSuccessWorkflow() throws Exception {
+    sinceVersion(Api.Version.V3);
+
+    serviceHelper.stubClient()
+        .respond(Response.forPayload(serialize(WORKFLOW_WITH_IMAGE)))
+        .to(SCHEDULER_BASE + "/api/v0/workflows");
+
+    Response<ByteString> response =
+        awaitResponse(
+            serviceHelper
+                .request("POST", path("/foo"), serialize(WORKFLOW_CONFIGURATION_WITH_IMAGE)));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertThat(deserialize(response.payload().get(), Workflow.class), equalTo(WORKFLOW_WITH_IMAGE));
+  }
+
+  @Test
+  public void shouldReturnErrorMessageWhenSchedulerFailsWorkflow() throws Exception {
+    sinceVersion(Api.Version.V3);
+
+    serviceHelper.stubClient()
+        .respond(Response.forStatus(Status.SERVICE_UNAVAILABLE))
+        .to(SCHEDULER_BASE + "/api/v0/workflows");
+
+    Response<ByteString> response =
+        awaitResponse(
+            serviceHelper
+                .request("POST", path("/foo"), serialize(WORKFLOW_CONFIGURATION_WITH_IMAGE)));
+
+    assertThat(response, hasStatus(withCode(Status.SERVICE_UNAVAILABLE)));
+    assertThat(response, hasNoPayload());
+  }
+
+  @Test
+  public void shouldForwardInternalResponseForDeleteWorkflow() throws Exception {
+    sinceVersion(Api.Version.V3);
+
+    serviceHelper.stubClient()
+        .respond(Response.forStatus(Status.OK))
+        .to(SCHEDULER_BASE + "/api/v0/workflows/foo/bar");
+
+    Response<ByteString> response =
+        awaitResponse(
+            serviceHelper.request("DELETE", path("/foo/bar")));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertThat(response, hasNoPayload());
   }
 
   @Test

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -560,7 +560,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     serviceHelper.stubClient()
         .respond(Response.forPayload(serialize(WORKFLOW_WITH_IMAGE)))
-        .to(SCHEDULER_BASE + "/api/v0/workflows");
+        .to(SCHEDULER_BASE + "/api/v0/workflows/foo");
 
     Response<ByteString> response =
         awaitResponse(
@@ -579,7 +579,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     serviceHelper.stubClient()
         .respond(Response.forStatus(Status.SERVICE_UNAVAILABLE))
-        .to(SCHEDULER_BASE + "/api/v0/workflows");
+        .to(SCHEDULER_BASE + "/api/v0/workflows/foo");
 
     Response<ByteString> response =
         awaitResponse(

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -346,7 +346,8 @@ public class StyxScheduler implements AppInit {
     setupMetrics(stateManager, workflowCache, storage, dequeueRateLimiter, stats);
 
     final SchedulerResource schedulerResource =
-        new SchedulerResource(stateManager, trigger, storage, time);
+        new SchedulerResource(stateManager, trigger, workflowChangeListener, workflowRemoveListener,
+                              storage, time);
 
     environment.routingEngine()
         .registerAutoRoute(Route.sync("GET", "/ping", rc -> "pong"))

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -347,7 +347,7 @@ public class StyxScheduler implements AppInit {
 
     final SchedulerResource schedulerResource =
         new SchedulerResource(stateManager, trigger, workflowChangeListener, workflowRemoveListener,
-                              storage, time);
+                              storage, time, new DockerImageValidator());
 
     environment.routingEngine()
         .registerAutoRoute(Route.sync("GET", "/ping", rc -> "pong"))

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
@@ -25,6 +25,7 @@ import static com.spotify.apollo.Status.INTERNAL_SERVER_ERROR;
 import static com.spotify.styx.util.ParameterUtil.parseAlignedInstant;
 
 import com.spotify.apollo.Response;
+import com.spotify.apollo.Status;
 import com.spotify.apollo.entity.EntityMiddleware;
 import com.spotify.apollo.entity.JacksonEntityCodec;
 import com.spotify.apollo.route.AsyncHandler;
@@ -33,6 +34,7 @@ import com.spotify.apollo.route.Route;
 import com.spotify.styx.TriggerListener;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.Workflow;
+import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.serialization.Json;
 import com.spotify.styx.state.StateManager;
@@ -44,6 +46,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import okio.ByteString;
 
@@ -54,6 +57,8 @@ public class SchedulerResource {
 
   private final StateManager stateManager;
   private final TriggerListener triggerListener;
+  private final Consumer<Workflow> workflowChangeListener;
+  private final Consumer<Workflow> workflowRemoveListener;
   private final Storage storage;
   private final Time time;
 
@@ -62,10 +67,14 @@ public class SchedulerResource {
   public SchedulerResource(
       StateManager stateManager,
       TriggerListener triggerListener,
+      Consumer<Workflow> workflowChangeListener,
+      Consumer<Workflow> workflowRemoveListener,
       Storage storage,
       Time time) {
     this.stateManager = Objects.requireNonNull(stateManager);
     this.triggerListener = Objects.requireNonNull(triggerListener);
+    this.workflowChangeListener = workflowChangeListener;
+    this.workflowRemoveListener = workflowRemoveListener;
     this.storage = Objects.requireNonNull(storage);
     this.time = Objects.requireNonNull(time);
   }
@@ -82,10 +91,41 @@ public class SchedulerResource {
         Route.with(
             em.response(WorkflowInstance.class),
             "POST", BASE + "/trigger",
-            rc -> this::triggerWorkflowInstance)
+            rc -> this::triggerWorkflowInstance),
+        Route.with(
+            em.response(Workflow.class),
+            "POST", BASE + "/workflows",
+            rc -> this::createOrUpdateWorkflow),
+        Route.with(
+            em.serializerResponse(ByteString.class),
+            "DELETE", BASE + "/workflows/<cid>/<wfid>",
+            rc -> deleteWorkflow(rc.pathArgs().get("cid"), rc.pathArgs().get("wfid")))
     )
+
         .map(r -> r.withMiddleware(Middleware::syncToAsync));
   }
+
+  private Response<ByteString> deleteWorkflow(String cid, String wfid) {
+    WorkflowId workflowId = WorkflowId.create(cid, wfid);
+    Optional<Workflow> workflowOpt = null;
+    try {
+      workflowOpt = storage.workflow(workflowId);
+    } catch (IOException e) {
+      return Response
+          .forStatus(Status.INTERNAL_SERVER_ERROR.withReasonPhrase("Error in internal storage"));
+    }
+    if (!workflowOpt.isPresent()) {
+      return Response.forStatus(Status.NOT_FOUND.withReasonPhrase("Workflow does not exist"));
+    }
+    workflowRemoveListener.accept(workflowOpt.get());
+    return Response.forStatus(Status.NO_CONTENT);
+  }
+
+  private Response<Workflow> createOrUpdateWorkflow(Workflow workflow) {
+    workflowChangeListener.accept(workflow);
+    return Response.forPayload(workflow);
+  }
+
 
   private Response<Event> injectEvent(Event event) {
     if (!stateManager.isActiveWorkflowInstance(event.workflowInstance())) {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
@@ -178,7 +178,7 @@ public class SchedulerResourceTest {
     Response<ByteString> response = serviceHelper.request("DELETE", String
         .join("/", SchedulerResource.BASE, "workflows", HOURLY_WORKFLOW.componentId(),
               HOURLY_WORKFLOW.workflowId())).toCompletableFuture().get();
-    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertThat(response, hasStatus(withCode(Status.NO_CONTENT)));
     assertThat(storage.workflow(HOURLY_WORKFLOW.id()), isEmpty());
   }
 


### PR DESCRIPTION
* This reverts PR #255 (3aac3da) and reintroduces workflow CRUD REST API endpoints.

* The Styx workflow storage is now the source of truth.

* Integrations with CD platform and ingestion from external truth sources can be performed directly using the workflow CRUD REST API endpoints.

* Unavailability of CD platforms and external truth sources does not affect the workflows that are stored by Styx itself.