### PR TITLE
Cleanup GCP keys if related secret's creation fails with 409

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
@@ -25,8 +25,12 @@ import com.google.api.services.iam.v1.Iam;
 import com.google.api.services.iam.v1.model.CreateServiceAccountKeyRequest;
 import com.google.api.services.iam.v1.model.ServiceAccountKey;
 import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ServiceAccountKeyManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ServiceAccountKeyManager.class);
 
   private final Iam iam;
 
@@ -80,7 +84,13 @@ public class ServiceAccountKeyManager {
         .execute();
   }
 
-  public void deleteKey(String keyName) throws IOException {
+  /**
+   * Attempt to delete a service account key as a best effort procedure. Exceptions are logged but
+   * not re-thrown.
+   * @param keyName The fully qualified name of the key to delete.
+   */
+  public void tryDeleteKey(String keyName) {
+    LOG.info("[AUDIT] Deleting service account key: {}", keyName);
     try {
       iam.projects().serviceAccounts().keys()
           .delete(keyName)
@@ -88,9 +98,12 @@ public class ServiceAccountKeyManager {
     } catch (GoogleJsonResponseException e) {
       // TODO: handle 403 correctly once google fixes their API
       if (e.getStatusCode() == 403 || e.getStatusCode() == 404) {
+        LOG.debug("Couldn't find key to delete {}", keyName);
         return;
       }
-      throw e;
+      LOG.warn("[AUDIT] Failed to delete key {}", keyName, e);
+    } catch (Exception e) {
+      LOG.warn("[AUDIT] Failed to delete key {}", keyName, e);
     }
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
@@ -22,7 +22,6 @@ package com.spotify.styx.docker;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.iam.v1.model.ServiceAccountKey;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
@@ -56,7 +55,7 @@ import org.slf4j.LoggerFactory;
 
 class KubernetesGCPServiceAccountSecretManager {
 
-  private static final Logger logger = LoggerFactory.getLogger(KubernetesGCPServiceAccountSecretManager.class);
+  private static final Logger LOG = LoggerFactory.getLogger(KubernetesGCPServiceAccountSecretManager.class);
 
   private static final String STYX_WORKFLOW_SA_ID_ANNOTATION = "styx-wf-sa";
   private static final String STYX_WORKFLOW_SA_EPOCH_ANNOTATION = "styx-wf-sa-epoch";
@@ -96,7 +95,8 @@ class KubernetesGCPServiceAccountSecretManager {
     this.clock = Objects.requireNonNull(clock);
   }
 
-  KubernetesGCPServiceAccountSecretManager(NamespacedKubernetesClient client,
+  KubernetesGCPServiceAccountSecretManager(
+      NamespacedKubernetesClient client,
       ServiceAccountKeyManager keyManager) {
     this(client, keyManager, DEFAULT_SECRET_EPOCH_PROVIDER, DEFAULT_CLOCK);
   }
@@ -105,8 +105,8 @@ class KubernetesGCPServiceAccountSecretManager {
     final long epoch = epochProvider.epoch(clock.millis(), serviceAccount);
     final String secretName = buildSecretName(serviceAccount, epoch);
 
-    logger.info("[AUDIT] Workflow {} refers to secret {} storing keys of {}",
-             workflowId, secretName, serviceAccount);
+    LOG.info("[AUDIT] Workflow {} refers to secret {} storing keys of {}",
+        workflowId, secretName, serviceAccount);
 
     try {
       return serviceAccountSecretCache.get(serviceAccount, () ->
@@ -130,7 +130,7 @@ class KubernetesGCPServiceAccountSecretManager {
     // Check that the service account exists
     final boolean serviceAccountExists = keyManager.serviceAccountExists(serviceAccount);
     if (!serviceAccountExists) {
-      logger.warn("[AUDIT] Workflow {} refers to non-existent service account {}", workflowId, serviceAccount);
+      LOG.warn("[AUDIT] Workflow {} refers to non-existent service account {}", workflowId, serviceAccount);
       throw new InvalidExecutionException("Referenced service account " + serviceAccount + " was not found");
     }
 
@@ -145,21 +145,21 @@ class KubernetesGCPServiceAccountSecretManager {
         return secretName;
       }
 
-      logger.info("[AUDIT] Service account keys have been deleted for {}, recreating", serviceAccount);
+      LOG.info("[AUDIT] Service account keys have been deleted for {}, recreating", serviceAccount);
 
       // Delete secret and any lingering key before creating new keys
-      keyManager.deleteKey(jsonKeyName);
-      keyManager.deleteKey(p12KeyName);
-      client.secrets().delete(existingSecret);
+      keyManager.tryDeleteKey(jsonKeyName);
+      keyManager.tryDeleteKey(p12KeyName);
+      tryDeleteSecret(existingSecret);
     }
 
     // Create service account keys and secret
-    createSecret(workflowId, serviceAccount, epoch, secretName);
+    createKeysAndSecret(workflowId, serviceAccount, epoch, secretName);
 
     return secretName;
   }
 
-  private void createSecret(String workflowId, String serviceAccount, long epoch, String secretName)
+  private void createKeysAndSecret(String workflowId, String serviceAccount, long epoch, String secretName)
       throws IOException {
     final ServiceAccountKey jsonKey;
     final ServiceAccountKey p12Key;
@@ -167,7 +167,7 @@ class KubernetesGCPServiceAccountSecretManager {
       jsonKey = keyManager.createJsonKey(serviceAccount);
       p12Key = keyManager.createP12Key(serviceAccount);
     } catch (IOException e) {
-      logger.warn("[AUDIT] Failed to create keys for {}", serviceAccount, e);
+      LOG.warn("[AUDIT] Failed to create keys for {}", serviceAccount, e);
       throw e;
     }
 
@@ -191,9 +191,19 @@ class KubernetesGCPServiceAccountSecretManager {
         .withData(keys)
         .build();
 
-    client.secrets().create(newSecret);
+    try {
+      client.secrets().create(newSecret);
+    } catch (KubernetesClientException e) {
+      if (e.getCode() == 409) {
+        LOG.debug("Secret with name {} already exists", secretName);
+        // Delete the previously generated GCP keys since another entity already created the secret
+        keyManager.tryDeleteKey(jsonKey.getName());
+        keyManager.tryDeleteKey(p12Key.getName());
+        return;
+      }
+    }
 
-    logger.info("[AUDIT] Secret {} created to store keys of {} referred by workflow {}, jsonKey: {}, p12Key: {}",
+    LOG.info("[AUDIT] Secret {} created to store keys of {} referred by workflow {}, jsonKey: {}, p12Key: {}",
         secretName, serviceAccount, workflowId, jsonKey.getName(), p12Key.getName());
   }
 
@@ -232,26 +242,10 @@ class KubernetesGCPServiceAccountSecretManager {
 
     // Delete keys and secrets for all inactive service accounts and let them be recreated by future executions
     for (Secret secret : inactiveServiceAccountSecrets) {
-      final String name = secret.getMetadata().getName();
-      final String serviceAcount = serviceAccount(secret);
-
-      try {
-        final Map<String, String> annotations = secret.getMetadata().getAnnotations();
-        final String jsonKeyName = annotations.get(STYX_WORKFLOW_SA_JSON_KEY_NAME_ANNOTATION);
-        final String p12KeyName = annotations.get(STYX_WORKFLOW_SA_P12_KEY_NAME_ANNOTATION);
-
-        logger.info("[AUDIT] Deleting service account key: {}", jsonKeyName);
-        tryDeleteServiceAccountKey(jsonKeyName);
-
-        logger.info("[AUDIT] Deleting service account key: {}", p12KeyName);
-        tryDeleteServiceAccountKey(p12KeyName);
-
-        logger.info("[AUDIT] Deleting service account {} secret {}", serviceAcount, name);
-        client.secrets().delete(secret);
-      } catch (IOException | KubernetesClientException e) {
-        logger.warn("[AUDIT] Failed to delete service account {} keys and/or secret {}",
-            serviceAcount, name);
-      }
+      final Map<String, String> annotations = secret.getMetadata().getAnnotations();
+      keyManager.tryDeleteKey(annotations.get(STYX_WORKFLOW_SA_JSON_KEY_NAME_ANNOTATION));
+      keyManager.tryDeleteKey(annotations.get(STYX_WORKFLOW_SA_P12_KEY_NAME_ANNOTATION));
+      tryDeleteSecret(secret);
     }
   }
 
@@ -274,19 +268,22 @@ class KubernetesGCPServiceAccountSecretManager {
   }
 
   /**
-   * Try to delete a service account key, giving up with a warning if permission was denied.
-   * @param keyName The fully qualified name of the key to delete.
+   * Try to delete a Kubernetes secret, logging failures without throwing exceptions.
+   * @param secret The secret object identifying the secret to delete.
    */
-  private void tryDeleteServiceAccountKey(String keyName) throws IOException {
+  private void tryDeleteSecret(Secret secret) {
+    LOG.info("[AUDIT] Deleting service account {} secret {}", serviceAccount(secret),
+        secret.getMetadata().getName());
     try {
-      keyManager.deleteKey(keyName);
-    } catch (GoogleJsonResponseException e) {
-      if (GcpUtil.isPermissionDenied(e)) {
-        logger.warn("[AUDIT] Permission denied when trying to delete unused service account key {}",
-                    keyName);
+      client.secrets().delete(secret);
+    } catch (KubernetesClientException e) {
+      if (e.getCode() == 404) {
+        LOG.debug("Couldn't find secret to delete {}", secret.getMetadata().getName());
       } else {
-        throw e;
+        LOG.warn("[AUDIT] Failed to delete secret {}", secret.getMetadata().getName());
       }
+    } catch (Exception e) {
+      LOG.warn("[AUDIT] Failed to delete secret {}", secret.getMetadata().getName());
     }
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/ServiceAccountKeyManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/ServiceAccountKeyManagerTest.java
@@ -100,8 +100,15 @@ public class ServiceAccountKeyManagerTest {
     verify(iam.projects().serviceAccounts().keys()).get("foo");
   }
 
+  @Test(expected = GoogleJsonResponseException.class)
+  public void deleteKeyShouldThrowUnknownExceptions() throws Exception {
+    when(delete.execute()).thenThrow(INTERNAL_SERVER_ERROR);
+    sakm.deleteKey("foo");
+    verify(iam.projects().serviceAccounts().keys()).delete("foo");
+  }
+
   @Test
-  public void deleteKeyShouldIgnoreUnknownExceptions() throws Exception {
+  public void tryDeleteKeyShouldIgnoreUnknownExceptions() throws Exception {
     when(delete.execute()).thenThrow(INTERNAL_SERVER_ERROR);
     sakm.tryDeleteKey("foo");
     verify(iam.projects().serviceAccounts().keys()).delete("foo");
@@ -110,14 +117,14 @@ public class ServiceAccountKeyManagerTest {
   @Test
   public void deleteKeyShouldIgnorePermissionDenied() throws Exception {
     when(delete.execute()).thenThrow(PERMISSION_DENIED);
-    sakm.tryDeleteKey("foo");
+    sakm.deleteKey("foo");
     verify(iam.projects().serviceAccounts().keys()).delete("foo");
   }
 
   @Test
   public void deleteKeyShouldIgnoreNotFound() throws Exception {
     when(delete.execute()).thenThrow(NOT_FOUND);
-    sakm.tryDeleteKey("foo");
+    sakm.deleteKey("foo");
     verify(iam.projects().serviceAccounts().keys()).delete("foo");
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/ServiceAccountKeyManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/ServiceAccountKeyManagerTest.java
@@ -96,21 +96,21 @@ public class ServiceAccountKeyManagerTest {
     sakm.keyExists("foo");
   }
 
-  @Test(expected = GoogleJsonResponseException.class)
-  public void deleteKeyShouldThrowUnknownExceptions() throws Exception {
+  @Test
+  public void deleteKeyShouldIgnoreUnknownExceptions() throws Exception {
     when(delete.execute()).thenThrow(INTERNAL_SERVER_ERROR);
-    sakm.deleteKey("foo");
+    sakm.tryDeleteKey("foo");
   }
 
   @Test
   public void deleteKeyShouldIgnorePermissionDenied() throws Exception {
     when(delete.execute()).thenThrow(PERMISSION_DENIED);
-    sakm.deleteKey("foo");
+    sakm.tryDeleteKey("foo");
   }
 
   @Test
   public void deleteKeyShouldIgnoreNotFound() throws Exception {
     when(delete.execute()).thenThrow(NOT_FOUND);
-    sakm.deleteKey("foo");
+    sakm.tryDeleteKey("foo");
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/ServiceAccountKeyManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/ServiceAccountKeyManagerTest.java
@@ -23,6 +23,7 @@ package com.spotify.styx;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.googleapis.json.GoogleJsonError;
@@ -82,35 +83,41 @@ public class ServiceAccountKeyManagerTest {
   public void keyExistsTreatsPermissionDeniedAsNotFound() throws Exception {
     when(get.execute()).thenThrow(PERMISSION_DENIED);
     assertThat(sakm.keyExists("foo"), is(false));
+    verify(iam.projects().serviceAccounts().keys()).get("foo");
   }
 
   @Test
   public void keyExistsReturnsFalseForNotFound() throws Exception {
     when(get.execute()).thenThrow(NOT_FOUND);
     assertThat(sakm.keyExists("foo"), is(false));
+    verify(iam.projects().serviceAccounts().keys()).get("foo");
   }
 
   @Test(expected = GoogleJsonResponseException.class)
   public void keyExistsShouldThrowUnknownExceptions() throws Exception {
     when(get.execute()).thenThrow(INTERNAL_SERVER_ERROR);
     sakm.keyExists("foo");
+    verify(iam.projects().serviceAccounts().keys()).get("foo");
   }
 
   @Test
   public void deleteKeyShouldIgnoreUnknownExceptions() throws Exception {
     when(delete.execute()).thenThrow(INTERNAL_SERVER_ERROR);
     sakm.tryDeleteKey("foo");
+    verify(iam.projects().serviceAccounts().keys()).delete("foo");
   }
 
   @Test
   public void deleteKeyShouldIgnorePermissionDenied() throws Exception {
     when(delete.execute()).thenThrow(PERMISSION_DENIED);
     sakm.tryDeleteKey("foo");
+    verify(iam.projects().serviceAccounts().keys()).delete("foo");
   }
 
   @Test
   public void deleteKeyShouldIgnoreNotFound() throws Exception {
     when(delete.execute()).thenThrow(NOT_FOUND);
     sakm.tryDeleteKey("foo");
+    verify(iam.projects().serviceAccounts().keys()).delete("foo");
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
@@ -58,6 +58,7 @@ import io.fabric8.kubernetes.api.model.PodStatus;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.SecretList;
+import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
@@ -154,7 +155,6 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
 
   @Test
   public void shouldCreateServiceAccountKeysAndSecret() throws IsClosedException, IOException {
-
     when(serviceAccountKeyManager.serviceAccountExists(SERVICE_ACCOUNT)).thenReturn(true);
 
     ServiceAccountKey jsonKey = new ServiceAccountKey();
@@ -176,6 +176,29 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
     assertThat(createdSecret.getMetadata().getAnnotations(), hasEntry("styx-wf-sa", SERVICE_ACCOUNT));
     assertThat(createdSecret.getData(), hasEntry("styx-wf-sa.json", jsonKey.getPrivateKeyData()));
     assertThat(createdSecret.getData(), hasEntry("styx-wf-sa.p12", p12Key.getPrivateKeyData()));
+  }
+
+  @Test
+  public void shouldDeleteGCPKeysIfSecretAlreadyExists() throws IsClosedException, IOException {
+    when(serviceAccountKeyManager.serviceAccountExists(SERVICE_ACCOUNT)).thenReturn(true);
+
+    ServiceAccountKey jsonKey = new ServiceAccountKey();
+    jsonKey.setName("key.json");
+    jsonKey.setPrivateKeyData("json-private-key-data");
+    ServiceAccountKey p12Key = new ServiceAccountKey();
+    p12Key.setName("key.p12");
+    p12Key.setPrivateKeyData("p12-private-key-data");
+    when(serviceAccountKeyManager.createJsonKey(any(String.class))).thenReturn(jsonKey);
+    when(serviceAccountKeyManager.createP12Key(any(String.class))).thenReturn(p12Key);
+    when(k8sClient.secrets().create(any())).thenThrow(new KubernetesClientException(
+        "Already exists", 409, new Status()));
+
+    sut.ensureServiceAccountKeySecret(WORKFLOW_ID.toString(), SERVICE_ACCOUNT);
+
+    verify(serviceAccountKeyManager).createJsonKey(SERVICE_ACCOUNT);
+    verify(serviceAccountKeyManager).createP12Key(SERVICE_ACCOUNT);
+    verify(serviceAccountKeyManager).tryDeleteKey("key.json");
+    verify(serviceAccountKeyManager).tryDeleteKey("key.p12");
   }
 
   @Test
@@ -234,7 +257,6 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
     verify(serviceAccountKeyManager, times(1)).createP12Key(SERVICE_ACCOUNT);
   }
 
-
   @Test
   public void shouldRemoveServiceAccountSecretsAndKeys() throws Exception {
     final Secret secret = fakeServiceAccountKeySecret(
@@ -247,8 +269,8 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
     // Verify that an unused service account key secret is deleted
     when(podList.getItems()).thenReturn(ImmutableList.of());
     sut.cleanup();
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "json-key"));
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "p12-key"));
+    verify(serviceAccountKeyManager).tryDeleteKey(keyName(SERVICE_ACCOUNT, "json-key"));
+    verify(serviceAccountKeyManager).tryDeleteKey(keyName(SERVICE_ACCOUNT, "p12-key"));
     verify(secrets).delete(secret);
   }
 
@@ -272,8 +294,8 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
 
     when(podList.getItems()).thenReturn(ImmutableList.of());
     sut.cleanup();
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "json-key"));
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "p12-key"));
+    verify(serviceAccountKeyManager).tryDeleteKey(keyName(SERVICE_ACCOUNT, "json-key"));
+    verify(serviceAccountKeyManager).tryDeleteKey(keyName(SERVICE_ACCOUNT, "p12-key"));
     verify(secrets).delete(secret);
   }
 
@@ -293,7 +315,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
     pod.setStatus(podStatus("Running"));
     when(podList.getItems()).thenReturn(ImmutableList.of(pod));
     sut.cleanup();
-    verify(serviceAccountKeyManager, never()).deleteKey(anyString());
+    verify(serviceAccountKeyManager, never()).tryDeleteKey(anyString());
     verify(secrets, never()).delete(any(Secret.class));
   }
 
@@ -309,8 +331,8 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
 
     sut.cleanup();
 
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "old-json-key"));
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "old-p12-key"));
+    verify(serviceAccountKeyManager).tryDeleteKey(keyName(SERVICE_ACCOUNT, "old-json-key"));
+    verify(serviceAccountKeyManager).tryDeleteKey(keyName(SERVICE_ACCOUNT, "old-p12-key"));
     verify(secrets).delete(secret);
   }
 
@@ -328,7 +350,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
 
     sut.cleanup();
 
-    verify(serviceAccountKeyManager, never()).deleteKey(anyString());
+    verify(serviceAccountKeyManager, never()).tryDeleteKey(anyString());
     verify(secrets, never()).delete(any(Secret.class));
   }
 
@@ -347,63 +369,6 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
     exception.expectMessage("Maximum number of keys on service account reached: " + SERVICE_ACCOUNT);
 
     sut.ensureServiceAccountKeySecret(WORKFLOW_ID.toString(), SERVICE_ACCOUNT);
-  }
-
-  @Test
-  public void shouldHandlePermissionDeniedErrorsWhenDeletingServiceAccountKeys() throws Exception {
-    final Secret secret = fakeServiceAccountKeySecret(
-        SERVICE_ACCOUNT, SECRET_EPOCH, "json-key", "p12-key", EXPIRED_CREATION_TIMESTAMP.toString());
-
-    when(podList.getItems()).thenReturn(ImmutableList.of());
-    when(k8sClient.secrets()).thenReturn(secrets);
-    when(secrets.list()).thenReturn(secretList);
-    when(secretList.getItems()).thenReturn(ImmutableList.of(secret));
-
-    // Verify that the secret is delete even if we get permission denied errors on deleting the keys
-    final GoogleJsonResponseException permissionDenied = new GoogleJsonResponseException(
-        new HttpResponseException.Builder(403, "Forbidden", new HttpHeaders()),
-        new GoogleJsonError().set("status", "PERMISSION_DENIED"));
-    doThrow(permissionDenied).when(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "json-key"));
-    doThrow(permissionDenied).when(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "p12-key"));
-
-    sut.cleanup();
-
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "json-key"));
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "p12-key"));
-    verify(secrets).delete(secret);
-  }
-
-  @Test
-  public void shouldHandleErrorsWhenDeletingServiceAccountKeys() throws Exception {
-    final Secret secret1 = fakeServiceAccountKeySecret(
-        SERVICE_ACCOUNT, SECRET_EPOCH, "json-key-1", "p12-key-1", EXPIRED_CREATION_TIMESTAMP.toString());
-    final Secret secret2 = fakeServiceAccountKeySecret(
-        SERVICE_ACCOUNT, SECRET_EPOCH, "json-key-2", "p12-key-2", EXPIRED_CREATION_TIMESTAMP.toString());
-    final Secret secret3 = fakeServiceAccountKeySecret(
-        SERVICE_ACCOUNT, SECRET_EPOCH, "json-key-3", "p12-key-3", EXPIRED_CREATION_TIMESTAMP.toString());
-
-    when(podList.getItems()).thenReturn(ImmutableList.of());
-    when(k8sClient.secrets()).thenReturn(secrets);
-    when(secrets.list()).thenReturn(secretList);
-    when(secretList.getItems()).thenReturn(ImmutableList.of(secret1, secret2, secret3));
-
-    when(secrets.delete(secret1)).thenThrow(new KubernetesClientException("fail delete secret1"));
-    doThrow(new IOException("fail delete json-key-2")).when(serviceAccountKeyManager).deleteKey("json-key-2");
-    doThrow(new IOException("fail delete p12-key-2")).when(serviceAccountKeyManager).deleteKey("p12-key-2");
-
-    sut.cleanup();
-
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "json-key-1"));
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "p12-key-1"));
-    verify(secrets).delete(secret1);
-
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "json-key-2"));
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "p12-key-2"));
-    verify(secrets).delete(secret2);
-
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "json-key-3"));
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, "p12-key-3"));
-    verify(secrets).delete(secret3);
   }
 
   @Test
@@ -477,8 +442,8 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
 
     sut.ensureServiceAccountKeySecret(WORKFLOW_INSTANCE.workflowId().toString(), SERVICE_ACCOUNT);
 
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, jsonKeyId));
-    verify(serviceAccountKeyManager).deleteKey(keyName(SERVICE_ACCOUNT, p12KeyId));
+    verify(serviceAccountKeyManager).tryDeleteKey(keyName(SERVICE_ACCOUNT, jsonKeyId));
+    verify(serviceAccountKeyManager).tryDeleteKey(keyName(SERVICE_ACCOUNT, p12KeyId));
     verify(serviceAccountKeyManager).createJsonKey(SERVICE_ACCOUNT);
     verify(serviceAccountKeyManager).createP12Key(SERVICE_ACCOUNT);
     verify(secrets).delete(secret);


### PR DESCRIPTION
The main purpose of this PR is to make the SA management in Styx compatible with a distributed multi-master setup. Failures when creating a new secret due to racy conditions among schedulers will be handled as non-erroneous behaviour; related GCP keys created during the failing attempt are going to be cleaned-up (as a best effort attempt).