### PR TITLE
Bump MAX_DOCKER_ARGS_TOTAL

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/WorkflowValidator.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/WorkflowValidator.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 public class WorkflowValidator {
 
   static final int MAX_ID_LENGTH = 256;
-  static final int MAX_DOCKER_ARGS_TOTAL = 1024;
+  static final int MAX_DOCKER_ARGS_TOTAL = 1000000;
   static final int MAX_RESOURCES = 5;
   static final int MAX_RESOURCE_LENGTH = 256;
   static final int MAX_COMMIT_SHA_LENGTH = 256;


### PR DESCRIPTION
We're bound by Datastore property size limit really, https://cloud.google.com/datastore/docs/concepts/limits . Command lines usually can be 2MB long. It just astonishes users if knocked down by orders of magnitude.