### PR TITLE
helpful credentials error message

### DIFF
--- a/styx-client/src/main/java/com/spotify/styx/client/ApiErrorException.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/ApiErrorException.java
@@ -27,13 +27,19 @@ package com.spotify.styx.client;
 public class ApiErrorException extends RuntimeException {
 
   private final int code;
+  private final boolean authenticated;
 
-  ApiErrorException(String message, int code) {
+  public ApiErrorException(String message, int code, boolean authenticated) {
     super(message);
     this.code = code;
+    this.authenticated = authenticated;
   }
 
   public int getCode() {
     return code;
+  }
+
+  public boolean isAuthenticated() {
+    return authenticated;
   }
 }


### PR DESCRIPTION
Display a helpful error message telling the user how to set up credentials when getting a `401 Unauthorized` from Styx and there are no credentials available:

```
API error: Unauthorized: Please set up Application Default Credentials or set the GOOGLE_APPLICATION_CREDENTIALS env var to point to a file defining the credentials.

Hint: Try setting up credentials using gcloud: 

	$ gcloud auth application-default login
```