### PR TITLE
[hold] scheduler: cache resources and config

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -56,6 +56,7 @@ import com.spotify.styx.api.Api;
 import com.spotify.styx.api.SchedulerResource;
 import com.spotify.styx.docker.DockerRunner;
 import com.spotify.styx.model.Event;
+import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.SequenceEvent;
 import com.spotify.styx.model.StyxConfig;
 import com.spotify.styx.model.Workflow;
@@ -354,8 +355,11 @@ public class StyxScheduler implements AppInit {
     final Consumer<Workflow> workflowChangeListener =
         workflowChanged(workflowCache, workflowInitializer, stats, stateManager, workflowConsumer);
 
-    final Scheduler scheduler = new Scheduler(time, timeoutConfig, stateManager, workflowCache,
-                                              storage, resourceDecorator, stats, dequeueRateLimiter);
+    final Supplier<List<Resource>> resources = new CachedSupplier<>(storage::resources, time);
+    final Scheduler scheduler = new Scheduler(
+        time, timeoutConfig, stateManager, workflowCache,
+        resourceDecorator, stats, dequeueRateLimiter,
+        styxConfig, resources);
 
     final Cleaner cleaner = new Cleaner(dockerRunner);
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -86,7 +86,6 @@ public class SchedulerTest {
       WorkflowInstance.create(WORKFLOW_ID1, "2016-12-02T01");
 
   private WorkflowCache workflowCache;
-  private Storage storage;
   private StateManager stateManager;
   private Scheduler scheduler;
 
@@ -116,18 +115,15 @@ public class SchedulerTest {
     workflowCache = new InMemWorkflowCache();
     TimeoutConfig timeoutConfig = createWithDefaultTtl(ofSeconds(timeoutSeconds));
 
-    storage = mock(Storage.class);
-    when(storage.resources()).thenReturn(resourceLimits);
     when(config.globalConcurrency()).thenReturn(Optional.empty());
-    when(storage.config()).thenReturn(config);
 
     when(resourceDecorator.decorateResources(
         any(RunState.class), any(WorkflowConfiguration.class), anySetOf(String.class)))
         .thenAnswer(a -> a.getArgumentAt(2, Set.class));
 
     stateManager = Mockito.spy(new SyncStateManager());
-    scheduler = new Scheduler(time, timeoutConfig, stateManager, workflowCache, storage, resourceDecorator,
-                              stats, rateLimiter);
+    scheduler = new Scheduler(time, timeoutConfig, stateManager, workflowCache, resourceDecorator,
+                              stats, rateLimiter, () -> config, () -> resourceLimits);
   }
 
   private void setResourceLimit(String resourceId, long limit) {


### PR DESCRIPTION
Avoid re-reading the resource and config entities on each tick.