### PR TITLE
Remove last execution id from 'styx ls'

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -57,7 +57,7 @@ class PrettyCliOutput implements CliOutput {
     System.out.println(String.format("  %-20s %-12s %-47s %-7s %s",
                                      "WORKFLOW INSTANCE",
                                      "STATE",
-                                     "LAST EXECUTION ID",
+                                     "EXECUTION ID",
                                      "TRIES",
                                      "PREVIOUS EXECUTION MESSAGE"));
 


### PR DESCRIPTION
#323 made the execution id disappear when replaying the events for workflow instances in QUEUED or PREPARED state, so in those cases the execution id do not show up with the CLI command `styx ls`. However, such information is not very relevant for the users and the execution id can still be retrieved via `styx events ...` so we can remove it completely from `styx ls`.

EDIT: we can also keep displaying the execution id for current executions