### PR TITLE
Log type of state that times out

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -179,8 +179,7 @@ public class Scheduler {
             .collect(toCollection(Lists::newArrayList));
     Collections.shuffle(eligibleInstances);
 
-    timedOutInstances.stream().map(wfi -> InstanceState.create(wfi, activeStatesMap.get(wfi)))
-        .collect(toList()).forEach(this::sendTimeout);
+    timedOutInstances.forEach(wfi -> this.sendTimeout(wfi, activeStatesMap.get(wfi)));
 
     limitAndDequeue(config, resources, workflowResourceReferences, currentResourceUsage,
         eligibleInstances);
@@ -380,10 +379,10 @@ public class Scheduler {
     return !deadline.isAfter(now);
   }
 
-  private void sendTimeout(InstanceState instanceState) {
-    LOG.info("Found stale {} state, issuing timeout for {}",
-             instanceState.runState().state().name(), instanceState.workflowInstance());
-    stateManager.receiveIgnoreClosed(Event.timeout(instanceState.workflowInstance()));
+  private void sendTimeout(WorkflowInstance workflowInstance, RunState runState) {
+    LOG.info("Found stale state {} since {} for workflow {}; Issuing a timeout",
+             runState.state(), Instant.ofEpochMilli(runState.timestamp()), workflowInstance);
+    stateManager.receiveIgnoreClosed(Event.timeout(workflowInstance));
   }
 
   @AutoValue


### PR DESCRIPTION
We've observed timeouts being applied potentially too late on a workflow state - when the state has already transitioned forward, so we see the timeout out of order in the events sequence. This PR logs which state the timeout has been applied to. We may in the future want to increase the timeout limit for some states.