### PR TITLE
single (last) message in RunState

### DIFF
--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -84,15 +84,6 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   private static LocalDatastoreHelper localDatastore;
 
-  private Datastore datastore = localDatastore.getOptions().getService();
-  private Connection bigtable = setupBigTableMockTable();
-  private AggregateStorage storage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
-
-  public WorkflowResourceTest(Api.Version version) {
-    super("/workflows", version, "workflow-test");
-    MockitoAnnotations.initMocks(this);
-  }
-
   private static final WorkflowConfiguration WORKFLOW_CONFIGURATION =
       WorkflowConfiguration.builder()
           .id("bar")
@@ -122,6 +113,15 @@ public class WorkflowResourceTest extends VersionedApiTest {
       ByteString.encodeUtf8("{\"The BAD\"}");
 
   @Mock DockerImageValidator dockerImageValidator;
+
+  private Datastore datastore = localDatastore.getOptions().getService();
+  private Connection bigtable = setupBigTableMockTable();
+  private AggregateStorage storage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
+
+  public WorkflowResourceTest(Api.Version version) {
+    super("/workflows", version, "workflow-test");
+    MockitoAnnotations.initMocks(this);
+  }
 
   @Override
   protected void init(Environment environment) {

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
@@ -48,32 +48,19 @@ class PlainCliOutput implements CliOutput {
     SortedMap<WorkflowId, SortedSet<RunStateDataPayload.RunStateData>> groupedStates =
         CliUtil.groupStates(runStateDataPayload.activeStates());
 
-    groupedStates.entrySet().forEach(entry -> {
-      WorkflowId workflowId = entry.getKey();
-      entry.getValue().forEach(RunStateData -> {
-        final StateData stateData = RunStateData.stateData();
-        final List<Message> messages = stateData.messages();
-
-        final String lastMessage;
-        if (messages.isEmpty()) {
-          lastMessage = "No info";
-        } else {
-          final Message message = messages.get(messages.size() - 1);
-          lastMessage = message.line();
-        }
-
-        System.out.println(String.format(
-            "%s %s %s %s %s %d %s",
-            workflowId.componentId(),
-            workflowId.id(),
-            RunStateData.workflowInstance().parameter(),
-            RunStateData.state(),
-            stateData.executionId().orElse("<no-execution-id>"),
-            stateData.tries(),
-            lastMessage
-        ));
-      });
-    });
+    groupedStates.forEach((workflowId, value) -> value.forEach(RunStateData -> {
+      final StateData stateData = RunStateData.stateData();
+      System.out.println(String.format(
+          "%s %s %s %s %s %d %s",
+          workflowId.componentId(),
+          workflowId.id(),
+          RunStateData.workflowInstance().parameter(),
+          RunStateData.state(),
+          stateData.executionId().orElse("<no-execution-id>"),
+          stateData.tries(),
+          stateData.message().map(Message::line).orElse("No info")
+      ));
+    }));
   }
 
   @Override

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -32,7 +32,6 @@ import static org.fusesource.jansi.Ansi.Color.GREEN;
 import static org.fusesource.jansi.Ansi.Color.RED;
 import static org.fusesource.jansi.Ansi.Color.YELLOW;
 
-import com.google.common.collect.Iterables;
 import com.spotify.styx.api.BackfillPayload;
 import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.model.Backfill;
@@ -73,8 +72,8 @@ class PrettyCliOutput implements CliOutput {
         final StateData stateData = runStateData.stateData();
         final Ansi ansiState = getAnsiForState(runStateData);
 
-        final Message lastMessage = Iterables.getLast(
-            stateData.messages(), Message.create(Message.MessageLevel.UNKNOWN, "No info"));
+        final Message lastMessage =
+            stateData.message().orElse(Message.create(Message.MessageLevel.UNKNOWN, "No info"));
         final Ansi ansiMessage = colored(messageColor(lastMessage.level()),
                                          lastMessage.line());
 

--- a/styx-common/src/main/java/com/spotify/styx/state/RunState.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/RunState.java
@@ -40,7 +40,6 @@ import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.Message.MessageLevel;
 import com.spotify.styx.util.Time;
-import com.spotify.styx.util.TriggerUtil;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -145,7 +144,6 @@ public abstract class RunState {
               SUBMITTED,
               data().builder()
                   .trigger(Trigger.unknown("UNKNOWN"))
-                  .triggerId("UNKNOWN") // for backwards compatibility
                   .build());
 
         default:
@@ -161,7 +159,6 @@ public abstract class RunState {
               QUEUED,
               data().builder()
                   .trigger(trigger)
-                  .triggerId(TriggerUtil.triggerId(trigger)) // for backwards compatibility
                   .build());
 
         default:
@@ -195,7 +192,7 @@ public abstract class RunState {
           return state(
               QUEUED,
               data().builder()
-                  .addMessage(message)
+                  .message(message)
                   .build());
 
         default:
@@ -277,7 +274,7 @@ public abstract class RunState {
               .retryCost(data().retryCost() + cost)
               .lastExit(exitCode)
               .consecutiveFailures(consecutiveFailures)
-              .addMessage(Message.create(level, "Exit code: " + exitCode.map(String::valueOf).orElse("-")))
+              .message(Message.create(level, "Exit code: " + exitCode.map(String::valueOf).orElse("-")))
               .build();
 
           return state(TERMINATED, newStateData);
@@ -331,7 +328,7 @@ public abstract class RunState {
               .retryCost(data().retryCost() + FAILURE_COST)
               .lastExit(empty())
               .consecutiveFailures(data().consecutiveFailures() + 1)
-              .addMessage(Message.error(message))
+              .message(Message.error(message))
               .build();
 
           return state(FAILED, newStateData);

--- a/styx-common/src/main/java/com/spotify/styx/state/StateData.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/StateData.java
@@ -22,7 +22,9 @@ package com.spotify.styx.state;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.spotify.styx.model.ExecutionDescription;
+import com.spotify.styx.util.TriggerUtil;
 import io.norberg.automatter.AutoMatter;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,10 +44,16 @@ public interface StateData {
   Optional<Long> retryDelayMillis();
   Optional<Integer> lastExit();
   Optional<Trigger> trigger();
-  Optional<String> triggerId(); //for backwards compatibility
   Optional<String> executionId();
   Optional<ExecutionDescription> executionDescription();
-  List<Message> messages();
+  Optional<Message> message();
+
+  @Deprecated default Optional<String> triggerId() {
+    return trigger().map(TriggerUtil::triggerId);
+  }
+  @Deprecated default List<Message> messages() {
+    return message().map(Collections::singletonList).orElseGet(Collections::emptyList);
+  }
 
   StateDataBuilder builder();
 

--- a/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
@@ -32,6 +32,7 @@ import static com.spotify.styx.state.RunState.State.SUBMITTING;
 import static com.spotify.styx.state.RunState.State.TERMINATED;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.spotify.styx.WorkflowInstanceEventFactory;
@@ -494,11 +495,8 @@ public class RunStateTest {
     transitioner.receive(eventFactory.runError("Error"));
 
     assertThat(
-        transitioner.get(WORKFLOW_INSTANCE).data().messages(),
-        contains(
-            Message.create(Message.MessageLevel.WARNING, "Exit code: 20"),
-            Message.create(Message.MessageLevel.ERROR, "Error")
-        ));
+        transitioner.get(WORKFLOW_INSTANCE).data().message().get(),
+        is(Message.create(Message.MessageLevel.ERROR, "Error")));
   }
 
   @Test
@@ -509,10 +507,8 @@ public class RunStateTest {
     transitioner.receive(eventFactory.info(Message.warning("warning message")));
 
     assertThat(
-        transitioner.get(WORKFLOW_INSTANCE).data().messages(),
-        contains(
-            Message.info("info message"),
-            Message.warning("warning message")));
+        transitioner.get(WORKFLOW_INSTANCE).data().message().get(),
+        is(Message.warning("warning message")));
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -279,7 +279,7 @@ public class SchedulerTest {
     scheduler.tick();
 
     assertThat(
-    stateManager.get(INSTANCE).data().messages().get(0).line(),
+    stateManager.get(INSTANCE).data().message().get().line(),
         is("Referenced resources not found: [unknown]"));
     assertThat(stateManager.get(INSTANCE).state(), is(State.FAILED));
   }
@@ -294,7 +294,7 @@ public class SchedulerTest {
     scheduler.tick();
 
     assertThat(
-        stateManager.get(INSTANCE).data().messages().get(0).line(),
+        stateManager.get(INSTANCE).data().message().get().line(),
         is(String.format("Resource limit reached for: [Resource{id=%s, concurrency=%d}]",
                          Scheduler.GLOBAL_RESOURCE_ID, 0)));
     assertThat(stateManager.get(INSTANCE).state(), is(State.QUEUED));
@@ -310,7 +310,7 @@ public class SchedulerTest {
     scheduler.tick();
 
     assertThat(
-        stateManager.get(INSTANCE).data().messages().get(0).line(),
+        stateManager.get(INSTANCE).data().message().get().line(),
         is("Resource limit reached for: [Resource{id=r1, concurrency=0}]"));
     assertThat(stateManager.get(INSTANCE).state(), is(State.QUEUED));
   }
@@ -326,7 +326,7 @@ public class SchedulerTest {
     scheduler.tick();
 
     assertThat(
-        stateManager.get(INSTANCE).data().messages().get(0).line(),
+        stateManager.get(INSTANCE).data().message().get().line(),
         is("Referenced resources not found: [r2, r3]"));
     assertThat(stateManager.get(INSTANCE).state(), is(State.FAILED));
   }
@@ -341,7 +341,7 @@ public class SchedulerTest {
     scheduler.tick();
     scheduler.tick();
 
-    assertThat(stateManager.get(INSTANCE).data().messages().size(), is(1));
+    assertThat(stateManager.get(INSTANCE).data().message().isPresent(), is(true));
     assertThat(stateManager.get(INSTANCE).state(), is(State.QUEUED));
   }
 


### PR DESCRIPTION
We're always only using the last message anyway.

Also deprecates `triggerId`.

Note: Unfortunately this would be a breaking api change.