### PR TITLE
k8s: watch from latest

### DIFF
--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -151,7 +151,6 @@ public class KubernetesDockerRunnerTest {
   @Mock ContainerState containerState;
   @Mock ContainerStateTerminated containerStateTerminated;
   @Mock ListMeta listMeta;
-  @Mock Watchable<Watch, Watcher<Pod>> podWatchable;
   @Mock Watch watch;
   @Mock Debug debug;
 
@@ -174,14 +173,12 @@ public class KubernetesDockerRunnerTest {
     when(k8sClient.inNamespace(any(String.class))).thenReturn(k8sClient);
     when(k8sClient.pods()).thenReturn(pods);
 
-    // pods().list().getMetadata().getResourceVersion()
     when(pods.list()).thenReturn(podList);
     when(podList.getItems()).thenReturn(ImmutableList.of(createdPod));
     when(podList.getMetadata()).thenReturn(listMeta);
     when(listMeta.getResourceVersion()).thenReturn("1000");
 
-    when(pods.withResourceVersion("1000")).thenReturn(podWatchable);
-    when(podWatchable.watch(watchCaptor.capture())).thenReturn(watch);
+    when(pods.watch(watchCaptor.capture())).thenReturn(watch);
 
     when(serviceAccountSecretManager.ensureServiceAccountKeySecret(
         WORKFLOW_INSTANCE.workflowId().toString(), SERVICE_ACCOUNT))


### PR DESCRIPTION
In a high volume k8s cluster, resource versions go stale quickly enough that watching from a resource version returned by a pod list operation often fails with a "too old resource version" error.

Omitting the resource version parameter from the watch call causes k8s to watch from the latest resource version. This has been tested empirically using our GKE clusters but the docs are ambiguous on this point.

Styx might miss events when the watcher is re-established, but that is already the case.

In the high-volume case it does not seem likely that there is a way to not miss events using only the watcher, thus polling acts as a fallback.

For the low-volume case we could keep storing the last observed resource version etc in an attempt to not miss any events. However, I did not think that useful enough to warrant the complexity, given that the polling mechanism will likely observe terminated pods before they are GC'd in this case.

Note: Even omitting the resource version parameter from the watch call has been observed to immediately fail with a "too old resource version" error on occasion.