### PR TITLE
name the containers

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -242,7 +242,7 @@ class KubernetesDockerRunner implements DockerRunner {
     runSpec.memLimit().ifPresent(s -> resourceRequirements.addToLimits("memory", new Quantity(s)));
 
     final ContainerBuilder containerBuilder = new ContainerBuilder()
-        .withName(STYX_RUN)
+        .withName(runSpec.executionId())
         .withImage(imageWithTag)
         .withArgs(runSpec.args())
         .withEnv(buildEnv(workflowInstance, runSpec))

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
@@ -22,6 +22,7 @@ package com.spotify.styx.docker;
 
 import static com.spotify.styx.docker.DockerRunner.LOG;
 import static com.spotify.styx.docker.KubernetesDockerRunner.DOCKER_TERMINATION_LOGGING_ANNOTATION;
+import static com.spotify.styx.docker.KubernetesDockerRunner.getStyxContainer;
 import static java.util.Collections.emptyList;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -44,13 +45,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Predicate;
 import okio.ByteString;
 
 final class KubernetesPodEventTranslator {
-
-  private static final Predicate<ContainerStatus> IS_STYX_CONTAINER =
-      (cs) -> KubernetesDockerRunner.STYX_RUN.equals(cs.getName());
 
   private KubernetesPodEventTranslator() {
     throw new UnsupportedOperationException();
@@ -175,22 +172,19 @@ final class KubernetesPodEventTranslator {
     switch (phase) {
       case "Running":
         // check that the styx container is ready
-        started = status.getContainerStatuses().stream()
-            .anyMatch(IS_STYX_CONTAINER.and(ContainerStatus::getReady));
+        started = getStyxContainer(pod)
+            .map(ContainerStatus::getReady)
+            .orElse(false);
         break;
 
       case "Succeeded":
       case "Failed":
         exited = true;
-        exitCode = pod.getStatus().getContainerStatuses().stream()
-            .filter(IS_STYX_CONTAINER)
-            .map(cs -> getExitCodeIfValid(
+        exitCode = getStyxContainer(pod)
+            .flatMap(cs -> getExitCodeIfValid(
                 workflowInstance.toKey(),
                 pod,
-                cs, stats))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .findFirst();
+                cs, stats));
         break;
 
       default:
@@ -234,18 +228,13 @@ final class KubernetesPodEventTranslator {
     switch (phase) {
       case "Pending":
         // check if one or more docker contains failed to pull their image, a possible silent error
-        return status.getContainerStatuses().stream()
-            .filter(IS_STYX_CONTAINER.and(KubernetesPodEventTranslator::hasPullImageError))
-            .findAny()
-            .map((x) -> Event.runError(workflowInstance, "One or more containers failed to pull their image"));
+        return getStyxContainer(pod)
+            .filter(KubernetesPodEventTranslator::hasPullImageError)
+            .map(x -> Event.runError(workflowInstance, "One or more containers failed to pull their image"));
 
       case "Succeeded":
       case "Failed":
-        final Optional<ContainerStatus> containerStatusOpt =
-            pod.getStatus().getContainerStatuses().stream()
-                .filter(IS_STYX_CONTAINER)
-                .findFirst();
-
+        final Optional<ContainerStatus> containerStatusOpt = getStyxContainer(pod);
         if (!containerStatusOpt.isPresent()) {
           return Optional.of(Event.runError(workflowInstance, "Could not find our container in pod"));
         }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -174,8 +174,8 @@ public class KubernetesDockerRunnerPodPollerTest {
     when(namedPod1.get()).thenReturn(createdPod1);
     when(namedPod2.get()).thenReturn(createdPod2);
 
-    setStatusAndState(createdPod1);
-    setStatusAndState(createdPod2);
+    setStatusAndState(createdPod1, RUN_SPEC.executionId());
+    setStatusAndState(createdPod2, RUN_SPEC_2.executionId());
 
     kdr.pollPods();
 
@@ -183,10 +183,10 @@ public class KubernetesDockerRunnerPodPollerTest {
     verify(namedPod2).delete();
   }
 
-  private void setStatusAndState(Pod createdPod) {
+  private void setStatusAndState(Pod createdPod, String containerName) {
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
-    when(containerStatus.getName()).thenReturn(KubernetesDockerRunner.STYX_RUN);
+    when(containerStatus.getName()).thenReturn(containerName);
     when(containerStatus.getState()).thenReturn(containerState);
     when(containerState.getTerminated()).thenReturn(containerStateTerminated);
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -79,6 +79,8 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -100,6 +102,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class KubernetesDockerRunnerTest {
 
   private static final String POD_NAME = "test-pod-1";
+  private static final String CONTAINER_NAME = "test-container-1";
   private static final String SERVICE_ACCOUNT = "sa@example.com";
   private static final String SERVICE_ACCOUNT_SECRET = "sa-secret";
   private static final WorkflowInstance WORKFLOW_INSTANCE = WorkflowInstance.create(TestData.WORKFLOW_ID, "foo");
@@ -215,6 +218,15 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
+  public void shouldCreateSingleContainerNamedByExecutionId() throws IOException, IsClosedException {
+    kdr.start(WORKFLOW_INSTANCE, RUN_SPEC);
+    verify(pods).create(podCaptor.capture());
+    Pod submittedPod = podCaptor.getValue();
+    assertThat(submittedPod.getSpec().getContainers().size(), is(1));
+    assertThat(submittedPod.getSpec().getContainers().get(0).getName(), is(RUN_SPEC.executionId()));
+  }
+
+  @Test
   public void shouldNotDeletePodIfDebugEnabled() throws Exception {
     when(debug.get()).thenReturn(true);
     final String name = createdPod.getMetadata().getName();
@@ -224,7 +236,7 @@ public class KubernetesDockerRunnerTest {
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
-    when(containerStatus.getName()).thenReturn(KubernetesDockerRunner.STYX_RUN);
+    when(containerStatus.getName()).thenReturn(CONTAINER_NAME);
     when(containerStatus.getState()).thenReturn(containerState);
     when(containerState.getTerminated()).thenReturn(containerStateTerminated);
     when(containerStateTerminated.getFinishedAt())
@@ -247,7 +259,7 @@ public class KubernetesDockerRunnerTest {
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
-    when(containerStatus.getName()).thenReturn(KubernetesDockerRunner.STYX_RUN);
+    when(containerStatus.getName()).thenReturn(CONTAINER_NAME);
     when(containerStatus.getState()).thenReturn(containerState);
     when(containerState.getTerminated()).thenReturn(containerStateTerminated);
     when(containerStateTerminated.getFinishedAt())
@@ -266,7 +278,7 @@ public class KubernetesDockerRunnerTest {
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
-    when(containerStatus.getName()).thenReturn(KubernetesDockerRunner.STYX_RUN);
+    when(containerStatus.getName()).thenReturn(CONTAINER_NAME);
     when(containerStatus.getState()).thenReturn(containerState);
     when(containerState.getTerminated()).thenReturn(containerStateTerminated);
 
@@ -309,7 +321,7 @@ public class KubernetesDockerRunnerTest {
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
-    when(containerStatus.getName()).thenReturn(KubernetesDockerRunner.STYX_RUN);
+    when(containerStatus.getName()).thenReturn(CONTAINER_NAME);
     when(containerStatus.getState()).thenReturn(containerState);
     when(containerState.getTerminated()).thenReturn(containerStateTerminated);
     when(containerStateTerminated.getFinishedAt())
@@ -328,7 +340,7 @@ public class KubernetesDockerRunnerTest {
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
-    when(containerStatus.getName()).thenReturn(KubernetesDockerRunner.STYX_RUN);
+    when(containerStatus.getName()).thenReturn(CONTAINER_NAME);
     when(containerStatus.getState()).thenReturn(containerState);
 
     kdr.cleanupWithRunState(WORKFLOW_INSTANCE, name);
@@ -336,25 +348,28 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
-  public void shouldNotCleanupPodIfNotStyxContainer() {
+  public void shouldNotCleanupNonStyxPod() {
     final String name = createdPod.getMetadata().getName();
     when(k8sClient.pods().withName(name)).thenReturn(namedPod);
     when(namedPod.get()).thenReturn(createdPod);
 
+    createdPod.getMetadata().setAnnotations(Collections.emptyMap());
+
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
-    when(containerStatus.getName()).thenReturn("foo");
 
     kdr.cleanupWithRunState(WORKFLOW_INSTANCE, name);
     verify(namedPod, never()).delete();
   }
 
   @Test
-  public void shouldNotCleanupPodWithoutRunStateIfNotStyxContainer() {
+  public void shouldNotCleanupNonStyxPodWithoutRunState() {
     final String name = createdPod.getMetadata().getName();
     when(k8sClient.pods().withName(name)).thenReturn(namedPod);
     when(namedPod.get()).thenReturn(createdPod);
+
+    createdPod.getMetadata().setAnnotations(Collections.emptyMap());
 
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
@@ -374,7 +389,7 @@ public class KubernetesDockerRunnerTest {
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
-    when(containerStatus.getName()).thenReturn(KubernetesDockerRunner.STYX_RUN);
+    when(containerStatus.getName()).thenReturn(CONTAINER_NAME);
     when(containerStatus.getState()).thenReturn(containerState);
 
     kdr.cleanupWithoutRunState(WORKFLOW_INSTANCE, name);
@@ -390,7 +405,7 @@ public class KubernetesDockerRunnerTest {
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
-    when(containerStatus.getName()).thenReturn(KubernetesDockerRunner.STYX_RUN);
+    when(containerStatus.getName()).thenReturn(CONTAINER_NAME);
     when(containerStatus.getState()).thenReturn(containerState);
     when(containerState.getTerminated()).thenReturn(containerStateTerminated);
     when(containerStateTerminated.getFinishedAt())
@@ -409,7 +424,7 @@ public class KubernetesDockerRunnerTest {
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
-    when(containerStatus.getName()).thenReturn(KubernetesDockerRunner.STYX_RUN);
+    when(containerStatus.getName()).thenReturn(CONTAINER_NAME);
     when(containerStatus.getState()).thenReturn(containerState);
     when(containerState.getTerminated()).thenReturn(containerStateTerminated);
     when(containerStateTerminated.getFinishedAt())

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -373,7 +373,6 @@ public class KubernetesDockerRunnerTest {
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
-    when(containerStatus.getName()).thenReturn("foo");
 
     kdr.cleanupWithoutRunState(WORKFLOW_INSTANCE, name);
     verify(namedPod, never()).delete();

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -79,7 +79,6 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -321,8 +321,8 @@ public class KubernetesPodEventTranslatorTest {
   static PodStatus podStatus(String phase, boolean ready, ContainerState containerState) {
     PodStatus podStatus = podStatusNoContainer(phase);
     podStatus.getContainerStatuses()
-        .add(new ContainerStatus(KubernetesDockerRunner.STYX_RUN, "", "", containerState,
-                                 KubernetesDockerRunner.STYX_RUN, ready, 0, containerState));
+        .add(new ContainerStatus("foo", "", "", containerState,
+                                 "bar", ready, 0, containerState));
     return podStatus;
   }
 


### PR DESCRIPTION
The container engine visualizer shows the container name when hovering.

Using the execution id as the container name makes it a little easier to look up the corresponding execution/wfi for an container spotted in the visualizer.