### PR TITLE
add CLI support to enable and disable workflows

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -381,16 +381,28 @@ public final class CliMain {
     final String component = namespace.getString(parser.workflowEnableComponentId.getDest());
     final List<String> workflows = namespace.getList(parser.workflowEnableWorkflowId.getDest());
     workflowStateUpdate(component, workflows, WorkflowState.patchEnabled(true))
-        .forEach(t -> cliOutput
-            .printMessage("Workflow " + t._1 + " in component " + component + " enabled."));
+        .forEach(t -> {
+          if (t._2.enabled().orElse(false)) {
+            cliOutput.printMessage("Workflow " + t._1 + " in component " + component + " enabled.");
+          } else {
+            cliOutput.printMessage(
+                "Failed to enable workflow " + t._1 + " in component " + component + ".");
+          }
+        });
   }
 
   private void workflowDisable() throws ExecutionException, InterruptedException {
     final String component = namespace.getString(parser.workflowDisableComponentId.getDest());
     final List<String> workflows = namespace.getList(parser.workflowDisableWorkflowId.getDest());
     workflowStateUpdate(component, workflows, WorkflowState.patchEnabled(false))
-        .forEach(t -> cliOutput
-            .printMessage("Workflow " + t._1 + " in component " + component + " disabled."));
+        .forEach(t -> {
+          if (!t._2.enabled().orElse(false)) {
+            cliOutput.printMessage("Workflow " + t._1 + " in component " + component + " disabled.");
+          } else {
+            cliOutput.printMessage(
+                "Failed to disable workflow " + t._1 + " in component " + component + ".");
+          }
+        });
   }
 
   private List<Tuple2<String, WorkflowState>> workflowStateUpdate(String component,

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -30,6 +30,7 @@ import static net.sourceforge.argparse4j.impl.Arguments.fileType;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.spotify.apollo.Client;
 import com.spotify.apollo.core.Service;
 import com.spotify.apollo.core.Services;
@@ -258,6 +259,12 @@ public final class CliMain {
             case DELETE:
               workflowDelete();
               break;
+            case ENABLE:
+              workflowEnable();
+              break;
+            case DISABLE:
+              workflowDisable();
+              break;
             default:
               // parsing unknown command will fail so this would only catch non-exhaustive switches
               throw new ArgumentParserException(
@@ -337,17 +344,7 @@ public final class CliMain {
         future._2.toCompletableFuture().get();
         cliOutput.printMessage("Workflow " + workflow + " in component " + component + " deleted.");
       } catch (ExecutionException e) {
-        final Throwable cause = e.getCause();
-        if (cause instanceof ApiErrorException) {
-          final ApiErrorException apiError = (ApiErrorException) cause;
-          if (apiError.getCode() == NOT_FOUND.code()) {
-            cliOutput.printMessage("Workflow " + workflow + " in component " + component + " not found.");
-          } else {
-            throw e;
-          }
-        } else {
-          throw e;
-        }
+        handleWorkflowNotFound(component, workflow, e);
       }
     }
   }
@@ -377,6 +374,62 @@ public final class CliMain {
       final Workflow created = future.toCompletableFuture().get();
       cliOutput.printMessage("Workflow " + created.workflowId() + " in component "
           + created.componentId() + " created.");
+    }
+  }
+
+  private void workflowEnable() throws ExecutionException, InterruptedException {
+    final String component = namespace.getString(parser.workflowEnableComponentId.getDest());
+    final List<String> workflows = namespace.getList(parser.workflowEnableWorkflowId.getDest());
+    workflowStateUpdate(component, workflows, WorkflowState.patchEnabled(true))
+        .forEach(t -> cliOutput
+            .printMessage("Workflow " + t._1 + " in component " + component + " enabled."));
+  }
+
+  private void workflowDisable() throws ExecutionException, InterruptedException {
+    final String component = namespace.getString(parser.workflowDisableComponentId.getDest());
+    final List<String> workflows = namespace.getList(parser.workflowDisableWorkflowId.getDest());
+    workflowStateUpdate(component, workflows, WorkflowState.patchEnabled(false))
+        .forEach(t -> cliOutput
+            .printMessage("Workflow " + t._1 + " in component " + component + " disabled."));
+  }
+
+  private List<Tuple2<String, WorkflowState>> workflowStateUpdate(String component,
+                                                                  List<String> workflows,
+                                                                  WorkflowState workflowState)
+      throws ExecutionException, InterruptedException {
+    final List<Tuple2<String, CompletionStage<WorkflowState>>> futures = workflows.stream()
+        .map(workflow -> Tuple.of(workflow,
+                                  styxClient.updateWorkflowState(component,
+                                                                 workflow,
+                                                                 workflowState)))
+        .collect(toList());
+
+    final List<Tuple2<String, WorkflowState>> updatedWorkflowStates =
+        Lists.newArrayListWithCapacity(futures.size());
+    for (Tuple2<String, CompletionStage<WorkflowState>> future : futures) {
+      final String workflow = future._1;
+      try {
+        updatedWorkflowStates.add(Tuple.of(workflow, future._2.toCompletableFuture().get()));
+      } catch (ExecutionException e) {
+        handleWorkflowNotFound(component, workflow, e);
+      }
+    }
+
+    return updatedWorkflowStates;
+  }
+
+  private void handleWorkflowNotFound(String component, String workflow, ExecutionException e)
+      throws ExecutionException {
+    final Throwable cause = e.getCause();
+    if (cause instanceof ApiErrorException) {
+      final ApiErrorException apiError = (ApiErrorException) cause;
+      if (apiError.getCode() == NOT_FOUND.code()) {
+        cliOutput.printMessage("Workflow " + workflow + " in component " + component + " not found.");
+      } else {
+        throw e;
+      }
+    } else {
+      throw e;
     }
   }
 
@@ -639,6 +692,18 @@ public final class CliMain {
             .setDefault(false)
             .action(Arguments.storeTrue());
 
+    final Subparser workflowEnable = WorkflowCommand.ENABLE.parser(workflowParser);
+    final Argument workflowEnableComponentId =
+        workflowEnable.addArgument("component").help("Component ID");
+    final Argument workflowEnableWorkflowId =
+        workflowEnable.addArgument("workflow").nargs("+").help("Workflow IDs");
+
+    final Subparser workflowDisable = WorkflowCommand.DISABLE.parser(workflowParser);
+    final Argument workflowDisableComponentId =
+        workflowDisable.addArgument("component").help("Component ID");
+    final Argument workflowDisableWorkflowId =
+        workflowDisable.addArgument("workflow").nargs("+").help("Workflow IDs");
+
     final Subparser list = Command.LIST.parser(subCommands);
     final Argument listComponent = list.addArgument("-c", "--component")
         .help("only show instances for COMPONENT");
@@ -774,7 +839,9 @@ public final class CliMain {
   private enum WorkflowCommand {
     SHOW("get", "Show info about a specific workflow"),
     CREATE("", "Create or update a workflow"),
-    DELETE("", "Delete a workflow");
+    DELETE("", "Delete a workflow"),
+    ENABLE("", "Enable a workflow"),
+    DISABLE("", "Disable a workflow");
 
     private final String alias;
     private final String description;

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -381,28 +381,16 @@ public final class CliMain {
     final String component = namespace.getString(parser.workflowEnableComponentId.getDest());
     final List<String> workflows = namespace.getList(parser.workflowEnableWorkflowId.getDest());
     workflowStateUpdate(component, workflows, WorkflowState.patchEnabled(true))
-        .forEach(t -> {
-          if (t._2.enabled().orElse(false)) {
-            cliOutput.printMessage("Workflow " + t._1 + " in component " + component + " enabled.");
-          } else {
-            cliOutput.printMessage(
-                "Failed to enable workflow " + t._1 + " in component " + component + ".");
-          }
-        });
+        .forEach(t -> cliOutput
+            .printMessage("Workflow " + t._1 + " in component " + component + " enabled."));
   }
 
   private void workflowDisable() throws ExecutionException, InterruptedException {
     final String component = namespace.getString(parser.workflowDisableComponentId.getDest());
     final List<String> workflows = namespace.getList(parser.workflowDisableWorkflowId.getDest());
     workflowStateUpdate(component, workflows, WorkflowState.patchEnabled(false))
-        .forEach(t -> {
-          if (!t._2.enabled().orElse(false)) {
-            cliOutput.printMessage("Workflow " + t._1 + " in component " + component + " disabled.");
-          } else {
-            cliOutput.printMessage(
-                "Failed to disable workflow " + t._1 + " in component " + component + ".");
-          }
-        });
+        .forEach(t -> cliOutput
+            .printMessage("Workflow " + t._1 + " in component " + component + " disabled."));
   }
 
   private List<Tuple2<String, WorkflowState>> workflowStateUpdate(String component,

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -30,7 +30,6 @@ import static net.sourceforge.argparse4j.impl.Arguments.fileType;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.spotify.apollo.Client;
 import com.spotify.apollo.core.Service;
 import com.spotify.apollo.core.Services;
@@ -57,6 +56,7 @@ import com.spotify.styx.util.ParameterUtil;
 import java.io.File;
 import java.io.IOException;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -417,7 +417,7 @@ public final class CliMain {
         .collect(toList());
 
     final List<Tuple2<String, WorkflowState>> updatedWorkflowStates =
-        Lists.newArrayListWithCapacity(futures.size());
+        new ArrayList<>(futures.size());
     for (Tuple2<String, CompletionStage<WorkflowState>> future : futures) {
       final String workflow = future._1;
       try {

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -850,10 +850,10 @@ public final class CliMain {
 
   private enum WorkflowCommand {
     SHOW("get", "Show info about a specific workflow"),
-    CREATE("", "Create or update a workflow"),
-    DELETE("", "Delete a workflow"),
-    ENABLE("", "Enable a workflow"),
-    DISABLE("", "Disable a workflow");
+    CREATE("", "Create or update workflow(s)"),
+    DELETE("", "Delete workflow(s)"),
+    ENABLE("", "Enable workflow(s)"),
+    DISABLE("", "Disable workflow(s)");
 
     private final String alias;
     private final String description;

--- a/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
@@ -284,6 +284,23 @@ public class CliMainTest {
   }
 
   @Test
+  public void shouldFailToEnableWorkflow() {
+    final String component = "quux";
+    final WorkflowState workflowState = WorkflowState.builder()
+        .enabled(true)
+        .build();
+
+    when(client.updateWorkflowState(any(), any(), eq(workflowState)))
+        .thenReturn(
+            CompletableFuture.completedFuture(WorkflowState.builder().enabled(false).build()));
+
+    CliMain.run(cliContext, "workflow", "enable", component, "foo");
+
+    verify(client).updateWorkflowState(component, "foo", workflowState);
+    verify(cliOutput).printMessage("Failed to enable workflow foo in component " + component + ".");
+  }
+
+  @Test
   public void testWorkflowDisable() {
     final String component = "quux";
     final WorkflowState workflowState = WorkflowState.builder()
@@ -299,6 +316,23 @@ public class CliMainTest {
     verify(client).updateWorkflowState(component, "bar", workflowState);
     verify(cliOutput).printMessage("Workflow foo in component " + component + " disabled.");
     verify(cliOutput).printMessage("Workflow bar in component " + component + " disabled.");
+  }
+
+  @Test
+  public void shouldFailToDisableWorkflow() {
+    final String component = "quux";
+    final WorkflowState workflowState = WorkflowState.builder()
+        .enabled(false)
+        .build();
+
+    when(client.updateWorkflowState(any(), any(), eq(workflowState)))
+        .thenReturn(
+            CompletableFuture.completedFuture(WorkflowState.builder().enabled(true).build()));
+
+    CliMain.run(cliContext, "workflow", "disable", component, "foo");
+
+    verify(client).updateWorkflowState(component, "foo", workflowState);
+    verify(cliOutput).printMessage("Failed to disable workflow foo in component " + component + ".");
   }
 
   @Test

--- a/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
@@ -284,23 +284,6 @@ public class CliMainTest {
   }
 
   @Test
-  public void shouldFailWhenReturningUnexpectedStateWhenEnablingWorkflow() {
-    final String component = "quux";
-    final WorkflowState workflowState = WorkflowState.builder()
-        .enabled(true)
-        .build();
-
-    when(client.updateWorkflowState(any(), any(), eq(workflowState)))
-        .thenReturn(
-            CompletableFuture.completedFuture(WorkflowState.builder().enabled(false).build()));
-
-    CliMain.run(cliContext, "workflow", "enable", component, "foo");
-
-    verify(client).updateWorkflowState(component, "foo", workflowState);
-    verify(cliOutput).printMessage("Failed to enable workflow foo in component " + component + ".");
-  }
-
-  @Test
   public void testWorkflowDisable() {
     final String component = "quux";
     final WorkflowState workflowState = WorkflowState.builder()
@@ -316,23 +299,6 @@ public class CliMainTest {
     verify(client).updateWorkflowState(component, "bar", workflowState);
     verify(cliOutput).printMessage("Workflow foo in component " + component + " disabled.");
     verify(cliOutput).printMessage("Workflow bar in component " + component + " disabled.");
-  }
-
-  @Test
-  public void shouldFailWhenReturningUnexpectedStateWhenDisablingWorkflow() {
-    final String component = "quux";
-    final WorkflowState workflowState = WorkflowState.builder()
-        .enabled(false)
-        .build();
-
-    when(client.updateWorkflowState(any(), any(), eq(workflowState)))
-        .thenReturn(
-            CompletableFuture.completedFuture(WorkflowState.builder().enabled(true).build()));
-
-    CliMain.run(cliContext, "workflow", "disable", component, "foo");
-
-    verify(client).updateWorkflowState(component, "foo", workflowState);
-    verify(cliOutput).printMessage("Failed to disable workflow foo in component " + component + ".");
   }
 
   @Test

--- a/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
@@ -284,7 +284,7 @@ public class CliMainTest {
   }
 
   @Test
-  public void shouldFailToEnableWorkflow() {
+  public void shouldFailWhenReturningUnexpectedStateWhenEnablingWorkflow() {
     final String component = "quux";
     final WorkflowState workflowState = WorkflowState.builder()
         .enabled(true)
@@ -319,7 +319,7 @@ public class CliMainTest {
   }
 
   @Test
-  public void shouldFailToDisableWorkflow() {
+  public void shouldFailWhenReturningUnexpectedStateWhenDisablingWorkflow() {
     final String component = "quux";
     final WorkflowState workflowState = WorkflowState.builder()
         .enabled(false)

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
@@ -205,6 +205,24 @@ class StyxApolloClient implements StyxClient {
   }
 
   @Override
+  public CompletionStage<WorkflowState> updateWorkflowState(String componentId, String workflowId,
+                                                            WorkflowState workflowState) {
+    final HttpUrl.Builder urlBuilder = getUrlBuilder()
+        .addPathSegment("workflows")
+        .addPathSegment(componentId)
+        .addPathSegment(workflowId)
+        .addPathSegment("state");
+    final ByteString payload;
+    try {
+      payload = serialize(workflowState);
+    } catch (JsonProcessingException e) {
+      return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
+    }
+    return executeRequest(Request.forUri(urlBuilder.build().toString(), "PATCH")
+                              .withPayload(payload), WorkflowState.class);
+  }
+
+  @Override
   public CompletionStage<Void> triggerWorkflowInstance(String componentId,
                                                        String workflowId,
                                                        String parameter) {

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxWorkflowClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxWorkflowClient.java
@@ -33,31 +33,48 @@ public interface StyxWorkflowClient {
   /**
    * Get a {@link Workflow}
    *
-   * @param componentId componentId id
-   * @param workflowId  workflowId id
+   * @param componentId component id
+   * @param workflowId  workflow id
+   * @return the {@link Workflow}
    */
   CompletionStage<Workflow> workflow(final String componentId, final String workflowId);
 
   /**
-   * Create or update a workflow.
-   * @param componentId The component that the workflow belongs to.
-   * @param workflowConfig The workflow configuration.
-   * @return The created {@link Workflow}.
+   * Create or update a workflow
+   *
+   * @param componentId    component id
+   * @param workflowConfig workflow configuration
+   * @return the created {@link Workflow}
    */
-  CompletionStage<Workflow> createOrUpdateWorkflow(String componentId, WorkflowConfiguration workflowConfig);
+  CompletionStage<Workflow> createOrUpdateWorkflow(String componentId,
+                                                   WorkflowConfiguration workflowConfig);
 
   /**
    * Delete a {@link Workflow}
-   * @param componentId The component that the workflow belongs to.
-   * @param workflowId The workflow to delete.
+   *
+   * @param componentId component id
+   * @param workflowId  workflow id
    */
   CompletionStage<Void> deleteWorkflow(String componentId, String workflowId);
 
   /**
    * Get a {@link WorkflowState}
    *
-   * @param componentId componentId id
-   * @param workflowId  workflowId id
+   * @param componentId component id
+   * @param workflowId  workflow id
+   * @return the {@link WorkflowState}
    */
   CompletionStage<WorkflowState> workflowState(final String componentId, final String workflowId);
+
+  /**
+   * Update {@link WorkflowState}
+   *
+   * @param componentId   component id
+   * @param workflowId    workflow id
+   * @param workflowState workflow state
+   * @return the updated {@link WorkflowState}
+   */
+  CompletionStage<WorkflowState> updateWorkflowState(final String componentId,
+                                                     final String workflowId,
+                                                     final WorkflowState workflowState);
 }


### PR DESCRIPTION
the client side is more generic with the ability to handle a complete
workflow state including `enabled`, `nextNaturalTrigger`, and
`nextNaturalOffsetTrigger`.

@danielnorberg PTAL

_Github has signed me out due to long time idling so I decided to write some code._