### PR TITLE
Improve error handling for events injection APIs

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
@@ -203,10 +203,15 @@ public class SchedulerResource {
   private StatusType eventInjectorHelper(Event event) {
     try {
       stateManager.receive(event).toCompletableFuture().get();
-    } catch (IllegalArgumentException | IllegalStateException e) {
-      return BAD_REQUEST.withReasonPhrase(e.getMessage());
-    } catch (IsClosedException | InterruptedException | ExecutionException e) {
+    } catch (IsClosedException | InterruptedException e) {
       return INTERNAL_SERVER_ERROR.withReasonPhrase(e.getMessage());
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof IllegalArgumentException
+          || e.getCause() instanceof IllegalStateException) {
+        return BAD_REQUEST.withReasonPhrase(e.getCause().getMessage());
+      } else {
+        return INTERNAL_SERVER_ERROR.withReasonPhrase(e.getMessage());
+      }
     }
     return OK;
   }


### PR DESCRIPTION
The `SyncStateManager` used in some tests might not behave exactly as the `QueuedStateManager` used online. This makes parts of the tests relying on `SyncStateManager` potentially wrong or irrelevant. 
In this specific case, different error handling in `SyncStateManager` with respect to `QueuedStateManager` caused unexpected API error codes being returned from the event injecting APIs.
In future PRs we could remove `SyncStateManager` from these tests and think about a different approach.