### PR TITLE
log pod UID

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -558,8 +558,9 @@ class KubernetesDockerRunner implements DockerRunner {
         .getOrDefault(KubernetesDockerRunner.STYX_WORKFLOW_INSTANCE_ANNOTATION, "N/A");
     final String status = readStatus(pod);
 
-    LOG.info("{}Pod event for {} at resource version {}, action: {}, workflow instance: {}, status: {}",
-             polled ? "Polled: " : "", podName, resourceVersion, action, workflowInstance, status);
+    LOG.info("{}Pod event for {} ({}) at resource version {}, action: {}, workflow instance: {}, status: {}",
+             polled ? "Polled: " : "", podName, pod.getMetadata().getUid(), resourceVersion, action, workflowInstance,
+             status);
   }
 
   private String readStatus(Pod pod) {


### PR DESCRIPTION
Allow looking up WFIs for pods spotted in the container engine visualizer (which only shows pod UIDs).