### PR TITLE
scoped client cannot be used when nginx is in front of scheduler

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -107,6 +107,11 @@ public class StyxApi implements AppInit {
                                            : DEFAULT_SCHEDULER_SERVICE_BASE_URL;
 
     final Storage storage = storageFactory.apply(environment);
+    
+    // N.B. if we need to forward a request to scheduler that behind an nginx, we CAN NOT
+    // use rc.requestScopedClient() and at the same time inherit all headers from original
+    // request, because request scoped client would add Authorization header again which
+    // results duplicated headers, and that would make nginx unhappy.
 
     final WorkflowResource workflowResource = new WorkflowResource(storage,
                                                                    schedulerServiceBaseUrl,

--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -110,7 +110,8 @@ public class StyxApi implements AppInit {
 
     final WorkflowResource workflowResource = new WorkflowResource(storage,
                                                                    schedulerServiceBaseUrl,
-                                                                   new DockerImageValidator());
+                                                                   new DockerImageValidator(),
+                                                                   environment.client());
     final BackfillResource backfillResource = new BackfillResource(schedulerServiceBaseUrl,
                                                                    storage);
     final ResourceResource resourceResource = new ResourceResource(storage);

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -151,7 +151,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
   @Override
   protected void init(Environment environment) {
     when(dockerImageValidator.validateImageReference(Mockito.anyString())).thenReturn(Collections.emptyList());
-    WorkflowResource workflowResource = new WorkflowResource(storage, SCHEDULER_BASE, dockerImageValidator);
+    WorkflowResource workflowResource = new WorkflowResource(storage, SCHEDULER_BASE, dockerImageValidator,
+                                                             environment.client());
 
     environment.routingEngine()
         .registerRoutes(Api.withCommonMiddleware(


### PR DESCRIPTION
scoped client would add another Authorization header and that makes
nginx sad.

@bergman PTAL