### PR TITLE
Improved CLI Readability

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -551,7 +551,7 @@ public final class CliMain {
         .addArgument("--no-trunc")
         .setDefault(false)
         .action(Arguments.storeTrue())
-        .help("don't truncate output");
+        .help("don't truncate output (only for pretty printing)");
 
     final Subparser backfillEdit = BackfillCommand.EDIT.parser(backfillParser);
     final Argument backfillEditId =
@@ -578,7 +578,7 @@ public final class CliMain {
             .addArgument("--no-trunc")
             .setDefault(false)
             .action(Arguments.storeTrue())
-            .help("don't truncate output");
+            .help("don't truncate output (only for pretty printing)");
 
     final Subparser backfillCreate = BackfillCommand.CREATE.parser(backfillParser);
     final Argument backfillCreateComponent =

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -390,7 +390,7 @@ public final class CliMain {
     final Backfill backfill =
         styxClient.backfillCreate(component, workflow, start, end, concurrency, description)
             .toCompletableFuture().get();
-    cliOutput.printBackfill(backfill);
+    cliOutput.printBackfill(backfill, true);
   }
 
   private void backfillEdit() throws ExecutionException, InterruptedException {
@@ -400,7 +400,7 @@ public final class CliMain {
     if (concurrency != null) {
       final Backfill backfill =
           styxClient.backfillEditConcurrency(id, concurrency).toCompletableFuture().get();
-      cliOutput.printBackfill(backfill);
+      cliOutput.printBackfill(backfill, true);
     }
   }
 
@@ -414,9 +414,10 @@ public final class CliMain {
 
   private void backfillShow() throws ExecutionException, InterruptedException {
     final String id = namespace.getString(parser.backfillShowId.getDest());
+    final boolean noTruncate = namespace.getBoolean((parser.backfillShowNoTruncate.getDest()));
 
     final BackfillPayload backfillPayload = styxClient.backfill(id, true).toCompletableFuture().get();
-    cliOutput.printBackfillPayload(backfillPayload);
+    cliOutput.printBackfillPayload(backfillPayload, noTruncate);
   }
 
   private void backfillList() throws ExecutionException, InterruptedException {
@@ -425,11 +426,12 @@ public final class CliMain {
     final Optional<String> workflow =
         Optional.ofNullable(namespace.getString(parser.backfillListWorkflow.getDest()));
     final boolean showAll = namespace.getBoolean(parser.backfillListShowAll.getDest());
+    final boolean noTruncate = namespace.getBoolean(parser.backfillListNoTruncate.getDest());
 
     final BackfillsPayload backfillsPayload =
         styxClient.backfillList(component, workflow, showAll, false)
             .toCompletableFuture().get();
-    cliOutput.printBackfills(backfillsPayload.backfills());
+    cliOutput.printBackfills(backfillsPayload.backfills(), noTruncate);
   }
 
   private void resourceCreate() throws ExecutionException, InterruptedException {
@@ -545,6 +547,11 @@ public final class CliMain {
     final Subparser backfillShow = BackfillCommand.SHOW.parser(backfillParser);
     final Argument backfillShowId =
         backfillShow.addArgument("backfill").help("Backfill ID");
+    final Argument backfillShowNoTruncate = backfillShow
+        .addArgument("--no-trunc")
+        .setDefault(false)
+        .action(Arguments.storeTrue())
+        .help("don't truncate description");
 
     final Subparser backfillEdit = BackfillCommand.EDIT.parser(backfillParser);
     final Argument backfillEditId =
@@ -567,6 +574,11 @@ public final class CliMain {
             .setDefault(false)
             .action(Arguments.storeTrue())
             .help("show all backfills, even halted and all-triggered ones");
+    final Argument backfillListNoTruncate = backfillList
+            .addArgument("--no-trunc")
+            .setDefault(false)
+            .action(Arguments.storeTrue())
+            .help("don't truncate descriptions");
 
     final Subparser backfillCreate = BackfillCommand.CREATE.parser(backfillParser);
     final Argument backfillCreateComponent =
@@ -582,7 +594,6 @@ public final class CliMain {
     final Argument backfillCreateDescription =
         backfillCreate.addArgument("-d", "--description")
             .help("a description of the backfill");
-
 
     final Subparsers resourceParser =
         Command.RESOURCE.parser(subCommands)

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -551,7 +551,7 @@ public final class CliMain {
         .addArgument("--no-trunc")
         .setDefault(false)
         .action(Arguments.storeTrue())
-        .help("don't truncate description");
+        .help("don't truncate output");
 
     final Subparser backfillEdit = BackfillCommand.EDIT.parser(backfillParser);
     final Argument backfillEditId =
@@ -578,7 +578,7 @@ public final class CliMain {
             .addArgument("--no-trunc")
             .setDefault(false)
             .action(Arguments.storeTrue())
-            .help("don't truncate descriptions");
+            .help("don't truncate output");
 
     final Subparser backfillCreate = BackfillCommand.CREATE.parser(backfillParser);
     final Argument backfillCreateComponent =

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliOutput.java
@@ -38,11 +38,11 @@ interface CliOutput {
 
   void printEvents(List<EventInfo> eventInfos);
 
-  void printBackfill(Backfill backfill);
+  void printBackfill(Backfill backfill, boolean noTruncate);
 
-  void printBackfillPayload(BackfillPayload backfillPayload);
+  void printBackfillPayload(BackfillPayload backfillPayload, boolean noTruncate);
 
-  void printBackfills(List<BackfillPayload> backfills);
+  void printBackfills(List<BackfillPayload> backfills, boolean noTruncate);
 
   void printResources(List<Resource> resources);
 

--- a/styx-cli/src/main/java/com/spotify/styx/cli/JsonCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/JsonCliOutput.java
@@ -57,17 +57,17 @@ class JsonCliOutput implements CliOutput {
   }
 
   @Override
-  public void printBackfill(Backfill backfill) {
+  public void printBackfill(Backfill backfill, boolean ignored) {
     printJson(backfill);
   }
 
   @Override
-  public void printBackfillPayload(BackfillPayload backfillPayload) {
+  public void printBackfillPayload(BackfillPayload backfillPayload, boolean ignored) {
     printJson(backfillPayload);
   }
 
   @Override
-  public void printBackfills(List<BackfillPayload> backfills) {
+  public void printBackfills(List<BackfillPayload> backfills, boolean ignored) {
     printJson(backfills);
   }
 

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
@@ -88,7 +88,7 @@ class PlainCliOutput implements CliOutput {
   }
 
   @Override
-  public void printBackfill(Backfill backfill) {
+  public void printBackfill(Backfill backfill, boolean ignored) {
     System.out.println(String.format("%s %s %s %s %s %s %s %s %s %s",
                                      backfill.id(),
                                      backfill.workflowId().componentId(),
@@ -103,16 +103,16 @@ class PlainCliOutput implements CliOutput {
   }
 
   @Override
-  public void printBackfillPayload(BackfillPayload backfillPayload) {
-    printBackfill(backfillPayload.backfill());
+  public void printBackfillPayload(BackfillPayload backfillPayload, boolean ignored) {
+    printBackfill(backfillPayload.backfill(), true);
     if (backfillPayload.statuses().isPresent()) {
       printStates(backfillPayload.statuses().get());
     }
   }
 
   @Override
-  public void printBackfills(List<BackfillPayload> backfills) {
-    backfills.forEach(this::printBackfillPayload);
+  public void printBackfills(List<BackfillPayload> backfills, boolean ignored) {
+    backfills.forEach(backfill -> printBackfillPayload(backfill, true));
   }
 
   @Override

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -223,10 +223,12 @@ class PrettyCliOutput implements CliOutput {
 
   private String formatDescription(Optional<String> description, boolean noTruncate) {
     if (description.isPresent()) {
-      if (noTruncate) {
-        return description.get();
+      final String descriptionString = description.get();
+
+      if (noTruncate || descriptionString.length() <= 20) {
+        return descriptionString;
       } else {
-        return description.get().substring(0, 20) + "...";
+        return descriptionString.substring(0, 20) + "...";
       }
     } else {
       return "N/A";

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -222,17 +222,13 @@ class PrettyCliOutput implements CliOutput {
   }
 
   private String formatDescription(Optional<String> description, boolean noTruncate) {
-    if (description.isPresent()) {
-      final String descriptionString = description.get();
-
-      if (noTruncate || descriptionString.length() <= 20) {
-        return descriptionString;
+    return description.map(x -> {
+      if (noTruncate || x.length() <= 20) {
+        return x;
       } else {
-        return descriptionString.substring(0, 20) + "...";
+        return x.substring(0, 20) + "...";
       }
-    } else {
-      return "N/A";
-    }
+    }).orElse("N/A");
   }
 
   private Ansi getAnsiForState(RunStateDataPayload.RunStateData RunStateData) {

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -128,7 +128,7 @@ class PrettyCliOutput implements CliOutput {
                                      toParameter(schedule, backfill.nextTrigger()),
                                      workflowId.componentId(),
                                      workflowId.id(),
-                                     this.formatDescription(backfill.description(), noTruncate)));
+                                     formatDescription(backfill.description(), noTruncate)));
   }
 
   private void printBackfillHeader(int cidLength, int widLength) {

--- a/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
@@ -162,7 +162,7 @@ public class CliMainTest {
         "1");
 
     verify(client).backfillCreate(component, "foo", start, end, 1, null);
-    verify(cliOutput).printBackfill(backfill);
+    verify(cliOutput).printBackfill(backfill, true);
   }
 
   @Test
@@ -190,7 +190,7 @@ public class CliMainTest {
         "1", "-d", "Description");
 
     verify(client).backfillCreate(component, "foo", start, end, 1, "Description");
-    verify(cliOutput).printBackfill(backfill);
+    verify(cliOutput).printBackfill(backfill, true);
   }
 
   @Test

--- a/styx-cli/src/test/java/com/spotify/styx/cli/JsonCliOutputTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/JsonCliOutputTest.java
@@ -20,7 +20,7 @@
 
 package com.spotify.styx.cli;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.spotify.styx.api.BackfillPayload;
@@ -35,8 +35,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PlainCliOutputTest {
-
+public class JsonCliOutputTest {
+  
   private static final Backfill BACKFILL = Backfill.newBuilder()
       .id("backfill-2")
       .start(Instant.parse("2017-01-01T00:00:00Z"))
@@ -47,9 +47,23 @@ public class PlainCliOutputTest {
       .nextTrigger(Instant.parse("2017-01-01T00:00:00Z"))
       .schedule(Schedule.DAYS)
       .build();
-  private static final String EXPECTED_OUTPUT =
-      "backfill-2 component workflow2 false false 2 2017-01-01T00:00:00Z"
-        + " 2017-01-02T00:00:00Z 2017-01-01T00:00:00Z Description\n";
+  
+  private static final String EXPECTED_OUTPUT = "{\"id\":\"backfill-2\"," 
+                                               + "\"start\":\"2017-01-01T00:00:00Z\"," 
+                                               + "\"end\":\"2017-01-02T00:00:00Z\"," 
+                                               + "\"workflow_id\":" 
+                                               + "{\"component_id\":\"component\"," 
+                                               + "\"id\":\"workflow2\"}," 
+                                               + "\"concurrency\":2," 
+                                               + "\"description\":\"Description\"," 
+                                               + "\"next_trigger\":\"2017-01-01T00:00:00Z\"," 
+                                               + "\"schedule\":\"days\"," 
+                                               + "\"all_triggered\":false," 
+                                               + "\"halted\":false}";
+
+  private static final String EXPECTED_OUTPUT_WITH_STATUS = "{\"backfill\":"
+                                                            + EXPECTED_OUTPUT
+                                                            + ",\"statuses\":null}";
 
   private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
 
@@ -61,7 +75,7 @@ public class PlainCliOutputTest {
   public void setUp() {
     old = System.out;
     System.setOut(new PrintStream(outContent));
-    cliOutput = new PlainCliOutput();
+    cliOutput = new JsonCliOutput();
   }
 
   @After
@@ -72,8 +86,7 @@ public class PlainCliOutputTest {
   @Test
   public void shouldPrintBackfill() {
     cliOutput.printBackfill(BACKFILL, true);
-    assertEquals(EXPECTED_OUTPUT,
-        outContent.toString());
+    assertEquals(EXPECTED_OUTPUT + "\n", outContent.toString());
   }
 
   @Test
@@ -81,14 +94,12 @@ public class PlainCliOutputTest {
     cliOutput.printBackfills(
         ImmutableList.of(BackfillPayload.create(BACKFILL, Optional.empty())),
         true);
-    assertEquals(EXPECTED_OUTPUT,
-        outContent.toString());
+    assertEquals("[" + EXPECTED_OUTPUT_WITH_STATUS + "]\n", outContent.toString());
   }
 
   @Test
   public void shouldPrintBackfillPayload() {
     cliOutput.printBackfillPayload(BackfillPayload.create(BACKFILL, Optional.empty()), true);
-    assertEquals(EXPECTED_OUTPUT,
-        outContent.toString());
+    assertEquals(EXPECTED_OUTPUT_WITH_STATUS + "\n", outContent.toString());
   }
 }

--- a/styx-cli/src/test/java/com/spotify/styx/cli/PlainCliOutputTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/PlainCliOutputTest.java
@@ -65,7 +65,7 @@ public class PlainCliOutputTest {
         .schedule(Schedule.DAYS)
         .build();
 
-    cliOutput.printBackfill(backfill);
+    cliOutput.printBackfill(backfill, true);
     assertEquals("backfill-2 component workflow2 false false 2 2017-01-01T00:00:00Z"
                  + " 2017-01-02T00:00:00Z 2017-01-01T00:00:00Z Description\n",
         outContent.toString());

--- a/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.time.Instant;
 import java.util.Optional;
+import javax.swing.text.html.Option;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -104,8 +105,42 @@ public class PrettyCliOutputTest {
   }
 
   @Test
-  public void shouldPrintBackfills() {
+  public void shouldPrintBackfillPayload() {
+    cliOutput.printBackfillPayload(BackfillPayload.create(backfill(LONG_DESCRIPTION),
+        Optional.empty()), false);
+    assertEquals(EXPECTED_HEADER +
+                 "                  backfill-2   false          false          " 
+                 + "  2  "
+                 + "2017-01-01            2017-01-02            2017-01-01            component  "
+                 + "workflow2 Description which is...\n",
+        outContent.toString());
+  }
 
+  @Test
+  public void shouldPrintBackfillPayloadWithShortDescription() {
+    cliOutput.printBackfillPayload(BackfillPayload.create(backfill(SHORT_DESCRIPTION),
+        Optional.empty()), false);
+    assertEquals(EXPECTED_HEADER +
+                 "                  backfill-2   false          false          " 
+                 + "  2  "
+                 + "2017-01-01            2017-01-02            2017-01-01            component  "
+                 + "workflow2 Description\n",
+        outContent.toString());
+  }
+
+  @Test
+  public void shouldPrintBackfillPayloadWithoutTruncating() {
+    cliOutput.printBackfillPayload(BackfillPayload.create(backfill(LONG_DESCRIPTION),
+        Optional.empty()), true);
+    assertEquals( EXPECTED_HEADER +
+        "                  backfill-2   false          false            2  "
+                 + "2017-01-01            2017-01-02            2017-01-01            component  "
+                 + "workflow2 Description which is long enough to truncate\n",
+        outContent.toString());
+  }
+
+  @Test
+  public void shouldPrintBackfills() {
     cliOutput.printBackfills(
         ImmutableList.of(BackfillPayload.create(backfill(LONG_DESCRIPTION), Optional.empty())),
         false);
@@ -118,7 +153,6 @@ public class PrettyCliOutputTest {
 
   @Test
   public void shouldPrintBackfillsWithoutTruncating() {
-
     cliOutput.printBackfills(
         ImmutableList.of(BackfillPayload.create(backfill(LONG_DESCRIPTION), Optional.empty())),
         true);
@@ -131,7 +165,6 @@ public class PrettyCliOutputTest {
 
   @Test
   public void shouldPrintNAWhenBackfillLacksDescription() {
-
     cliOutput.printBackfills(
         ImmutableList.of(BackfillPayload.create(backfill(null), Optional.empty()))
         , false);

--- a/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
@@ -37,7 +37,14 @@ import org.junit.Test;
 
 public class PrettyCliOutputTest {
 
-  private Backfill backfill(String description) {
+  private static final String SHORT_DESCRIPTION = "Description";
+  private static final String LONG_DESCRIPTION = "Description which is long enough to truncate";
+  private static final String EXPECTED_HEADER =
+      "                 BACKFILL ID  HALTED  ALL TRIGGERED  CONCURRENCY  "
+      + "START (INCL)          END (EXCL)            NEXT TRIGGER          COMPONENT"
+      + "  WORKFLOW  DESCRIPTION\n";
+
+  private static Backfill backfill(String description) {
     return Backfill.newBuilder()
         .id("backfill-2")
         .start(Instant.parse("2017-01-01T00:00:00Z"))
@@ -50,18 +57,12 @@ public class PrettyCliOutputTest {
         .build();
   }
 
-  private static final String SHORT_DESCRIPTION = "Description";
-  private static final String LONG_DESCRIPTION = "Description which is long enough to truncate";
-  private static final String EXPECTED_HEADER =
-      "                 BACKFILL ID  HALTED  ALL TRIGGERED  CONCURRENCY  "
-      + "START (INCL)          END (EXCL)            NEXT TRIGGER          COMPONENT"
-      + "  WORKFLOW  DESCRIPTION\n";
-
   private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
 
   private PrintStream old;
 
   private CliOutput cliOutput;
+
 
   @Before
   public void setUp() {
@@ -118,9 +119,8 @@ public class PrettyCliOutputTest {
   @Test
   public void shouldPrintBackfillsWithoutTruncating() {
 
-    cliOutput.printBackfills(ImmutableList.of(BackfillPayload.create(backfill(LONG_DESCRIPTION), Optional
-            .empty
-            ())),
+    cliOutput.printBackfills(
+        ImmutableList.of(BackfillPayload.create(backfill(LONG_DESCRIPTION), Optional.empty())),
         true);
     assertEquals(EXPECTED_HEADER
                  + "                  backfill-2   false          false            2  "
@@ -132,8 +132,8 @@ public class PrettyCliOutputTest {
   @Test
   public void shouldPrintNAWhenBackfillLacksDescription() {
 
-    cliOutput.printBackfills(ImmutableList.of(BackfillPayload.create(backfill(null),
-        Optional.empty()))
+    cliOutput.printBackfills(
+        ImmutableList.of(BackfillPayload.create(backfill(null), Optional.empty()))
         , false);
     assertEquals(EXPECTED_HEADER
                  + "                  backfill-2   false          false            2  "

--- a/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 
 public class PrettyCliOutputTest {
 
-  private Backfill BACKFILL(String description) {
+  private Backfill backfill(String description) {
     return Backfill.newBuilder()
         .id("backfill-2")
         .start(Instant.parse("2017-01-01T00:00:00Z"))
@@ -50,8 +50,9 @@ public class PrettyCliOutputTest {
         .build();
   }
 
-  private static final String longDescription = "Description which is long enough to truncate";
-  private static final String expectedHeader =
+  private static final String SHORT_DESCRIPTION = "Description";
+  private static final String LONG_DESCRIPTION = "Description which is long enough to truncate";
+  private static final String EXPECTED_HEADER =
       "                 BACKFILL ID  HALTED  ALL TRIGGERED  CONCURRENCY  "
       + "START (INCL)          END (EXCL)            NEXT TRIGGER          COMPONENT"
       + "  WORKFLOW  DESCRIPTION\n";
@@ -76,7 +77,7 @@ public class PrettyCliOutputTest {
 
   @Test
   public void shouldPrintBackfill() {
-    cliOutput.printBackfill(BACKFILL(longDescription), false);
+    cliOutput.printBackfill(backfill(LONG_DESCRIPTION), false);
     assertEquals("                  backfill-2   false          false            2  "
                  + "2017-01-01            2017-01-02            2017-01-01            component  "
                  + "workflow2 Description which is...\n",
@@ -84,8 +85,17 @@ public class PrettyCliOutputTest {
   }
 
   @Test
+  public void shouldPrintBackfillWithShortDescription() {
+    cliOutput.printBackfill(backfill(SHORT_DESCRIPTION), false);
+    assertEquals("                  backfill-2   false          false            2  "
+                 + "2017-01-01            2017-01-02            2017-01-01            component  "
+                 + "workflow2 Description\n",
+        outContent.toString());
+  }
+
+  @Test
   public void shouldPrintBackfillWithoutTruncating() {
-    cliOutput.printBackfill(BACKFILL(longDescription), true);
+    cliOutput.printBackfill(backfill(LONG_DESCRIPTION), true);
     assertEquals("                  backfill-2   false          false            2  "
                  + "2017-01-01            2017-01-02            2017-01-01            component  "
                  + "workflow2 Description which is long enough to truncate\n",
@@ -96,9 +106,9 @@ public class PrettyCliOutputTest {
   public void shouldPrintBackfills() {
 
     cliOutput.printBackfills(
-        ImmutableList.of(BackfillPayload.create(BACKFILL(longDescription), Optional.empty())),
+        ImmutableList.of(BackfillPayload.create(backfill(LONG_DESCRIPTION), Optional.empty())),
         false);
-    assertEquals(expectedHeader
+    assertEquals(EXPECTED_HEADER
                  + "                  backfill-2   false          false            2  "
                  + "2017-01-01            2017-01-02            2017-01-01            component  "
                  + "workflow2 Description which is...\n",
@@ -108,11 +118,11 @@ public class PrettyCliOutputTest {
   @Test
   public void shouldPrintBackfillsWithoutTruncating() {
 
-    cliOutput.printBackfills(ImmutableList.of(BackfillPayload.create(BACKFILL(longDescription), Optional
+    cliOutput.printBackfills(ImmutableList.of(BackfillPayload.create(backfill(LONG_DESCRIPTION), Optional
             .empty
             ())),
         true);
-    assertEquals(expectedHeader
+    assertEquals(EXPECTED_HEADER
                  + "                  backfill-2   false          false            2  "
                  + "2017-01-01            2017-01-02            2017-01-01            component  "
                  + "workflow2 Description which is long enough to truncate\n",
@@ -122,10 +132,10 @@ public class PrettyCliOutputTest {
   @Test
   public void shouldPrintNAWhenBackfillLacksDescription() {
 
-    cliOutput.printBackfills(ImmutableList.of(BackfillPayload.create(BACKFILL(null),
+    cliOutput.printBackfills(ImmutableList.of(BackfillPayload.create(backfill(null),
         Optional.empty()))
         , false);
-    assertEquals(expectedHeader
+    assertEquals(EXPECTED_HEADER
                  + "                  backfill-2   false          false            2  "
                  + "2017-01-01            2017-01-02            2017-01-01            "
                  + "component  workflow2 N/A\n",

--- a/styx-common/src/main/java/com/spotify/styx/api/BackfillsPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/BackfillsPayload.java
@@ -34,7 +34,7 @@ public abstract class BackfillsPayload {
   public abstract List<BackfillPayload> backfills();
 
   @JsonCreator
-  static BackfillsPayload create(
+  public static BackfillsPayload create(
       @JsonProperty("backfills") List<BackfillPayload> backfills) {
     return new AutoValue_BackfillsPayload(backfills);
   }


### PR DESCRIPTION
Made column sizes more appropriate when listing workflows using CLI, and also truncating backfill descriptions by default. To not truncate you supply the command "--no-trunc" similar to Docker, and then you will get the full descriptions.