### PR TITLE
Strict counter verification in event processing

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -48,7 +48,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import org.apache.commons.lang.NotImplementedException;
 
 /**
  * A Storage implementation with state stored in memory. For testing.

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -253,8 +253,8 @@ public class Scheduler {
 
     if (blocker.isPresent()) {
       stateManager.receiveIgnoreClosed(Event.retryAfter(instanceState.workflowInstance(),
-                                                        blocker.get().delay().toMillis()),
-                                       instanceState.runState().counter());
+          blocker.get().delay().toMillis()),
+          instanceState.runState().counter());
       LOG.debug("Dequeue rescheduled: {}: {}", instanceState.workflowInstance(), blocker.get());
       return;
     }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -128,6 +128,7 @@ public class QueuedStateManager implements StateManager {
 
   @Override
   public CompletableFuture<Void> receive(Event event) throws IsClosedException {
+    ensureRunning();
     // Read state counter at enqueueing time
     final Optional<RunState> currentRunState = getActiveState(event.workflowInstance());
     if (!currentRunState.isPresent()) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/StaleEventException.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/StaleEventException.java
@@ -1,0 +1,32 @@
+/*-
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.state;
+
+/**
+ * An exception thrown from State Manager when a stale event is encountered. This can happen when
+ * a single-threaded looping tick enqueues the same event more than once due to slow state transitions.
+ */
+public class StaleEventException extends RuntimeException {
+
+  public StaleEventException(String message) {
+    super(message);
+  }
+}

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -141,7 +141,7 @@ public class SchedulerTest {
         .thenAnswer(a -> a.getArgumentAt(2, Set.class));
 
     scheduler = new Scheduler(time, timeoutConfig, stateManager, workflowCache, storage, resourceDecorator,
-                              stats, rateLimiter, gate);
+        stats, rateLimiter, gate);
   }
 
   private void setResourceLimit(String resourceId, long limit) {
@@ -300,7 +300,7 @@ public class SchedulerTest {
       initWorkflow(workflowUsingResources(workflowId));
       WorkflowInstance instance = WorkflowInstance.create(workflowId, "2016-12-02T01");
       populateActiveStates(RunState.create(instance, State.QUEUED, stateData,
-                                           time.get().minus(i, ChronoUnit.SECONDS)));
+          time.get().minus(i, ChronoUnit.SECONDS)));
       workflowInstances.add(instance);
     }
 
@@ -338,8 +338,8 @@ public class SchedulerTest {
 
     verify(stateManager).receiveIgnoreClosed(
         eq(Event.info(INSTANCE_1,
-                      Message.info("Resource limit reached for: "
-                                   + "[Resource{id=GLOBAL_STYX_CLUSTER, concurrency=0}]"))),
+            Message.info("Resource limit reached for: "
+                         + "[Resource{id=GLOBAL_STYX_CLUSTER, concurrency=0}]"))),
         anyLong());
   }
 
@@ -354,7 +354,7 @@ public class SchedulerTest {
 
     verify(stateManager).receiveIgnoreClosed(
         eq(Event.info(INSTANCE_1,
-                      Message.info("Resource limit reached for: [Resource{id=r1, concurrency=0}]"))),
+            Message.info("Resource limit reached for: [Resource{id=r1, concurrency=0}]"))),
         anyLong());
   }
 
@@ -370,7 +370,7 @@ public class SchedulerTest {
 
     verify(stateManager).receiveIgnoreClosed(
         eq(Event.runError(INSTANCE_1,
-                          "Referenced resources not found: [r2, r3]")),
+            "Referenced resources not found: [r2, r3]")),
         anyLong());
   }
 
@@ -388,7 +388,7 @@ public class SchedulerTest {
 
     verify(stateManager, times(0)).receiveIgnoreClosed(
         eq(Event.info(INSTANCE_1,
-                      Message.info("Resource limit reached for: [Resource{id=r1, concurrency=0}]"))),
+            Message.info("Resource limit reached for: [Resource{id=r1, concurrency=0}]"))),
         anyLong());
   }
 
@@ -642,12 +642,12 @@ public class SchedulerTest {
 
     verify(stateManager).receiveIgnoreClosed(
         eq(Event.info(INSTANCE_1,
-                      Message.info("Resource limit reached for: [Resource{id=baz, concurrency=0}]"))),
+            Message.info("Resource limit reached for: [Resource{id=baz, concurrency=0}]"))),
         anyLong());
 
     verify(stateManager, never()).receiveIgnoreClosed(
         eq(Event.dequeue(INSTANCE_1,
-                         ImmutableSet.of("baz", "quux", "GLOBAL_STYX_CLUSTER"))),
+            ImmutableSet.of("baz", "quux", "GLOBAL_STYX_CLUSTER"))),
         anyLong());
   }
 
@@ -687,7 +687,7 @@ public class SchedulerTest {
     verify(stateManager).receiveIgnoreClosed(Matchers.argThat(
         either(is(Event.dequeue(i0, ImmutableSet.of("baz", "GLOBAL_STYX_CLUSTER"))))
             .or(is(Event.dequeue(i4, ImmutableSet.of("baz", "GLOBAL_STYX_CLUSTER"))))),
-                                             anyLong());
+        anyLong());
   }
 
   @Test
@@ -726,7 +726,7 @@ public class SchedulerTest {
     verify(gate, times(2)).executionBlocker(INSTANCE_1);
 
     verify(stateManager).receiveIgnoreClosed(eq(Event.dequeue(INSTANCE_1, ImmutableSet.of())),
-                                             anyLong());
+        anyLong());
   }
 
   @Test
@@ -746,7 +746,7 @@ public class SchedulerTest {
     scheduler.tick();
 
     verify(stateManager).receiveIgnoreClosed(eq(Event.dequeue(INSTANCE_1, ImmutableSet.of())),
-                                             anyLong());
+        anyLong());
     verifyZeroInteractions(gate);
   }
 
@@ -772,7 +772,7 @@ public class SchedulerTest {
     verify(gate).executionBlocker(INSTANCE_1);
 
     verify(stateManager).receiveIgnoreClosed(eq(Event.dequeue(INSTANCE_1, ImmutableSet.of())),
-                                             anyLong());
+        anyLong());
     verifyZeroInteractions(gate);
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
@@ -693,12 +693,12 @@ public class QueuedStateManagerTest {
 
 
   public void givenState(WorkflowInstance instance, State state) throws IOException {
-    when(transaction.readActiveState(instance))
-        .thenReturn(Optional.of(RunState.create(instance, state, STATE_DATA_1, NOW.minusMillis(1), 17)));
+    final RunState runState = RunState.create(instance, state, STATE_DATA_1, NOW.minusMillis(1), 17);
+    when(transaction.readActiveState(instance)).thenReturn(Optional.of(runState));
+    when(storage.readActiveState(INSTANCE)).thenReturn(Optional.of(runState));
   }
 
   public void receiveEvent(Event event) throws Exception {
     stateManager.receive(event).toCompletableFuture().get(1, MINUTES);
   }
-
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -697,12 +696,8 @@ public class QueuedStateManagerTest {
   public void shouldReceiveEventIgnoreClosed() throws IOException, IsClosedException {
     final QueuedStateManager spied = spy(stateManager);
     spied.close();
-    givenState(INSTANCE, State.SUBMITTED);
 
-    final Event event = Event.started(INSTANCE);
-    spied.receiveIgnoreClosed(event);
-    verify(storage).readActiveState(INSTANCE);
-    verify(spied).receive(eq(event), anyLong());
+    spied.receiveIgnoreClosed(Event.started(INSTANCE));
     verify(spied).ensureRunning();
     verifyNoMoreInteractions(storage);
   }
@@ -711,7 +706,6 @@ public class QueuedStateManagerTest {
   public void shouldReceiveEventIgnoreClosedWithCounter() throws IOException, IsClosedException {
     final QueuedStateManager spied = spy(stateManager);
     spied.close();
-    givenState(INSTANCE, State.SUBMITTED);
 
     spied.receiveIgnoreClosed(Event.started(INSTANCE), 17);
     verify(spied).ensureRunning();

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
@@ -24,6 +24,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -134,6 +135,8 @@ public class QueuedStateManagerTest {
     final RunState instanceStateFresh =
         RunState.create(INSTANCE, State.NEW, StateData.zero(), NOW, -1);
     when(storage.getLatestStoredCounter(INSTANCE)).thenReturn(Optional.empty());
+    when(storage.readActiveState(INSTANCE))
+        .thenReturn(Optional.of(RunState.create(INSTANCE, State.NEW, NOW, -1)));
     when(transaction.workflow(INSTANCE.workflowId())).thenReturn(Optional.of(WORKFLOW));
     when(transaction.readActiveState(INSTANCE)).thenReturn(Optional.of(instanceStateFresh));
 
@@ -148,6 +151,7 @@ public class QueuedStateManagerTest {
   @Test
   public void shouldReInitializeWFInstanceFromNextCounter() throws Exception {
     when(storage.getLatestStoredCounter(INSTANCE)).thenReturn(Optional.of(INSTANCE_NEW_STATE.counter()));
+    when(storage.readActiveState(INSTANCE)).thenReturn(Optional.of(INSTANCE_NEW_STATE));
     when(transaction.workflow(INSTANCE.workflowId())).thenReturn(Optional.of(WORKFLOW));
     when(transaction.readActiveState(INSTANCE)).thenReturn(Optional.of(INSTANCE_NEW_STATE));
 
@@ -161,9 +165,10 @@ public class QueuedStateManagerTest {
 
   @Test
   public void shouldNotBeActiveAfterHalt() throws Exception {
-    when(transaction.readActiveState(INSTANCE)).thenReturn(
-        Optional.of(RunState.create(INSTANCE, State.PREPARE, StateData.zero(),
-            NOW, 17)));
+    Optional<RunState> runState = Optional.of(
+        RunState.create(INSTANCE, State.PREPARE, StateData.zero(), NOW, 17));
+    when(transaction.readActiveState(INSTANCE)).thenReturn(runState);
+    when(storage.readActiveState(INSTANCE)).thenReturn(runState);
 
     Event event = Event.halt(INSTANCE);
     stateManager.receive(event)
@@ -310,20 +315,22 @@ public class QueuedStateManagerTest {
 
   @Test(expected = IsClosedException.class)
   public void shouldRejectEventIfClosed() throws Exception {
+    when(storage.readActiveState(INSTANCE))
+        .thenReturn(Optional.of(RunState.create(INSTANCE, State.NEW, NOW, -1)));
     stateManager.close();
     stateManager.receive(Event.timeTrigger(INSTANCE));
   }
 
   @Test
   public void shouldCloseGracefully() throws Exception {
-    when(transaction.readActiveState(INSTANCE)).thenReturn(
-        Optional.of(RunState.create(INSTANCE, State.QUEUED, StateData.zero(),
-            NOW.minusMillis(1), 17)));
+    Optional<RunState> runState = Optional.of(
+        RunState.create(INSTANCE, State.QUEUED, StateData.zero(), NOW.minusMillis(1), 17));
+    when(transaction.readActiveState(INSTANCE)).thenReturn(runState);
 
     CompletableFuture<Void> barrier = new CompletableFuture<>();
 
     reset(storage);
-
+    when(storage.readActiveState(INSTANCE)).thenReturn(runState);
     when(storage.runInTransaction(any())).thenAnswer(a -> {
       barrier.get();
       return a.getArgumentAt(0, TransactionFunction.class).apply(transaction);
@@ -353,10 +360,10 @@ public class QueuedStateManagerTest {
   @Test
   public void shouldWriteEvents() throws Exception {
     Event event = Event.started(INSTANCE);
-
-    when(transaction.readActiveState(INSTANCE))
-        .then(a -> Optional.of(RunState.create(INSTANCE, State.SUBMITTED, StateData.zero(),
-            NOW, 17)));
+    Optional<RunState> runState = Optional.of(
+        RunState.create(INSTANCE, State.SUBMITTED, StateData.zero(), NOW, 17));
+    when(transaction.readActiveState(INSTANCE)).thenReturn(runState);
+    when(storage.readActiveState(INSTANCE)).thenReturn(runState);
 
     stateManager.receive(event)
         .toCompletableFuture().get(1, MINUTES);
@@ -365,10 +372,52 @@ public class QueuedStateManagerTest {
   }
 
   @Test
-  public void shouldRemoveStateIfTerminal() throws Exception {
+  public void shouldFailReceiveEventWithHigherCounter() throws Exception {
+    Event event = Event.started(INSTANCE);
+
     when(transaction.readActiveState(INSTANCE)).thenReturn(
-        Optional.of(RunState.create(INSTANCE, State.TERMINATED, StateData.zero(),
-            NOW, 17)));
+        Optional.of(RunState.create(INSTANCE, State.SUBMITTED, StateData.zero(), NOW, 17)));
+    when(storage.getLatestStoredCounter(any())).thenReturn(Optional.of(17L));
+
+    try {
+      stateManager.receive(event, 16)
+          .toCompletableFuture().get(1, MINUTES);
+      fail();
+    } catch (ExecutionException e) {
+      assertThat(e.getCause(), is(instanceOf(StaleEventException.class)));
+    }
+
+    verify(storage, never()).writeEvent(any());
+  }
+
+  @Test
+  public void shouldFailReceiveEventWithLowerCounter() throws Exception {
+    Event event = Event.started(INSTANCE);
+    Optional<RunState> runState = Optional.of(
+        RunState.create(INSTANCE, State.SUBMITTED, StateData.zero(), NOW.minusMillis(1), 17));
+    when(transaction.readActiveState(INSTANCE)).thenReturn(runState);
+    when(storage.getLatestStoredCounter(any())).thenReturn(Optional.of(17L));
+
+    try {
+      stateManager.receive(event, 18)
+          .toCompletableFuture().get(1, MINUTES);
+      fail();
+    } catch (ExecutionException e) {
+      assertThat(e.getCause(), is(instanceOf(RuntimeException.class)));
+      assertThat(e.getCause().getMessage(),
+          startsWith("Unexpected current counter is less than last observed one for"));
+    }
+
+    verify(storage, never()).writeEvent(any());
+  }
+
+  @Test
+  public void shouldRemoveStateIfTerminal() throws Exception {
+    Optional<RunState> runState = Optional.of(
+        RunState.create(INSTANCE, State.TERMINATED, StateData.zero(),
+            NOW, 17));
+    when(transaction.readActiveState(INSTANCE)).thenReturn(runState);
+    when(storage.readActiveState(INSTANCE)).thenReturn(runState);
 
     Event event = Event.success(INSTANCE);
     stateManager.receive(event)
@@ -380,13 +429,11 @@ public class QueuedStateManagerTest {
 
   @Test
   public void shouldHaveZeroQueuedEvent() throws Exception {
+    Optional<RunState> runState = Optional.of(
+        RunState.create(INSTANCE, State.TERMINATED, StateData.zero(), NOW, 17L));
     when(transaction.readActiveState(INSTANCE)).thenReturn(
-        Optional.of(RunState.create(
-            INSTANCE,
-            State.TERMINATED,
-            StateData.zero(),
-            NOW,
-            17L)));
+        runState);
+    when(storage.readActiveState(INSTANCE)).thenReturn(runState);
 
     assertThat(stateManager.queuedEvents(), is(0L));
 
@@ -401,8 +448,10 @@ public class QueuedStateManagerTest {
 
   @Test
   public void shouldWriteActiveStateOnEvent() throws Exception {
-    when(transaction.readActiveState(INSTANCE)).thenReturn(Optional.of(RunState.create(INSTANCE,
-        State.QUEUED, StateData.zero(), NOW.minusMillis(1), 17)));
+    Optional<RunState> runState = Optional.of(
+        RunState.create(INSTANCE, State.QUEUED, StateData.zero(), NOW, 17));
+    when(transaction.readActiveState(INSTANCE)).thenReturn(runState);
+    when(storage.readActiveState(INSTANCE)).thenReturn(runState);
 
     stateManager.receive(Event.dequeue(INSTANCE, ImmutableSet.of()))
         .toCompletableFuture().get(1, MINUTES);
@@ -413,8 +462,10 @@ public class QueuedStateManagerTest {
 
   @Test
   public void shouldPreventIllegalStateTransition() throws Exception {
-    when(transaction.readActiveState(INSTANCE)).thenReturn(Optional.of(RunState.create(INSTANCE,
-        State.QUEUED, StateData.zero(), NOW.minusMillis(1), 17)));
+    Optional<RunState> runState = Optional.of(
+        RunState.create(INSTANCE, State.QUEUED, StateData.zero(), NOW.minusMillis(1), 17));
+    when(transaction.readActiveState(INSTANCE)).thenReturn(runState);
+    when(storage.readActiveState(INSTANCE)).thenReturn(runState);
 
     CompletableFuture<Void> f = stateManager.receive(Event.terminate(INSTANCE, Optional.empty()))
         .toCompletableFuture();
@@ -432,17 +483,13 @@ public class QueuedStateManagerTest {
   @Test
   public void shouldFailReceiveForUnknownActiveWFInstance() throws Exception {
     when(transaction.readActiveState(INSTANCE)).thenReturn(Optional.empty());
-
-    CompletableFuture<Void> f = stateManager.receive(Event.terminate(INSTANCE, Optional.empty()))
-        .toCompletableFuture();
+    when(storage.readActiveState(INSTANCE)).thenReturn(Optional.empty());
 
     try {
-      f.get(1, MINUTES);
-      fail();
+      stateManager.receive(Event.terminate(INSTANCE, Optional.empty())).toCompletableFuture().get();
     } catch (ExecutionException e) {
       assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
     }
-
     verify(transaction, never()).updateActiveState(any(), any());
   }
 
@@ -489,9 +536,11 @@ public class QueuedStateManagerTest {
 
   @Test
   public void triggerShouldHandleThrowingOutputHandler() throws Exception {
-    when(storage.getLatestStoredCounter(any())).thenReturn(Optional.empty());
+    Optional<RunState> runState = Optional.of(RunState.create(INSTANCE, State.NEW, NOW, -1));
+    when(storage.readActiveState(INSTANCE)).thenReturn(runState);
+    when(storage.getLatestStoredCounter(any())).thenReturn(Optional.of(-1L));
     when(transaction.workflow(INSTANCE.workflowId())).thenReturn(Optional.of(WORKFLOW));
-    when(transaction.readActiveState(INSTANCE)).thenReturn(Optional.of(INSTANCE_NEW_STATE));
+    when(transaction.readActiveState(INSTANCE)).thenReturn(runState);
     final RuntimeException rootCause = new RuntimeException("foo!");
     doThrow(rootCause).when(outputHandler).transitionInto(any());
     CompletableFuture<Void> f = stateManager.trigger(INSTANCE, TRIGGER1).toCompletableFuture();
@@ -505,8 +554,11 @@ public class QueuedStateManagerTest {
 
   @Test
   public void receiveShouldHandleThrowingOutputHandler() throws Exception {
-    when(transaction.readActiveState(INSTANCE)).thenReturn(Optional.of(RunState.create(INSTANCE,
-        State.QUEUED, StateData.zero(), NOW.minusMillis(1), 17)));
+    Optional<RunState> runState = Optional.of(
+        RunState.create(INSTANCE, State.QUEUED, StateData.zero(), NOW.minusMillis(1), 17));
+    when(transaction.readActiveState(INSTANCE)).thenReturn(runState);
+    when(storage.readActiveState(INSTANCE)).thenReturn(runState);
+    when(storage.getLatestStoredCounter(any())).thenReturn(Optional.of(17L));
 
     final RuntimeException rootCause = new RuntimeException("foo!");
     doThrow(rootCause).when(outputHandler).transitionInto(any());
@@ -522,7 +574,8 @@ public class QueuedStateManagerTest {
   @Test
   public void shouldThrowRuntimeException() throws Exception {
     final IOException exception = new IOException();
-    when(storage.getLatestStoredCounter(any())).thenReturn(Optional.empty());
+    Optional<RunState> runState = Optional.of(RunState.create(INSTANCE, State.NEW, NOW, -1));
+    when(storage.readActiveState(INSTANCE)).thenReturn(runState);
     doThrow(exception).when(storage).runInTransaction(any());
     CompletableFuture<Void> f = stateManager.receive(Event.dequeue(INSTANCE, ImmutableSet.of())).toCompletableFuture();
     try {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
@@ -691,6 +691,23 @@ public class QueuedStateManagerTest {
     verify(transaction, never()).updateCounter(eq(shardedCounter), anyString(), anyInt());
   }
 
+  @Test
+  public void shouldReceiveEventIgnoreClosed() throws IOException, IsClosedException {
+    final QueuedStateManager spied = spy(stateManager);
+    spied.close();
+    givenState(INSTANCE, State.SUBMITTED);
+    spied.receiveIgnoreClosed(Event.started(INSTANCE));
+    verify(spied).ensureRunning();
+  }
+
+  @Test
+  public void shouldReceiveEventIgnoreClosedWithCounter() throws IOException, IsClosedException {
+    final QueuedStateManager spied = spy(stateManager);
+    spied.close();
+    givenState(INSTANCE, State.SUBMITTED);
+    spied.receiveIgnoreClosed(Event.started(INSTANCE), 17);
+    verify(spied).ensureRunning();
+  }
 
   public void givenState(WorkflowInstance instance, State state) throws IOException {
     final RunState runState = RunState.create(instance, state, STATE_DATA_1, NOW.minusMillis(1), 17);


### PR DESCRIPTION
This is a early prototype of an idea to improve slow event processing and spot stale events that were enqueued but should not be processed anymore.

We can either supply the expected counter explicitly according to custom logic (for example according to the current state of active states read at the beginning of a tick) or, as a default behaviour, just read the current counter from Datastore at the moment of enqueueing (no transactions involved).