### PR TITLE
Hot-fix disable activeStatesMetric per Workflow

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
@@ -209,11 +209,12 @@ public final class MetricsStats implements Stats {
 
   @Override
   public void registerActiveStatesMetric(WorkflowId workflowId, Gauge<Long> activeStatesCount) {
-    activeStatesPerWorkflowGauges.computeIfAbsent(
-        workflowId, (ignoreKey) -> registry.register(
-            ACTIVE_STATES_PER_WORKFLOW.tagged(
-                "component-id", workflowId.componentId(), "workflow-id", workflowId.id()),
-            activeStatesCount));
+    // fixme temporarily disabled due to heavy load in presence of high volume of registered workflows
+    //activeStatesPerWorkflowGauges.computeIfAbsent(
+    //    workflowId, (ignoreKey) -> registry.register(
+    //        ACTIVE_STATES_PER_WORKFLOW.tagged(
+    //           "component-id", workflowId.componentId(), "workflow-id", workflowId.id()),
+    //        activeStatesCount));
   }
 
   @Override

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
@@ -46,6 +46,7 @@ import static com.spotify.styx.monitoring.MetricsStats.WORKFLOW_CONSUMER_RATE;
 import static com.spotify.styx.monitoring.MetricsStats.WORKFLOW_COUNT;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -160,7 +161,8 @@ public class MetricsStatsTest {
   public void shouldRegisterActiveStatesMetric() {
     WorkflowId workflowId = WorkflowId.create("component", "workflow");
     stats.registerActiveStatesMetric(workflowId, gauge);
-    verify(registry).register(ACTIVE_STATES_PER_WORKFLOW.tagged(
+    // fixme this should be called when registerActiveStatesMetric is re-enabled
+    verify(registry, never()).register(ACTIVE_STATES_PER_WORKFLOW.tagged(
         "component-id", workflowId.componentId(), "workflow-id", workflowId.id()), gauge);
   }
 


### PR DESCRIPTION
After #385, retrieving active states requires a call to persistent layer with considerable higher latencies. In case of high number of registered workflows, `registerActiveStatesMetric` per each workflow could cause the metric framework to be very slow. 