### PR TITLE
propagate CliExitException to main

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -299,6 +299,8 @@ public final class CliMain {
         cliOutput.printError(getStackTraceAsString(cause));
         throw CliExitException.of(ExitStatus.ClientError);
       }
+    } catch (CliExitException e) {
+      throw e;
     } catch (Exception e) {
       cliOutput.printError(getStackTraceAsString(e));
       throw CliExitException.of(ExitStatus.UnknownError);


### PR DESCRIPTION
Before:
```
$ styx workflow delete foo bar
Sure you want to delete the workflow bar in component foo? [yN] n
com.spotify.styx.cli.CliExitException
	at com.spotify.styx.cli.CliExitException.of(CliExitException.java:52)
	at com.spotify.styx.cli.CliMain.workflowDelete(CliMain.java:321)
	at com.spotify.styx.cli.CliMain.run(CliMain.java:256)
	at com.spotify.styx.cli.CliMain.run(CliMain.java:166)
	at com.spotify.styx.cli.CliMain.run(CliMain.java:123)
	at com.spotify.styx.cli.CliMain.main(CliMain.java:116)
```

After:
```
$ styx workflow delete foo bar
Sure you want to delete the workflow bar in component foo? [yN] n
```