### PR TITLE
Add ?status query parameter for GET backfill

### DIFF
--- a/doc/api.apib
+++ b/doc/api.apib
@@ -526,13 +526,82 @@ Workflow Instance belonging to a Backfill entity.
             }
         }
 
-## Backfill [/{version}/backfills/{backfill_id}]
+## Backfill [/{version}/backfills/{backfill_id}{?status}]
 
 + Parameters
     + version: `v3` (enum[string]) - API version
         + Members
             + `v3`
     + backfill_id: `backfill-1489054446085-52684` (string) - Backfill ID
+
+### Get Backfill [GET]
+
++ Parameters
+    + status: `true` (optional, boolean) - If to return the status list per backfill
+      + Default: true
+
++ Response 200 (application/json)
+
+        {
+            "backfill": {
+                "all_triggered": true,
+                "concurrency": 10,
+                "end": "2017-01-01T01:00:00Z",
+                "halted": false,
+                "id": "backfill-1489054446085-53384",
+                "next_trigger": "2017-01-01T01:00:00Z",
+                "schedule": "hours",
+                "start": "2017-01-01T00:00:00Z",
+                "workflow_id": {
+                    "component_id": "styx-canary",
+                    "id": "StyxCanary"
+                }
+            },
+            "statuses": {
+                "active_states": [{
+                    "state": "DONE",
+                    "workflow_instance": {
+                        "parameter": "2017-01-01T00",
+                        "workflow_id": {
+                            "component_id": "styx-canary",
+                            "id": "StyxCanary"
+                        }
+                    },
+                    "state_data": {
+                        "consecutive_failures": 0,
+                        "execution_description": {
+                            "commit_sha": "f043333085fa87738ac24f04d64fb58ecc845111",
+                            "docker_args": [
+                                "luigi",
+                                "--module",
+                                "canary_job",
+                                "CanaryJob"
+                            ],
+                            "docker_image": "styx-canary-dummy:dummy",
+                            "docker_termination_logging": false,
+                            "secret": null
+                        },
+                        "execution_id": "styx-run-6b1962c6-23ba-4245-a13b-ec3baa4b2133",
+                        "last_exit": 0,
+                        "messages": [
+                            {
+                                "level": "INFO",
+                                "line": "Exit code: 0"
+                            }
+                        ],
+                        "retry_cost": 0.0,
+                        "retry_delay_millis": null,
+                        "tries": 1,
+                        "trigger": {
+                            "@type": "backfill",
+                            "trigger_id": "backfill-1489054446085-53384"
+                        },
+                        "trigger_id": "backfill-1489054446085-53384"
+                    }
+                }]
+            }
+        }
+
 
 ### Modify Backfill [PUT]
 

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -392,7 +392,7 @@ public final class CliMain {
   private void backfillShow() throws ExecutionException, InterruptedException {
     final String id = namespace.getString(parser.backfillShowId.getDest());
 
-    final BackfillPayload backfillPayload = styxClient.backfill(id).toCompletableFuture().get();
+    final BackfillPayload backfillPayload = styxClient.backfill(id, true).toCompletableFuture().get();
     cliOutput.printBackfillPayload(backfillPayload);
   }
 

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
@@ -312,7 +312,7 @@ class StyxApolloClient implements StyxClient {
 
   @Override
   public CompletionStage<Backfill> backfillEditConcurrency(String backfillId, int concurrency) {
-    return backfill(backfillId).thenCompose(backfillPayload -> {
+    return backfill(backfillId, false).thenCompose(backfillPayload -> {
       final Backfill editedBackfill = backfillPayload.backfill().builder()
           .concurrency(concurrency)
           .build();
@@ -339,10 +339,11 @@ class StyxApolloClient implements StyxClient {
   }
 
   @Override
-  public CompletionStage<BackfillPayload> backfill(String backfillId) {
+  public CompletionStage<BackfillPayload> backfill(String backfillId, boolean status) {
     final HttpUrl.Builder urlBuilder = getUrlBuilder()
         .addPathSegment("backfills")
         .addPathSegment(backfillId);
+    urlBuilder.addQueryParameter("status", Boolean.toString(status));
     return executeRequest(Request.forUri(urlBuilder.build().toString()), BackfillPayload.class);
   }
 

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
@@ -339,11 +339,11 @@ class StyxApolloClient implements StyxClient {
   }
 
   @Override
-  public CompletionStage<BackfillPayload> backfill(String backfillId, boolean status) {
+  public CompletionStage<BackfillPayload> backfill(String backfillId, boolean includeStatus) {
     final HttpUrl.Builder urlBuilder = getUrlBuilder()
         .addPathSegment("backfills")
         .addPathSegment(backfillId);
-    urlBuilder.addQueryParameter("status", Boolean.toString(status));
+    urlBuilder.addQueryParameter("status", Boolean.toString(includeStatus));
     return executeRequest(Request.forUri(urlBuilder.build().toString()), BackfillPayload.class);
   }
 
@@ -351,12 +351,12 @@ class StyxApolloClient implements StyxClient {
   public CompletionStage<BackfillsPayload> backfillList(Optional<String> componentId,
                                                         Optional<String> workflowId,
                                                         boolean showAll,
-                                                        boolean status) {
+                                                        boolean includeStatus) {
     final HttpUrl.Builder urlBuilder = getUrlBuilder().addPathSegment("backfills");
     componentId.ifPresent(c -> urlBuilder.addQueryParameter("component", c));
     workflowId.ifPresent(w -> urlBuilder.addQueryParameter("workflow", w));
     urlBuilder.addQueryParameter("showAll", Boolean.toString(showAll));
-    urlBuilder.addQueryParameter("status", Boolean.toString(status));
+    urlBuilder.addQueryParameter("status", Boolean.toString(includeStatus));
     return executeRequest(Request.forUri(urlBuilder.build().toString()), BackfillsPayload.class);
   }
 

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxBackfillClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxBackfillClient.java
@@ -68,9 +68,10 @@ public interface StyxBackfillClient {
    * Get an existing {@link Backfill}
    *
    * @param backfillId backfill id
+   * @param status     if to include status info for the {@link Backfill}
    * @return The required {@link Backfill}
    */
-  CompletionStage<BackfillPayload> backfill(final String backfillId);
+  CompletionStage<BackfillPayload> backfill(final String backfillId, boolean status);
 
   /**
    * List of existing {@link Backfill}s

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxBackfillClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxBackfillClient.java
@@ -67,24 +67,24 @@ public interface StyxBackfillClient {
   /**
    * Get an existing {@link Backfill}
    *
-   * @param backfillId backfill id
-   * @param status     if to include status info for the {@link Backfill}
+   * @param backfillId    backfill id
+   * @param includeStatus if to include status info for the {@link Backfill}
    * @return The required {@link Backfill}
    */
-  CompletionStage<BackfillPayload> backfill(final String backfillId, boolean status);
+  CompletionStage<BackfillPayload> backfill(final String backfillId, boolean includeStatus);
 
   /**
    * List of existing {@link Backfill}s
    *
-   * @param componentId componentId id to filter on
-   * @param workflowId  componentId id to filter on
-   * @param showAll     if to include also inactive {@link Backfill}s
-   * @param status      if to include status info for the {@link Backfill}s
+   * @param componentId   componentId id to filter on
+   * @param workflowId    componentId id to filter on
+   * @param showAll       if to include also inactive {@link Backfill}s
+   * @param includeStatus if to include status info for the {@link Backfill}s
    * @return The required list of {@link Backfill}s, according to the applied filters/options
    */
   CompletionStage<BackfillsPayload> backfillList(final Optional<String> componentId,
                                                  final Optional<String> workflowId,
                                                  final boolean showAll,
-                                                 final boolean status);
+                                                 final boolean includeStatus);
 
 }


### PR DESCRIPTION
Also make use of the "status" query parameter in `backfillEditConcurrency` in the Styx client, to improve performance.