### PR TITLE
validate workflow before storing and update

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
+++ b/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
@@ -56,6 +56,23 @@ public final class TestData {
           .dockerImage("busybox")
           .schedule(HOURS)
           .build();
+  public static final WorkflowConfiguration HOURLY_WORKFLOW_CONFIGURATION_WITH_INVALID_OFFSET =
+      WorkflowConfiguration.builder()
+          .id("styx.TestEndpoint")
+          .commitSha(VALID_SHA)
+          .dockerImage("busybox")
+          .schedule(HOURS)
+          .offset("P1D2H") // the correct one should be P1DT2H
+          .build();
+
+  public static final WorkflowConfiguration HOURLY_WORKFLOW_CONFIGURATION_WITH_VALID_OFFSET =
+      WorkflowConfiguration.builder()
+          .id("styx.TestEndpoint")
+          .commitSha(VALID_SHA)
+          .dockerImage("busybox")
+          .schedule(HOURS)
+          .offset("P1DT2H")
+          .build();
 
   public static final WorkflowConfiguration DAILY_WORKFLOW_CONFIGURATION =
       WorkflowConfiguration.builder()
@@ -80,7 +97,6 @@ public final class TestData {
           .dockerImage("busybox")
           .schedule(MONTHS)
           .build();
-
 
   public static final WorkflowConfiguration FULL_WORKFLOW_CONFIGURATION =
       WorkflowConfiguration.builder()

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
@@ -148,7 +148,7 @@ public class SchedulerResource {
     try {
       workflowChangeListener.accept(workflow);
     } catch (WorkflowInitializationException e) {
-      return Response.forStatus(Status.BAD_REQUEST.withReasonPhrase(e.getLocalizedMessage()));
+      return Response.forStatus(Status.BAD_REQUEST.withReasonPhrase(e.getMessage()));
     }
 
     return Response.forPayload(workflow);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
@@ -45,6 +45,7 @@ import com.spotify.styx.util.DockerImageValidator;
 import com.spotify.styx.util.IsClosedException;
 import com.spotify.styx.util.RandomGenerator;
 import com.spotify.styx.util.Time;
+import com.spotify.styx.workflow.WorkflowInitializationException;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
@@ -143,7 +144,12 @@ public class SchedulerResource {
     }
 
     final Workflow workflow = Workflow.create(componentId, configuration);
-    workflowChangeListener.accept(workflow);
+
+    try {
+      workflowChangeListener.accept(workflow);
+    } catch (WorkflowInitializationException e) {
+      return Response.forStatus(Status.BAD_REQUEST.withReasonPhrase(e.getLocalizedMessage()));
+    }
 
     return Response.forPayload(workflow);
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/workflow/WorkflowInitializationException.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/workflow/WorkflowInitializationException.java
@@ -1,0 +1,28 @@
+/*-
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.workflow;
+
+public class WorkflowInitializationException extends RuntimeException {
+
+  public WorkflowInitializationException(Exception e) {
+    super(e);
+  }
+}

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/workflow/WorkflowInitializerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/workflow/WorkflowInitializerTest.java
@@ -1,0 +1,110 @@
+/*-
+ * -\-\-
+ * Spotify styx
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.workflow;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.spotify.styx.model.Workflow;
+import com.spotify.styx.storage.Storage;
+import com.spotify.styx.testdata.TestData;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WorkflowInitializerTest {
+
+  private final Workflow HOURLY_WORKFLOW = Workflow.create("styx",
+                                                           TestData.HOURLY_WORKFLOW_CONFIGURATION);
+  private final Workflow HOURLY_WORKFLOW_WITH_INVALID_OFFSET =
+      Workflow.create("styx", TestData.HOURLY_WORKFLOW_CONFIGURATION_WITH_INVALID_OFFSET);
+
+  private final Workflow HOURLY_WORKFLOW_WITH_VALID_OFFSET =
+      Workflow.create("styx", TestData.HOURLY_WORKFLOW_CONFIGURATION_WITH_VALID_OFFSET);
+
+  private WorkflowInitializer workflowInitializer;
+
+  @Mock
+  private Storage storage;
+
+  @Before
+  public void setUp() {
+    workflowInitializer = new WorkflowInitializer(storage,
+                                                  () -> Instant.parse("2015-12-31T23:59:10.000Z"));
+  }
+
+  @Test
+  public void shouldFailToReadWorkflow() throws Exception {
+    when(storage.workflow(HOURLY_WORKFLOW.id())).thenThrow(new IOException("read error"));
+
+    try {
+      workflowInitializer.inspectChange(HOURLY_WORKFLOW);
+      fail();
+    } catch (RuntimeException e) {
+      assertEquals("read error", e.getCause().getMessage());
+    }
+  }
+
+  @Test
+  public void shouldFailToStoreWorkflow() throws Exception {
+    doThrow(new IOException("write error")).when(storage).storeWorkflow(HOURLY_WORKFLOW);
+    when(storage.workflow(HOURLY_WORKFLOW.id())).thenReturn(Optional.of(HOURLY_WORKFLOW));
+
+    try {
+      workflowInitializer.inspectChange(HOURLY_WORKFLOW);
+      fail();
+    } catch (RuntimeException e) {
+      assertEquals("write error", e.getCause().getMessage());
+    }
+  }
+
+  @Test(expected = WorkflowInitializationException.class)
+  public void shouldFailComputeNextTrigger() throws Exception {
+    when(storage.workflow(HOURLY_WORKFLOW.id()))
+        .thenReturn(Optional.of(HOURLY_WORKFLOW));
+    workflowInitializer.inspectChange(HOURLY_WORKFLOW_WITH_INVALID_OFFSET);
+  }
+
+  @Test
+  public void shouldFailToUpdateNextNaturalTrigger() throws Exception {
+    doThrow(new IOException("update error")).when(storage)
+        .updateNextNaturalTrigger(eq(HOURLY_WORKFLOW.id()), any());
+    when(storage.workflow(HOURLY_WORKFLOW.id()))
+        .thenReturn(Optional.of(HOURLY_WORKFLOW));
+
+    try {
+      workflowInitializer.inspectChange(HOURLY_WORKFLOW_WITH_VALID_OFFSET);
+      fail();
+    } catch (RuntimeException e) {
+      assertEquals("update error", e.getCause().getMessage());
+    }
+  }
+}


### PR DESCRIPTION
initializing next natural trigger could throw RuntimeException due to
wrong syntax of offset or schedule.

@ulzha PTAL