### PR TITLE
move submission -> running timing to k8s runner

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/Time.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/Time.java
@@ -24,4 +24,8 @@ import java.time.Instant;
 import java.util.function.Supplier;
 
 public interface Time extends Supplier<Instant> {
+
+  default long nanoTime() {
+    return System.nanoTime();
+  }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -342,7 +342,7 @@ public class StyxScheduler implements AppInit {
         new DockerRunnerHandler(
             dockerRunner, stateManager),
         new TerminationHandler(retryUtil, stateManager),
-        new MonitoringHandler(time, stats),
+        new MonitoringHandler(stats),
         new PublisherHandler(publisher),
         new ExecutionDescriptionHandler(storage, stateManager, new DockerImageValidator())
     };

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -618,7 +618,7 @@ public class StyxScheduler implements AppInit {
   }
 
   private static Stats stats(Environment environment) {
-    return new MetricsStats(environment.resolve(SemanticMetricRegistry.class));
+    return new MetricsStats(environment.resolve(SemanticMetricRegistry.class), Instant::now);
   }
 
   private static StorageFactory storage(StorageFactory storage) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -84,8 +84,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -46,7 +46,9 @@ import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.util.Debug;
+import com.spotify.styx.util.EventUtil;
 import com.spotify.styx.util.IsClosedException;
+import com.spotify.styx.util.Time;
 import com.spotify.styx.util.TriggerUtil;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -72,7 +74,6 @@ import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.norberg.automatter.AutoMatter;
 import java.io.IOException;
-import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
@@ -81,6 +82,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -111,7 +114,7 @@ class KubernetesDockerRunner implements DockerRunner {
   static final String TRIGGER_TYPE = "STYX_TRIGGER_TYPE";
   private static final int DEFAULT_POLL_PODS_INTERVAL_SECONDS = 60;
   private static final int DEFAULT_POD_DELETION_DELAY_SECONDS = 120;
-  private static final Clock DEFAULT_CLOCK = Clock.systemUTC();
+  private static final Time DEFAULT_TIME = Instant::now;
   static final String STYX_WORKFLOW_SA_ENV_VARIABLE = "GOOGLE_APPLICATION_CREDENTIALS";
   static final String STYX_WORKFLOW_SA_SECRET_NAME = "styx-wf-sa-keys";
   private static final String STYX_WORKFLOW_SA_JSON_KEY = "styx-wf-sa.json";
@@ -133,14 +136,15 @@ class KubernetesDockerRunner implements DockerRunner {
   private final Debug debug;
   private final int pollPodsIntervalSeconds;
   private final int podDeletionDelaySeconds;
-  private final Clock clock;
+  private final Time time;
+  private final ConcurrentMap<String, Long> submissions = new ConcurrentHashMap<>();
 
   private Watch watch;
 
   KubernetesDockerRunner(NamespacedKubernetesClient client, StateManager stateManager, Stats stats,
                          KubernetesGCPServiceAccountSecretManager serviceAccountSecretManager,
                          Debug debug, int pollPodsIntervalSeconds, int podDeletionDelaySeconds,
-                         Clock clock) {
+                         Time time) {
     this.stateManager = Objects.requireNonNull(stateManager);
     this.client = Objects.requireNonNull(client);
     this.stats = Objects.requireNonNull(stats);
@@ -148,19 +152,20 @@ class KubernetesDockerRunner implements DockerRunner {
     this.debug = debug;
     this.pollPodsIntervalSeconds = pollPodsIntervalSeconds;
     this.podDeletionDelaySeconds = podDeletionDelaySeconds;
-    this.clock = Objects.requireNonNull(clock);
+    this.time = Objects.requireNonNull(time);
   }
 
   KubernetesDockerRunner(NamespacedKubernetesClient client, StateManager stateManager, Stats stats,
                          KubernetesGCPServiceAccountSecretManager serviceAccountSecretManager,
                          Debug debug) {
     this(client, stateManager, stats, serviceAccountSecretManager, debug,
-        DEFAULT_POLL_PODS_INTERVAL_SECONDS, DEFAULT_POD_DELETION_DELAY_SECONDS, DEFAULT_CLOCK);
+        DEFAULT_POLL_PODS_INTERVAL_SECONDS, DEFAULT_POD_DELETION_DELAY_SECONDS, DEFAULT_TIME);
   }
 
   @Override
   public void start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException {
     final KubernetesSecretSpec secretSpec = ensureSecrets(workflowInstance, runSpec);
+    submissions.put(runSpec.executionId(), time.nanoTime());
     try {
       client.pods().create(createPod(workflowInstance, runSpec, secretSpec));
     } catch (KubernetesClientException kce) {
@@ -379,7 +384,7 @@ class KubernetesDockerRunner implements DockerRunner {
   private boolean isNonDeletePeriodExpired(ContainerStatus containerStatus) {
     return Optional.ofNullable(containerStatus.getState().getTerminated().getFinishedAt())
         .map(finishedAt -> Instant.parse(finishedAt)
-            .isBefore(clock.instant().minus(
+            .isBefore(time.get().minus(
                 Duration.ofSeconds(podDeletionDelaySeconds))))
         .orElse(true);
   }
@@ -478,7 +483,6 @@ class KubernetesDockerRunner implements DockerRunner {
     final PodList list = client.pods().list();
     examineRunningWFISandAssociatedPods(runningWorkflowInstances, list);
 
-
     for (Pod pod : list.getItems()) {
       logEvent(Watcher.Action.MODIFIED, pod, list.getMetadata().getResourceVersion(), true);
       final Optional<WorkflowInstance> workflowInstance = readPodWorkflowInstance(pod);
@@ -540,6 +544,11 @@ class KubernetesDockerRunner implements DockerRunner {
     for (Event event : events) {
       if (event.accept(new PullImageErrorMatcher())) {
         stats.recordPullImageError();
+      }
+      if (EventUtil.name(event).equals("started")) {
+        final long runningNanos = time.nanoTime();
+        runState.data().executionId().map(submissions::remove).ifPresent(submissionNanos ->
+            stats.recordSubmitToRunningTime(TimeUnit.NANOSECONDS.toSeconds(runningNanos - submissionNanos)));
       }
 
       try {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/NoopStats.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/NoopStats.java
@@ -61,7 +61,11 @@ final class NoopStats implements Stats {
   }
 
   @Override
-  public void recordSubmitToRunningTime(long durationSeconds) {
+  public void recordSubmission(String executionId) {
+  }
+
+  @Override
+  public void recordRunning(String executionId) {
   }
 
   @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/NoopStats.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/NoopStats.java
@@ -62,10 +62,12 @@ final class NoopStats implements Stats {
 
   @Override
   public void recordSubmission(String executionId) {
+    // nop
   }
 
   @Override
   public void recordRunning(String executionId) {
+    // nop
   }
 
   @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/Stats.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/Stats.java
@@ -46,7 +46,9 @@ public interface Stats {
 
   void recordDockerOperationError(String operation, String type, int code, long durationMillis);
 
-  void recordSubmitToRunningTime(long durationSeconds);
+  void recordSubmission(String executionId);
+
+  void recordRunning(String executionId);
 
   void recordExitCode(WorkflowId workflowId, int exitCode);
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -628,6 +628,7 @@ public class KubernetesDockerRunnerTest {
   public void shouldGenerateStartedAndRecordSubmitToRunningTimeWhenContainerIsReady() throws Exception {
     when(time.nanoTime()).thenReturn(TimeUnit.SECONDS.toNanos(17));
     kdr.start(WORKFLOW_INSTANCE, RunSpec.simple(POD_NAME, "busybox"));
+    verify(stats).recordSubmission(POD_NAME);
 
     when(time.nanoTime()).thenReturn(TimeUnit.SECONDS.toNanos(18));
     StateData stateData = StateData.newBuilder().executionId(POD_NAME).build();
@@ -643,7 +644,7 @@ public class KubernetesDockerRunnerTest {
     podWatcher.eventReceived(Watcher.Action.MODIFIED, createdPod);
     assertThat(stateManager.get(WORKFLOW_INSTANCE).state(), is(RunState.State.RUNNING));
 
-    verify(stats).recordSubmitToRunningTime(4711 - 17);
+    verify(stats).recordRunning(POD_NAME);
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -52,6 +52,7 @@ import com.spotify.styx.state.SyncStateManager;
 import com.spotify.styx.testdata.TestData;
 import com.spotify.styx.util.Debug;
 import com.spotify.styx.util.IsClosedException;
+import com.spotify.styx.util.Time;
 import io.fabric8.kubernetes.api.model.ContainerState;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -76,14 +77,13 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import java.io.IOException;
-import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -136,7 +136,6 @@ public class KubernetesDockerRunnerTest {
   private static final int NO_POLL = Integer.MAX_VALUE;
   private static final int POD_DELETION_DELAY_SECONDS = 120;
   private static final Instant FIXED_INSTANT = Instant.parse("2017-09-01T01:00:00Z");
-  private static final Clock CLOCK = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
 
   @Mock NamespacedKubernetesClient k8sClient;
   @Mock KubernetesGCPServiceAccountSecretManager serviceAccountSecretManager;
@@ -152,6 +151,7 @@ public class KubernetesDockerRunnerTest {
   @Mock ListMeta listMeta;
   @Mock Watch watch;
   @Mock Debug debug;
+  @Mock Time time;
 
   @Captor ArgumentCaptor<Watcher<Pod>> watchCaptor;
   @Captor ArgumentCaptor<Pod> podCaptor;
@@ -183,8 +183,10 @@ public class KubernetesDockerRunnerTest {
         WORKFLOW_INSTANCE.workflowId().toString(), SERVICE_ACCOUNT))
         .thenReturn(SERVICE_ACCOUNT_SECRET);
 
+    when(time.get()).thenReturn(FIXED_INSTANT);
+
     kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager, debug, NO_POLL,
-                                     POD_DELETION_DELAY_SECONDS, CLOCK);
+                                     POD_DELETION_DELAY_SECONDS, time);
     kdr.init();
 
     podWatcher = watchCaptor.getValue();
@@ -623,17 +625,25 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
-  public void shouldGenerateStartedWhenContainerIsReady() throws Exception {
+  public void shouldGenerateStartedAndRecordSubmitToRunningTimeWhenContainerIsReady() throws Exception {
+    when(time.nanoTime()).thenReturn(TimeUnit.SECONDS.toNanos(17));
+    kdr.start(WORKFLOW_INSTANCE, RunSpec.simple(POD_NAME, "busybox"));
+
+    when(time.nanoTime()).thenReturn(TimeUnit.SECONDS.toNanos(18));
     StateData stateData = StateData.newBuilder().executionId(POD_NAME).build();
     stateManager.initialize(RunState.create(WORKFLOW_INSTANCE, RunState.State.SUBMITTED, stateData));
 
+    when(time.nanoTime()).thenReturn(TimeUnit.SECONDS.toNanos(19));
     createdPod.setStatus(running(/* ready= */ false));
     podWatcher.eventReceived(Watcher.Action.MODIFIED, createdPod);
     assertThat(stateManager.get(WORKFLOW_INSTANCE).state(), is(RunState.State.SUBMITTED));
 
+    when(time.nanoTime()).thenReturn(TimeUnit.SECONDS.toNanos(4711));
     createdPod.setStatus(running(/* ready= */ true));
     podWatcher.eventReceived(Watcher.Action.MODIFIED, createdPod);
     assertThat(stateManager.get(WORKFLOW_INSTANCE).state(), is(RunState.State.RUNNING));
+
+    verify(stats).recordSubmitToRunningTime(4711 - 17);
   }
 
   @Test
@@ -660,7 +670,7 @@ public class KubernetesDockerRunnerTest {
 
     // Start a new runner
     kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager,
-        debug, NO_POLL, 0, CLOCK);
+        debug, NO_POLL, 0, time);
     kdr.init();
 
     // Make the runner poll states for all pods
@@ -680,7 +690,7 @@ public class KubernetesDockerRunnerTest {
     // Set up a runner with short poll interval to avoid this test having to wait a long time for the poll
     kdr.close();
     kdr = new KubernetesDockerRunner(k8sClient, stateManager, stats, serviceAccountSecretManager,
-        debug, 1, 0, CLOCK);
+        debug, 1, 0, time);
     kdr.init();
     kdr.restore();
 


### PR DESCRIPTION
Make this measurement less dependent on event transitions happening on the same scheduler instance in preparation for HA multiple instance scheduler setup.