### PR TITLE
single (last) message in RunState

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
@@ -48,32 +48,19 @@ class PlainCliOutput implements CliOutput {
     SortedMap<WorkflowId, SortedSet<RunStateDataPayload.RunStateData>> groupedStates =
         CliUtil.groupStates(runStateDataPayload.activeStates());
 
-    groupedStates.entrySet().forEach(entry -> {
-      WorkflowId workflowId = entry.getKey();
-      entry.getValue().forEach(RunStateData -> {
-        final StateData stateData = RunStateData.stateData();
-        final List<Message> messages = stateData.messages();
-
-        final String lastMessage;
-        if (messages.isEmpty()) {
-          lastMessage = "No info";
-        } else {
-          final Message message = messages.get(messages.size() - 1);
-          lastMessage = message.line();
-        }
-
-        System.out.println(String.format(
-            "%s %s %s %s %s %d %s",
-            workflowId.componentId(),
-            workflowId.id(),
-            RunStateData.workflowInstance().parameter(),
-            RunStateData.state(),
-            stateData.executionId().orElse("<no-execution-id>"),
-            stateData.tries(),
-            lastMessage
-        ));
-      });
-    });
+    groupedStates.forEach((workflowId, value) -> value.forEach(RunStateData -> {
+      final StateData stateData = RunStateData.stateData();
+      System.out.println(String.format(
+          "%s %s %s %s %s %d %s",
+          workflowId.componentId(),
+          workflowId.id(),
+          RunStateData.workflowInstance().parameter(),
+          RunStateData.state(),
+          stateData.executionId().orElse("<no-execution-id>"),
+          stateData.tries(),
+          stateData.message().map(Message::line).orElse("No info")
+      ));
+    }));
   }
 
   @Override

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -32,7 +32,6 @@ import static org.fusesource.jansi.Ansi.Color.GREEN;
 import static org.fusesource.jansi.Ansi.Color.RED;
 import static org.fusesource.jansi.Ansi.Color.YELLOW;
 
-import com.google.common.collect.Iterables;
 import com.spotify.styx.api.BackfillPayload;
 import com.spotify.styx.api.RunStateDataPayload;
 import com.spotify.styx.model.Backfill;
@@ -73,8 +72,8 @@ class PrettyCliOutput implements CliOutput {
         final StateData stateData = runStateData.stateData();
         final Ansi ansiState = getAnsiForState(runStateData);
 
-        final Message lastMessage = Iterables.getLast(
-            stateData.messages(), Message.create(Message.MessageLevel.UNKNOWN, "No info"));
+        final Message lastMessage =
+            stateData.message().orElse(Message.create(Message.MessageLevel.UNKNOWN, "No info"));
         final Ansi ansiMessage = colored(messageColor(lastMessage.level()),
                                          lastMessage.line());
 

--- a/styx-common/src/main/java/com/spotify/styx/state/RunState.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/RunState.java
@@ -195,7 +195,7 @@ public abstract class RunState {
           return state(
               QUEUED,
               data().builder()
-                  .addMessage(message)
+                  .messages(message)
                   .build());
 
         default:
@@ -277,7 +277,7 @@ public abstract class RunState {
               .retryCost(data().retryCost() + cost)
               .lastExit(exitCode)
               .consecutiveFailures(consecutiveFailures)
-              .addMessage(Message.create(level, "Exit code: " + exitCode.map(String::valueOf).orElse("-")))
+              .messages(Message.create(level, "Exit code: " + exitCode.map(String::valueOf).orElse("-")))
               .build();
 
           return state(TERMINATED, newStateData);
@@ -331,7 +331,7 @@ public abstract class RunState {
               .retryCost(data().retryCost() + FAILURE_COST)
               .lastExit(empty())
               .consecutiveFailures(data().consecutiveFailures() + 1)
-              .addMessage(Message.error(message))
+              .messages(Message.error(message))
               .build();
 
           return state(FAILED, newStateData);

--- a/styx-common/src/main/java/com/spotify/styx/state/StateData.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/StateData.java
@@ -23,9 +23,7 @@ package com.spotify.styx.state;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.collect.Iterables;
 import com.spotify.styx.model.ExecutionDescription;
-import com.spotify.styx.util.TriggerUtil;
 import io.norberg.automatter.AutoMatter;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 

--- a/styx-common/src/main/java/com/spotify/styx/state/StateData.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/StateData.java
@@ -21,8 +21,11 @@
 package com.spotify.styx.state;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.common.collect.Iterables;
 import com.spotify.styx.model.ExecutionDescription;
+import com.spotify.styx.util.TriggerUtil;
 import io.norberg.automatter.AutoMatter;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,7 +48,17 @@ public interface StateData {
   Optional<String> triggerId(); //for backwards compatibility
   Optional<String> executionId();
   Optional<ExecutionDescription> executionDescription();
-  List<Message> messages();
+
+  /**
+   * This field is deprecated and kept only for backwards compatibility.
+   *
+   * @deprecated Use {@link #message()} instead.
+   */
+  @Deprecated List<Message> messages();
+
+  default Optional<Message> message() {
+    return messages().isEmpty() ? Optional.empty() : Optional.of(Iterables.getLast(messages()));
+  }
 
   StateDataBuilder builder();
 

--- a/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
@@ -32,7 +32,6 @@ import static com.spotify.styx.state.RunState.State.SUBMITTING;
 import static com.spotify.styx.state.RunState.State.TERMINATED;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.spotify.styx.WorkflowInstanceEventFactory;

--- a/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
@@ -32,6 +32,7 @@ import static com.spotify.styx.state.RunState.State.SUBMITTING;
 import static com.spotify.styx.state.RunState.State.TERMINATED;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.spotify.styx.WorkflowInstanceEventFactory;
@@ -495,10 +496,7 @@ public class RunStateTest {
 
     assertThat(
         transitioner.get(WORKFLOW_INSTANCE).data().messages(),
-        contains(
-            Message.create(Message.MessageLevel.WARNING, "Exit code: 20"),
-            Message.create(Message.MessageLevel.ERROR, "Error")
-        ));
+        contains(Message.create(Message.MessageLevel.ERROR, "Error")));
   }
 
   @Test
@@ -510,9 +508,7 @@ public class RunStateTest {
 
     assertThat(
         transitioner.get(WORKFLOW_INSTANCE).data().messages(),
-        contains(
-            Message.info("info message"),
-            Message.warning("warning message")));
+        contains(Message.warning("warning message")));
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
@@ -32,11 +32,13 @@ import static com.spotify.styx.state.RunState.State.SUBMITTING;
 import static com.spotify.styx.state.RunState.State.TERMINATED;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.spotify.styx.WorkflowInstanceEventFactory;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.state.Message.MessageLevel;
 import com.spotify.styx.testdata.TestData;
 import com.spotify.styx.util.TriggerUtil;
 import java.util.LinkedList;
@@ -481,7 +483,7 @@ public class RunStateTest {
   }
 
   @Test
-  public void testAccumulatesMessages() throws Exception {
+  public void testRunErrorEmitsMessage() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
     transitioner.receive(eventFactory.dequeue());
@@ -493,21 +495,21 @@ public class RunStateTest {
     transitioner.receive(eventFactory.dequeue());
     transitioner.receive(eventFactory.runError("Error"));
 
-    assertThat(
-        transitioner.get(WORKFLOW_INSTANCE).data().messages(),
-        contains(Message.create(Message.MessageLevel.ERROR, "Error")));
+    final Message expectedMessage = Message.create(MessageLevel.ERROR, "Error");
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().messages(), contains(expectedMessage));
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().message().get(), is(expectedMessage));
   }
 
   @Test
-  public void testAccumulatesMessagesWithInfo() throws Exception {
+  public void testKeepsLastMessage() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
     transitioner.receive(eventFactory.info(Message.info("info message")));
     transitioner.receive(eventFactory.info(Message.warning("warning message")));
 
-    assertThat(
-        transitioner.get(WORKFLOW_INSTANCE).data().messages(),
-        contains(Message.warning("warning message")));
+    final Message expectedMessage = Message.warning("warning message");
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().messages(), contains(expectedMessage));
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().message().get(), is(expectedMessage));
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/state/StateDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/StateDataTest.java
@@ -1,0 +1,42 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.state;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Optional;
+import org.junit.Test;
+
+public class StateDataTest {
+
+  @Test
+  public void testMessage() throws Exception {
+    assertThat(StateData.newBuilder().build().message(),
+        is(Optional.empty()));
+
+    assertThat(StateData.newBuilder().messages(Message.info("foo")).build().message(),
+        is(Optional.of(Message.info("foo"))));
+
+    assertThat(StateData.newBuilder().messages(Message.info("foo"), Message.info("bar")).build().message(),
+        is(Optional.of(Message.info("bar"))));
+  }
+}

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -288,8 +288,7 @@ public class Scheduler {
               depletedResources.stream()
                   .map(resources::get)
                   .collect(toList())));
-      final List<Message> messages = instance.runState().data().messages();
-      if (messages.size() == 0 || !message.equals(messages.get(messages.size() - 1))) {
+      if (!instance.runState().data().message().map(message::equals).orElse(false)) {
         stateManager.receiveIgnoreClosed(Event.info(instance.workflowInstance(), message));
       }
     } else {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -279,7 +279,7 @@ public class SchedulerTest {
     scheduler.tick();
 
     assertThat(
-    stateManager.get(INSTANCE).data().messages().get(0).line(),
+    stateManager.get(INSTANCE).data().message().get().line(),
         is("Referenced resources not found: [unknown]"));
     assertThat(stateManager.get(INSTANCE).state(), is(State.FAILED));
   }
@@ -294,7 +294,7 @@ public class SchedulerTest {
     scheduler.tick();
 
     assertThat(
-        stateManager.get(INSTANCE).data().messages().get(0).line(),
+        stateManager.get(INSTANCE).data().message().get().line(),
         is(String.format("Resource limit reached for: [Resource{id=%s, concurrency=%d}]",
                          Scheduler.GLOBAL_RESOURCE_ID, 0)));
     assertThat(stateManager.get(INSTANCE).state(), is(State.QUEUED));
@@ -310,7 +310,7 @@ public class SchedulerTest {
     scheduler.tick();
 
     assertThat(
-        stateManager.get(INSTANCE).data().messages().get(0).line(),
+        stateManager.get(INSTANCE).data().message().get().line(),
         is("Resource limit reached for: [Resource{id=r1, concurrency=0}]"));
     assertThat(stateManager.get(INSTANCE).state(), is(State.QUEUED));
   }
@@ -326,7 +326,7 @@ public class SchedulerTest {
     scheduler.tick();
 
     assertThat(
-        stateManager.get(INSTANCE).data().messages().get(0).line(),
+        stateManager.get(INSTANCE).data().message().get().line(),
         is("Referenced resources not found: [r2, r3]"));
     assertThat(stateManager.get(INSTANCE).state(), is(State.FAILED));
   }
@@ -341,7 +341,7 @@ public class SchedulerTest {
     scheduler.tick();
     scheduler.tick();
 
-    assertThat(stateManager.get(INSTANCE).data().messages().size(), is(1));
+    assertThat(stateManager.get(INSTANCE).data().message().isPresent(), is(true));
     assertThat(stateManager.get(INSTANCE).state(), is(State.QUEUED));
   }
 


### PR DESCRIPTION
We're always only using the last message anyway.

As opposed to https://github.com/spotify/styx/pull/369 this should be backwards compatible.