### PR TITLE
upgrade cron-utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
       <dependency>
         <groupId>com.cronutils</groupId>
         <artifactId>cron-utils</artifactId>
-        <version>5.0.5</version>
+        <version>7.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/styx-common/src/main/java/com/spotify/styx/util/ParameterUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ParameterUtil.java
@@ -170,7 +170,7 @@ public final class ParameterUtil {
 
     // test alignment
     if (!TimeUtil.isAligned(instant, schedule)) {
-      return TimeUtil.lastInstant(instant, schedule);
+      return TimeUtil.previousInstant(instant, schedule);
     } else {
       return instant;
     }

--- a/styx-common/src/main/java/com/spotify/styx/util/TimeUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/TimeUtil.java
@@ -63,14 +63,18 @@ public class TimeUtil {
 
     return (executionTime.isMatch(utcDateTime))
         ? instant
-        : executionTime.lastExecution(utcDateTime).toInstant();
+        : executionTime.lastExecution(utcDateTime)
+               .orElseThrow(IllegalArgumentException::new)
+               .toInstant();
   }
 
   public static Instant previousInstant(Instant instant, Schedule schedule) {
     final ExecutionTime executionTime = ExecutionTime.forCron(cron(schedule));
     final ZonedDateTime utcDateTime = instant.atZone(UTC);
 
-    return executionTime.lastExecution(utcDateTime).toInstant();
+    return executionTime.lastExecution(utcDateTime)
+        .orElseThrow(IllegalArgumentException::new)
+        .toInstant();
   }
 
   /**
@@ -85,9 +89,10 @@ public class TimeUtil {
   public static Instant nextInstant(Instant instant, Schedule schedule) {
     final ExecutionTime executionTime = ExecutionTime.forCron(cron(schedule));
     final ZonedDateTime utcDateTime = instant.atZone(UTC);
-    final ZonedDateTime nextDateTime = executionTime.nextExecution(utcDateTime);
 
-    return nextDateTime.toInstant();
+    return executionTime.nextExecution(utcDateTime)
+        .orElseThrow(IllegalArgumentException::new)
+        .toInstant();
   }
 
   /**

--- a/styx-common/src/test/java/com/spotify/styx/util/ParameterUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ParameterUtilTest.java
@@ -47,7 +47,7 @@ public class ParameterUtilTest {
   private static final Instant TIME = parse("2016-01-19T09:11:22.333Z");
 
   @Test
-  public void testToParameter() throws Exception {
+  public void testToParameter() {
     assertThat(ParameterUtil.toParameter(Schedule.HOURS, TIME), is("2016-01-19T09"));
     assertThat(ParameterUtil.toParameter(Schedule.DAYS, TIME), is("2016-01-19"));
     assertThat(ParameterUtil.toParameter(Schedule.WEEKS, TIME), is("2016-01-19"));
@@ -59,21 +59,21 @@ public class ParameterUtilTest {
   }
 
   @Test
-  public void shouldParseDateHour() throws Exception {
+  public void shouldParseDateHour() {
     final Instant instant = ParameterUtil.parseDateHour("2016-01-19T08");
 
     assertThat(instant, is(parse("2016-01-19T08:00:00.000Z")));
   }
 
   @Test
-  public void shouldParseDate() throws Exception {
+  public void shouldParseDate() {
     final Instant instant = ParameterUtil.parseDate("2016-01-19");
 
     assertThat(instant, is(parse("2016-01-19T00:00:00.000Z")));
   }
 
   @Test
-  public void shouldRangeOfInstantsHours() throws Exception {
+  public void shouldRangeOfInstantsHours() {
     final Instant startInstant = parse("2016-12-31T23:00:00.00Z");
     final Instant endInstant = parse("2017-01-01T02:00:00.00Z");
 
@@ -86,7 +86,7 @@ public class ParameterUtilTest {
   }
 
   @Test
-  public void shouldRangeOfInstantsDays() throws Exception {
+  public void shouldRangeOfInstantsDays() {
     final Instant startInstant = parse("2016-12-31T00:00:00.00Z");
     final Instant endInstant = parse("2017-01-03T00:00:00.00Z");
 
@@ -99,7 +99,7 @@ public class ParameterUtilTest {
   }
 
   @Test
-  public void shouldRangeOfInstantsWeeks() throws Exception {
+  public void shouldRangeOfInstantsWeeks() {
     final Instant startInstant = parse("2016-12-26T00:00:00.00Z");
     final Instant endInstant = parse("2017-01-16T00:00:00.00Z");
 
@@ -112,7 +112,7 @@ public class ParameterUtilTest {
   }
 
   @Test
-  public void shouldRangeOfInstantsMonths() throws Exception {
+  public void shouldRangeOfInstantsMonths() {
     final Instant startInstant = parse("2017-01-01T00:00:00.00Z");
     final Instant endInstant = parse("2017-04-01T00:00:00.00Z");
 
@@ -125,7 +125,7 @@ public class ParameterUtilTest {
   }
 
   @Test
-  public void shouldReturnEmptyListStartEqualsEnd() throws Exception {
+  public void shouldReturnEmptyListStartEqualsEnd() {
     final Instant startInstant = parse("2016-12-31T23:00:00.00Z");
     final Instant endInstant = parse("2016-12-31T23:00:00.00Z");
 
@@ -134,7 +134,7 @@ public class ParameterUtilTest {
   }
 
   @Test(expected=IllegalArgumentException.class)
-  public void shouldRaiseRangeOfInstantsStartAfterEnd() throws Exception {
+  public void shouldRaiseRangeOfInstantsStartAfterEnd() {
     final Instant startInstant = parse("2016-12-31T23:00:00.00Z");
     final Instant endInstant = parse("2016-01-01T01:00:00.00Z");
 
@@ -209,7 +209,7 @@ public class ParameterUtilTest {
   }
 
   @Test
-  public void parseAllExamples() throws Exception {
+  public void parseAllExamples() {
     for (ParseExample example : PARSE_EXAMPLES) {
       Instant parsed = parseAlignedInstant(example.toParse(), example.schedule());
       assertThat(
@@ -219,7 +219,7 @@ public class ParameterUtilTest {
   }
 
   @Test
-  public void unparsableExamples() throws Exception {
+  public void unparsableExamples() {
     for (ParseExample example : UNPARSABLE) {
       try {
         parseAlignedInstant(example.toParse(), example.schedule());

--- a/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
@@ -39,7 +39,7 @@ public class TimeUtilTest {
   private static final Instant TIME = Instant.parse("2016-01-19T09:11:22.333Z");
 
   @Test
-  public void shouldGetLastInstant() throws Exception {
+  public void shouldGetLastInstant() {
     final Instant lastTimeHours = Instant.parse("2016-01-19T09:00:00.00Z");
     final Instant lastTimeDays = Instant.parse("2016-01-19T00:00:00.00Z");
     final Instant lastTimeWeeks = Instant.parse("2016-01-18T00:00:00.00Z");
@@ -59,7 +59,18 @@ public class TimeUtilTest {
   }
 
   @Test
-  public void shouldReturnLastInstantUnchangedIfMatchingTime() throws Exception {
+  public void shouldWorkForComplexCron() {
+    final Instant lastInstant = lastInstant(Instant.parse("2016-01-19T09:00:00.00Z"),
+                                            Schedule.parse("5-59/20 * * * *"));
+    assertThat(lastInstant, is(Instant.parse("2016-01-19T08:45:00.00Z")));
+
+    final Instant nextInstance = nextInstant(Instant.parse("2016-01-19T09:00:00.00Z"),
+                                             Schedule.parse("5-59/20 * * * *"));
+    assertThat(nextInstance, is(Instant.parse("2016-01-19T09:05:00.00Z")));
+  }
+
+  @Test
+  public void shouldReturnLastInstantUnchangedIfMatchingTime() {
     final Instant lastTimeHours = Instant.parse("2016-01-19T09:00:00.00Z");
     final Instant lastTimeDays = Instant.parse("2016-01-19T00:00:00.00Z");
     final Instant lastTimeWeeks = Instant.parse("2016-01-18T00:00:00.00Z");
@@ -78,8 +89,20 @@ public class TimeUtilTest {
     assertThat(months, is(lastTimeMonths));
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldFailIfNoLastInstance() {
+    lastInstant(Instant.parse("2016-01-19T09:00:00.00Z"),
+                Schedule.parse("* * * * * 2017"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldFailIfNoPreviousInstance() {
+    lastInstant(Instant.parse("2016-01-19T09:00:00.00Z"),
+                Schedule.parse("* * * * * 2017"));
+  }
+
   @Test
-  public void shouldGetNextInstant() throws Exception {
+  public void shouldGetNextInstant() {
     final Instant nextTimeHours = Instant.parse("2016-01-19T10:00:00.00Z");
     final Instant nextTimeDays = Instant.parse("2016-01-20T00:00:00.00Z");
     final Instant nextTimeWeeks = Instant.parse("2016-01-25T00:00:00.00Z");
@@ -98,8 +121,14 @@ public class TimeUtilTest {
     assertThat(months, is(nextTimeMonths));
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldFailIfNoNextInstance() {
+    lastInstant(Instant.parse("2018-01-19T09:00:00.00Z"),
+                Schedule.parse("* * * * * 2017"));
+  }
+
   @Test
-  public void shouldTestWellKnownAlignedInstants() throws Exception {
+  public void shouldTestWellKnownAlignedInstants() {
     assertTrue(isAligned(Instant.parse("2017-02-06T10:00:00.00Z"), Schedule.HOURS));
     assertTrue(isAligned(Instant.parse("2017-02-06T00:00:00.00Z"), Schedule.DAYS));
     assertTrue(isAligned(Instant.parse("2017-02-06T00:00:00.00Z"), Schedule.WEEKS));
@@ -114,7 +143,7 @@ public class TimeUtilTest {
   }
 
   @Test
-  public void shouldTestCustomAlignedInstants() throws Exception {
+  public void shouldTestCustomAlignedInstants() {
     Schedule custom = Schedule.parse("15,42 10 * * *");
     assertTrue(isAligned(Instant.parse("2017-02-06T10:15:00.00Z"), custom));
     assertTrue(isAligned(Instant.parse("2017-02-06T10:42:00.00Z"), custom));
@@ -123,7 +152,7 @@ public class TimeUtilTest {
   }
 
   @Test
-  public void shouldSupportZeroOffset() throws Exception {
+  public void shouldSupportZeroOffset() {
     String offset = "PT0S";
     ZonedDateTime time = ZonedDateTime.parse("2017-01-22T08:07:11.22Z");
     ZonedDateTime offsetTime = addOffset(time, offset);
@@ -132,7 +161,7 @@ public class TimeUtilTest {
   }
 
   @Test
-  public void shouldAddOffset() throws Exception {
+  public void shouldAddOffset() {
     String offset = "P1M3DT1H7M5S";
     ZonedDateTime time = ZonedDateTime.parse("2017-01-22T08:07:11.22Z");
     ZonedDateTime offsetTime = addOffset(time, offset);
@@ -141,7 +170,7 @@ public class TimeUtilTest {
   }
 
   @Test
-  public void shouldAddOffsetWithNoPeriod() throws Exception {
+  public void shouldAddOffsetWithNoPeriod() {
     String offset = "PT1H7M5S";
     ZonedDateTime time = ZonedDateTime.parse("2017-01-22T08:07:11.22Z");
     ZonedDateTime offsetTime = addOffset(time, offset);
@@ -150,7 +179,7 @@ public class TimeUtilTest {
   }
 
   @Test
-  public void shouldAddOffsetWithNoTime() throws Exception {
+  public void shouldAddOffsetWithNoTime() {
     String offset = "P1M3D";
     ZonedDateTime time = ZonedDateTime.parse("2017-01-22T08:07:11.22Z");
     ZonedDateTime offsetTime = addOffset(time, offset);
@@ -159,7 +188,7 @@ public class TimeUtilTest {
   }
 
   @Test
-  public void shouldAddOffsetWithWeek() throws Exception {
+  public void shouldAddOffsetWithWeek() {
     String offset = "P2W";
     ZonedDateTime time = ZonedDateTime.parse("2017-01-22T08:07:11.22Z");
     ZonedDateTime offsetTime = addOffset(time, offset);
@@ -168,7 +197,7 @@ public class TimeUtilTest {
   }
 
   @Test
-  public void cronScheduleShouldNotEqualEquivalentWellKnownSchedule() throws Exception {
+  public void cronScheduleShouldNotEqualEquivalentWellKnownSchedule() {
     assertFalse(Schedule.parse("0 * * * *").equals(Schedule.HOURS));
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
@@ -65,7 +65,7 @@ public class TimeUtilTest {
     assertThat(lastInstant, is(Instant.parse("2016-01-19T08:45:00.00Z")));
 
     final Instant nextInstance = nextInstant(Instant.parse("2016-01-19T09:00:00.00Z"),
-                                             Schedule.parse("5-59/20 * * * *"));
+                                             Schedule.parse("05-59/20 * * * *"));
     assertThat(nextInstance, is(Instant.parse("2016-01-19T09:05:00.00Z")));
   }
 
@@ -87,18 +87,6 @@ public class TimeUtilTest {
 
     final Instant months = lastInstant(lastTimeMonths, Schedule.MONTHS);
     assertThat(months, is(lastTimeMonths));
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailIfNoLastInstance() {
-    lastInstant(Instant.parse("2016-01-19T09:00:00.00Z"),
-                Schedule.parse("* * * * * 2017"));
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailIfNoPreviousInstance() {
-    lastInstant(Instant.parse("2016-01-19T09:00:00.00Z"),
-                Schedule.parse("* * * * * 2017"));
   }
 
   @Test


### PR DESCRIPTION
Basically to get this fix in: https://github.com/jmrozanec/cron-utils/issues/144

Due to a change introduced by
https://github.com/jmrozanec/cron-utils/issues/155, we throw exception
if get an empty optional. This doesn't change the orignal behavior at
all, and we don't exepct this thing to happen in our use cases.

This change https://github.com/jmrozanec/cron-utils/issues/200 breaks
our previous assumption, and that's why there are so many fixes in this PR.

@danielnorberg PTAL