### PR TITLE
Update logging for Workflows added/modified/removed

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/InMemWorkflowCache.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/InMemWorkflowCache.java
@@ -40,12 +40,13 @@ public class InMemWorkflowCache implements WorkflowCache {
 
   @Override
   public void store(Workflow workflow) {
-    LOG.info("Storing {}", workflow);
+    LOG.debug("Adding to cache: {}", workflow);
     workflowStore.put(workflow.id(), workflow);
   }
 
   @Override
   public void remove(Workflow workflow) {
+    LOG.debug("Removing from cache: {}", workflow);
     workflowStore.remove(workflow.id());
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -581,6 +581,12 @@ public class StyxScheduler implements AppInit {
       workflowInitializer.inspectChange(workflow);
       cache.store(workflow);
       workflowConsumer.accept(oldWorkflowOptional, Optional.of(workflow));
+      if (oldWorkflowOptional.isPresent()) {
+        LOG.info("Workflow modified, old config: {}, new config: {}", oldWorkflowOptional.get(),
+            workflow);
+      } else {
+        LOG.info("Workflow added: {}", workflow);
+      }
     };
   }
 
@@ -597,6 +603,7 @@ public class StyxScheduler implements AppInit {
       }
       cache.remove(workflow);
       workflowConsumer.accept(Optional.of(workflow), Optional.empty());
+      LOG.info("Workflow removed: {}", workflow);
     });
   }
 


### PR DESCRIPTION
The logging regarding the workflowCache is updated and changed to DEBUG level. The reasoning for that is to only track, at the INFO level, the occurrence of a workflow correctly added/modified/removed, including (implicitly) all the related operations: storage update, cache update, consumers being called, metrics being registered, etc. 
Correct cache operations are a lower level implementation whose correct functioning can be tracked at the DEBUG level (optionally). 