### PR TITLE
guarded backfill triggering

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
@@ -22,6 +22,7 @@ package com.spotify.styx;
 
 import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
 import static com.google.common.base.CaseFormat.UPPER_CAMEL;
+import static com.spotify.styx.util.GuardedRunnable.guard;
 import static com.spotify.styx.util.TimeUtil.nextInstant;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
@@ -92,7 +93,7 @@ class BackfillTriggerManager {
     }
 
     final Map<String, Long> backfillStates = getBackfillStates();
-    backfills.forEach(backfill -> triggerBackfill(backfill, backfillStates));
+    backfills.forEach(backfill -> guard(() -> triggerBackfill(backfill, backfillStates)).run());
 
     final long durationMillis = t0.until(time.get(), ChronoUnit.MILLIS);
     stats.recordTickDuration(TICK_TYPE, durationMillis);
@@ -123,15 +124,13 @@ class BackfillTriggerManager {
         // Wait for the trigger execution to complete before proceeding to the next partition
         processed.get();
       } catch (AlreadyInitializedException e) {
-        LOG.warn("tried to trigger backfill for already active state [{}]: {}",
-                 partition, backfill);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new RuntimeException(e);
+        LOG.warn("tried to trigger backfill for already active state [{}]: {}", partition, backfill);
       } catch (ExecutionException e) {
-        LOG.error("failed to trigger backfill for state [{}]: {}",
-                  partition, backfill);
-        throw new RuntimeException(e);
+        LOG.warn("failed to trigger backfill for state [{}]: {}", partition, backfill, e);
+        return;
+      } catch (Throwable e) {
+        LOG.warn("backfill triggering threw exception for state [{}]: {}", partition, backfill, e);
+        return;
       }
 
       partition = nextInstant(partition, backfill.schedule());

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
@@ -123,13 +123,10 @@ class BackfillTriggerManager {
             .toCompletableFuture();
         // Wait for the trigger execution to complete before proceeding to the next partition
         processed.get();
-      } catch (AlreadyInitializedException e) {
-        LOG.warn("tried to trigger backfill for already active state [{}]: {}", partition, backfill);
-      } catch (ExecutionException e) {
-        LOG.warn("failed to trigger backfill for state [{}]: {}", partition, backfill, e);
-        return;
+      } catch (AlreadyInitializedException ignored) {
+        // nop
       } catch (Throwable e) {
-        LOG.warn("backfill triggering threw exception for state [{}]: {}", partition, backfill, e);
+        LOG.warn("failed to trigger backfill for state [{}]: {}", partition, backfill, e);
         return;
       }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
@@ -47,7 +47,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/TriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/TriggerManager.java
@@ -114,8 +114,8 @@ class TriggerManager {
               instantSpec.instant());
           // Wait for the event to be processed before proceeding to the next trigger
           processed.toCompletableFuture().get();
-        } catch (AlreadyInitializedException e) {
-          LOG.warn("{}", e.getMessage());
+        } catch (AlreadyInitializedException ignored) {
+          // nop
         } catch (Throwable e) {
           LOG.warn("Triggering {} threw exception", workflow.id(), e);
           return; // so we don't update the trigger time


### PR DESCRIPTION
When triggering one backfill fails, continue triggering others. `InterruptedException` is not handled specially any more because when that happens executor thread is stopping.