### PR TITLE
 Add resourceIds in StateData to propagate and persist them

### DIFF
--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -25,7 +25,7 @@ import static com.spotify.apollo.test.unit.StatusTypeMatchers.belongsToFamily;
 import static com.spotify.styx.api.JsonMatchers.assertJson;
 import static com.spotify.styx.api.JsonMatchers.assertNoJson;
 import static com.spotify.styx.testdata.TestData.EXECUTION_DESCRIPTION;
-import static com.spotify.styx.testdata.TestData.RESOURCE_REFS;
+import static com.spotify.styx.testdata.TestData.RESOURCE_IDS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -325,7 +325,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     WorkflowInstance wfi = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T01");
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T02:00:00Z")).build());
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi, Trigger.backfill("backfill-1")), 1L, 1L));
-    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi, RESOURCE_REFS),                           2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi, RESOURCE_IDS),                            2L, 2L));
     storage.writeEvent(SequenceEvent.create(Event.submit(wfi, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi),                                          5L, 5L));
@@ -507,7 +507,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     WorkflowInstance wfi = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T01");
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T02:00:00Z")).build());
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi, Trigger.backfill("backfill-1")), 1L, 1L));
-    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi, RESOURCE_REFS),                           2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi, RESOURCE_IDS),                            2L, 2L));
     storage.writeEvent(SequenceEvent.create(Event.submit(wfi, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi),                                          5L, 5L));
@@ -539,7 +539,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     WorkflowInstance wfi2 = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T02");
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T03:00:00Z")).build());
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi1, Trigger.backfill("backfill-1")), 1L, 1L));
-    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1, RESOURCE_REFS),                           2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1, RESOURCE_IDS),                            2L, 2L));
     storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi1, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi1),                                          5L, 5L));
@@ -584,13 +584,13 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T03:00:00Z")).build());
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi1, Trigger.backfill("backfill-1")), 1L, 1L));
-    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1, RESOURCE_REFS),                           2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1, RESOURCE_IDS),                            2L, 2L));
     storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi1, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi1),                                          5L, 5L));
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi2, Trigger.backfill("backfill-1")), 1L, 1L));
-    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi2, RESOURCE_REFS),                           2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi2, RESOURCE_IDS),                            2L, 2L));
     storage.writeEvent(SequenceEvent.create(Event.submit(wfi2, EXECUTION_DESCRIPTION, "exec-2"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi2, "exec-2"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi2),                                          5L, 5L));

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -25,6 +25,7 @@ import static com.spotify.apollo.test.unit.StatusTypeMatchers.belongsToFamily;
 import static com.spotify.styx.api.JsonMatchers.assertJson;
 import static com.spotify.styx.api.JsonMatchers.assertNoJson;
 import static com.spotify.styx.testdata.TestData.EXECUTION_DESCRIPTION;
+import static com.spotify.styx.testdata.TestData.RESOURCE_REFS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -324,7 +325,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     WorkflowInstance wfi = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T01");
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T02:00:00Z")).build());
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi, Trigger.backfill("backfill-1")), 1L, 1L));
-    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi),                                          2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi, RESOURCE_REFS),                           2L, 2L));
     storage.writeEvent(SequenceEvent.create(Event.submit(wfi, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi),                                          5L, 5L));
@@ -506,7 +507,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     WorkflowInstance wfi = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T01");
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T02:00:00Z")).build());
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi, Trigger.backfill("backfill-1")), 1L, 1L));
-    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi),                                          2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi, RESOURCE_REFS),                           2L, 2L));
     storage.writeEvent(SequenceEvent.create(Event.submit(wfi, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi),                                          5L, 5L));
@@ -538,7 +539,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     WorkflowInstance wfi2 = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T02");
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T03:00:00Z")).build());
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi1, Trigger.backfill("backfill-1")), 1L, 1L));
-    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1),                                          2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1, RESOURCE_REFS),                           2L, 2L));
     storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi1, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi1),                                          5L, 5L));
@@ -583,13 +584,13 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeBackfill(BACKFILL_1.builder().nextTrigger(Instant.parse("2017-01-01T03:00:00Z")).build());
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi1, Trigger.backfill("backfill-1")), 1L, 1L));
-    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1),                                          2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi1, RESOURCE_REFS),                           2L, 2L));
     storage.writeEvent(SequenceEvent.create(Event.submit(wfi1, EXECUTION_DESCRIPTION, "exec-1"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi1, "exec-1"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi1),                                          5L, 5L));
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(wfi2, Trigger.backfill("backfill-1")), 1L, 1L));
-    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi2),                                          2L, 2L));
+    storage.writeEvent(SequenceEvent.create(Event.dequeue(wfi2, RESOURCE_REFS),                           2L, 2L));
     storage.writeEvent(SequenceEvent.create(Event.submit(wfi2, EXECUTION_DESCRIPTION, "exec-2"),          3L, 3L));
     storage.writeEvent(SequenceEvent.create(Event.submitted(wfi2, "exec-2"),                              4L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(wfi2),                                          5L, 5L));

--- a/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
@@ -38,7 +38,7 @@ public interface EventVisitor<R> {
 
   R triggerExecution(@Getter WorkflowInstance workflowInstance, Trigger trigger);
   R info(@Getter WorkflowInstance workflowInstance, Message message);
-  R dequeue(@Getter WorkflowInstance workflowInstance, @Nullable Set<String> resourceRefs);
+  R dequeue(@Getter WorkflowInstance workflowInstance, @Nullable Set<String> resourceIds);
   R submit(@Getter WorkflowInstance workflowInstance, ExecutionDescription executionDescription,
       @Nullable String executionId);
   R submitted(@Getter WorkflowInstance workflowInstance, @Nullable String executionId);

--- a/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
@@ -38,7 +38,7 @@ public interface EventVisitor<R> {
 
   R triggerExecution(@Getter WorkflowInstance workflowInstance, Trigger trigger);
   R info(@Getter WorkflowInstance workflowInstance, Message message);
-  R dequeue(@Getter WorkflowInstance workflowInstance, @Nullable Set<String> resourceIds);
+  R dequeue(@Getter WorkflowInstance workflowInstance, Set<String> resourceIds);
   R submit(@Getter WorkflowInstance workflowInstance, ExecutionDescription executionDescription,
       @Nullable String executionId);
   R submitted(@Getter WorkflowInstance workflowInstance, @Nullable String executionId);

--- a/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
@@ -26,6 +26,7 @@ import com.github.sviperll.adt4j.Visitor;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.Trigger;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -37,7 +38,7 @@ public interface EventVisitor<R> {
 
   R triggerExecution(@Getter WorkflowInstance workflowInstance, Trigger trigger);
   R info(@Getter WorkflowInstance workflowInstance, Message message);
-  R dequeue(@Getter WorkflowInstance workflowInstance);
+  R dequeue(@Getter WorkflowInstance workflowInstance, Set<String> resourceRefs);
   R submit(@Getter WorkflowInstance workflowInstance, ExecutionDescription executionDescription,
       @Nullable String executionId);
   R submitted(@Getter WorkflowInstance workflowInstance, @Nullable String executionId);

--- a/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
@@ -38,7 +38,7 @@ public interface EventVisitor<R> {
 
   R triggerExecution(@Getter WorkflowInstance workflowInstance, Trigger trigger);
   R info(@Getter WorkflowInstance workflowInstance, Message message);
-  R dequeue(@Getter WorkflowInstance workflowInstance, Set<String> resourceRefs);
+  R dequeue(@Getter WorkflowInstance workflowInstance, @Nullable Set<String> resourceRefs);
   R submit(@Getter WorkflowInstance workflowInstance, ExecutionDescription executionDescription,
       @Nullable String executionId);
   R submitted(@Getter WorkflowInstance workflowInstance, @Nullable String executionId);

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -104,9 +104,9 @@ class WFIExecutionBuilder {
     }
 
     @Override
-    public Void dequeue(WorkflowInstance workflowInstance, Set<String> resourceRefs) {
+    public Void dequeue(WorkflowInstance workflowInstance, Set<String> resourceIds) {
       currWorkflowInstance = workflowInstance;
-      // TODO use resourceRefs somehow?
+      // TODO use resourceIds somehow?
       return null;
     }
 

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -31,6 +31,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 class WFIExecutionBuilder {
@@ -103,8 +104,9 @@ class WFIExecutionBuilder {
     }
 
     @Override
-    public Void dequeue(WorkflowInstance workflowInstance) {
+    public Void dequeue(WorkflowInstance workflowInstance, Set<String> resourceRefs) {
       currWorkflowInstance = workflowInstance;
+      // TODO use resourceRefs somehow?
       return null;
     }
 

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -106,7 +106,6 @@ class WFIExecutionBuilder {
     @Override
     public Void dequeue(WorkflowInstance workflowInstance, Set<String> resourceIds) {
       currWorkflowInstance = workflowInstance;
-      // TODO use resourceIds somehow?
       return null;
     }
 

--- a/styx-common/src/main/java/com/spotify/styx/serialization/PersistentEvent.java
+++ b/styx-common/src/main/java/com/spotify/styx/serialization/PersistentEvent.java
@@ -90,8 +90,8 @@ class PersistentEvent {
     }
 
     @Override
-    public PersistentEvent dequeue(WorkflowInstance workflowInstance, Set<String> resourceRefs) {
-      return new Dequeue(workflowInstance.toKey(), resourceRefs);
+    public PersistentEvent dequeue(WorkflowInstance workflowInstance, Set<String> resourceIds) {
+      return new Dequeue(workflowInstance.toKey(), resourceIds);
     }
 
     @Override
@@ -323,19 +323,19 @@ class PersistentEvent {
 
   public static class Dequeue extends PersistentEvent {
 
-    public final Set<String> resourceRefs;
+    public final Set<String> resourceIds;
 
     @JsonCreator
     public Dequeue(
         @JsonProperty("workflow_instance") String workflowInstance,
-        @JsonProperty("resource_refs") Set<String> resourceRefs) {
+        @JsonProperty("resource_ids") Set<String> resourceIds) {
       super("dequeue", workflowInstance);
-      this.resourceRefs = resourceRefs;
+      this.resourceIds = resourceIds;
     }
 
     @Override
     public Event toEvent() {
-      return Event.dequeue(WorkflowInstance.parseKey(workflowInstance), resourceRefs);
+      return Event.dequeue(WorkflowInstance.parseKey(workflowInstance), resourceIds);
     }
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/serialization/PersistentEvent.java
+++ b/styx-common/src/main/java/com/spotify/styx/serialization/PersistentEvent.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeId;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.google.common.collect.ImmutableSet;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.EventVisitor;
 import com.spotify.styx.model.ExecutionDescription;
@@ -91,7 +92,7 @@ class PersistentEvent {
 
     @Override
     public PersistentEvent dequeue(WorkflowInstance workflowInstance, Set<String> resourceIds) {
-      return new Dequeue(workflowInstance.toKey(), resourceIds);
+      return new Dequeue(workflowInstance.toKey(), Optional.of(resourceIds));
     }
 
     @Override
@@ -328,9 +329,9 @@ class PersistentEvent {
     @JsonCreator
     public Dequeue(
         @JsonProperty("workflow_instance") String workflowInstance,
-        @JsonProperty("resource_ids") Set<String> resourceIds) {
+        @JsonProperty("resource_ids") Optional<Set<String>> resourceIds) {
       super("dequeue", workflowInstance);
-      this.resourceIds = resourceIds;
+      this.resourceIds = resourceIds.orElse(ImmutableSet.of());
     }
 
     @Override

--- a/styx-common/src/main/java/com/spotify/styx/state/RunState.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/RunState.java
@@ -42,6 +42,7 @@ import com.spotify.styx.util.Time;
 import com.spotify.styx.util.TriggerUtil;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * State machine for run states.
@@ -182,13 +183,14 @@ public abstract class RunState {
     }
 
     @Override
-    public RunState dequeue(WorkflowInstance workflowInstance) {
+    public RunState dequeue(WorkflowInstance workflowInstance, Set<String> resourceRefs) {
       switch (state()) {
         case QUEUED:
           return state(
               PREPARE,
               data().builder()
                   .retryDelayMillis(empty())
+                  .resourceRefs(resourceRefs)
                   .build());
 
         default:

--- a/styx-common/src/main/java/com/spotify/styx/state/RunState.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/RunState.java
@@ -183,14 +183,14 @@ public abstract class RunState {
     }
 
     @Override
-    public RunState dequeue(WorkflowInstance workflowInstance, Set<String> resourceRefs) {
+    public RunState dequeue(WorkflowInstance workflowInstance, Set<String> resourceIds) {
       switch (state()) {
         case QUEUED:
           return state(
               PREPARE,
               data().builder()
                   .retryDelayMillis(empty())
-                  .resourceRefs(resourceRefs)
+                  .resourceIds(resourceIds)
                   .build());
 
         default:
@@ -344,7 +344,7 @@ public abstract class RunState {
                   .retryDelayMillis(delayMillis)
                   .executionId(empty())
                   .executionDescription(empty())
-                  .resourceRefs(empty())
+                  .resourceIds(empty())
                   .build());
 
         default:

--- a/styx-common/src/main/java/com/spotify/styx/state/RunState.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/RunState.java
@@ -344,6 +344,7 @@ public abstract class RunState {
                   .retryDelayMillis(delayMillis)
                   .executionId(empty())
                   .executionDescription(empty())
+                  .resourceRefs(empty())
                   .build());
 
         default:

--- a/styx-common/src/main/java/com/spotify/styx/state/StateData.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/StateData.java
@@ -47,7 +47,7 @@ public interface StateData {
   Optional<String> triggerId(); //for backwards compatibility
   Optional<String> executionId();
   Optional<ExecutionDescription> executionDescription();
-  Set<String> resourceRefs(); // resources configured at the time of dequeue
+  Optional<Set<String>> resourceRefs(); // resources configured at the time of dequeue
 
   /**
    * This field is deprecated and kept only for backwards compatibility.

--- a/styx-common/src/main/java/com/spotify/styx/state/StateData.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/StateData.java
@@ -47,7 +47,7 @@ public interface StateData {
   Optional<String> triggerId(); //for backwards compatibility
   Optional<String> executionId();
   Optional<ExecutionDescription> executionDescription();
-  Optional<Set<String>> resourceRefs(); // resources configured at the time of dequeue
+  Optional<Set<String>> resourceIds(); // resources referenced in the workflow configuration at the time of dequeue
 
   /**
    * This field is deprecated and kept only for backwards compatibility.

--- a/styx-common/src/main/java/com/spotify/styx/state/StateData.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/StateData.java
@@ -26,6 +26,7 @@ import com.spotify.styx.model.ExecutionDescription;
 import io.norberg.automatter.AutoMatter;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A value type for holding data related to the various states of the {@link RunState}.
@@ -46,6 +47,7 @@ public interface StateData {
   Optional<String> triggerId(); //for backwards compatibility
   Optional<String> executionId();
   Optional<ExecutionDescription> executionDescription();
+  Set<String> resourceRefs(); // resources configured at the time of dequeue
 
   /**
    * This field is deprecated and kept only for backwards compatibility.

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -388,7 +388,8 @@ class DatastoreStorage {
           .executionId(readOpt(entity, PROPERTY_STATE_EXECUTION_ID))
           .executionDescription(readOptJson(entity, PROPERTY_STATE_EXECUTION_DESCRIPTION,
               ExecutionDescription.class))
-          .resourceIds(readOpt(entity, PROPERTY_STATE_RESOURCE_IDS))
+          .resourceIds(readOptJson(entity, PROPERTY_STATE_RESOURCE_IDS,
+              new TypeReference<Set<String>>() { }))
           .build();
 
       persistentState
@@ -436,6 +437,9 @@ class DatastoreStorage {
 
       if (state.data().executionDescription().isPresent()) {
         entity.set(PROPERTY_STATE_EXECUTION_DESCRIPTION, jsonValue(state.data().executionDescription().get()));
+      }
+      if (state.data().resourceIds().isPresent()) {
+        entity.set(PROPERTY_STATE_RESOURCE_IDS, jsonValue(state.data().resourceIds().get()));
       }
     }
 
@@ -760,6 +764,13 @@ class DatastoreStorage {
   static <T> Optional<T> readOptJson(Entity entity, String property, Class<T> cls) throws IOException {
     return entity.contains(property)
         ? Optional.of(OBJECT_MAPPER.readValue(entity.getString(property), cls))
+        : Optional.empty();
+  }
+
+  static <T> Optional<T> readOptJson(Entity entity, String property, TypeReference valueTypeRef)
+      throws IOException {
+    return entity.contains(property)
+        ? Optional.of(OBJECT_MAPPER.readValue(entity.getString(property), valueTypeRef))
         : Optional.empty();
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -134,6 +134,7 @@ class DatastoreStorage {
   public static final String PROPERTY_STATE_LAST_EXIT = "lastExit";
   public static final String PROPERTY_STATE_EXECUTION_ID = "executionId";
   public static final String PROPERTY_STATE_EXECUTION_DESCRIPTION = "executionDescription";
+  public static final String PROPERTY_STATE_RESOURCE_IDS = "resourceIds";
 
   public static final String KEY_GLOBAL_CONFIG = "styxGlobal";
 
@@ -387,6 +388,7 @@ class DatastoreStorage {
           .executionId(readOpt(entity, PROPERTY_STATE_EXECUTION_ID))
           .executionDescription(readOptJson(entity, PROPERTY_STATE_EXECUTION_DESCRIPTION,
               ExecutionDescription.class))
+          .resourceIds(readOpt(entity, PROPERTY_STATE_RESOURCE_IDS))
           .build();
 
       persistentState

--- a/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
+++ b/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
@@ -38,7 +38,7 @@ public final class TestData {
 
   public static final String VALID_SHA = "00000ef508c1cb905e360590ce3e7e9193f6b370";
   public static final String INVALID_SHA = "XXXXXef508c1cb905e360590ce3e7e9193f6b370";
-  public static final Set<String> RESOURCE_REFS = ImmutableSet.of("foo-resource", "bar-resource");
+  public static final Set<String> RESOURCE_IDS = ImmutableSet.of("foo-resource", "bar-resource");
 
   public static final WorkflowId WORKFLOW_ID =
       WorkflowId.create("styx", "styx.TestEndpoint");

--- a/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
+++ b/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
@@ -26,16 +26,19 @@ import static com.spotify.styx.model.Schedule.MONTHS;
 import static com.spotify.styx.model.Schedule.WEEKS;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowConfiguration.Secret;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
+import java.util.Set;
 
 public final class TestData {
 
   public static final String VALID_SHA = "00000ef508c1cb905e360590ce3e7e9193f6b370";
   public static final String INVALID_SHA = "XXXXXef508c1cb905e360590ce3e7e9193f6b370";
+  public static final Set<String> RESOURCE_REFS = ImmutableSet.of("foo-resource", "bar-resource");
 
   public static final WorkflowId WORKFLOW_ID =
       WorkflowId.create("styx", "styx.TestEndpoint");

--- a/styx-common/src/main/java/com/spotify/styx/util/EventUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/EventUtil.java
@@ -27,6 +27,7 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.Trigger;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -73,7 +74,7 @@ public final class EventUtil {
     }
 
     @Override
-    public String dequeue(WorkflowInstance workflowInstance) {
+    public String dequeue(WorkflowInstance workflowInstance, Set<String> resourceRefs) {
       return "";
     }
 
@@ -156,7 +157,7 @@ public final class EventUtil {
     }
 
     @Override
-    public String dequeue(WorkflowInstance workflowInstance) {
+    public String dequeue(WorkflowInstance workflowInstance, Set<String> resourceRefs) {
       return "dequeue";
     }
 

--- a/styx-common/src/main/java/com/spotify/styx/util/EventUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/EventUtil.java
@@ -74,7 +74,7 @@ public final class EventUtil {
     }
 
     @Override
-    public String dequeue(WorkflowInstance workflowInstance, Set<String> resourceRefs) {
+    public String dequeue(WorkflowInstance workflowInstance, Set<String> resourceIds) {
       return "";
     }
 
@@ -157,7 +157,7 @@ public final class EventUtil {
     }
 
     @Override
-    public String dequeue(WorkflowInstance workflowInstance, Set<String> resourceRefs) {
+    public String dequeue(WorkflowInstance workflowInstance, Set<String> resourceIds) {
       return "dequeue";
     }
 

--- a/styx-common/src/test/java/com/spotify/styx/WorkflowInstanceEventFactory.java
+++ b/styx-common/src/test/java/com/spotify/styx/WorkflowInstanceEventFactory.java
@@ -52,8 +52,8 @@ public class WorkflowInstanceEventFactory {
     return Event.created(workflowInstance, executionId, dockerImage);
   }
 
-  public Event dequeue(Set<String> resourceRefs) {
-    return Event.dequeue(workflowInstance, resourceRefs);
+  public Event dequeue(Set<String> resourceIds) {
+    return Event.dequeue(workflowInstance, resourceIds);
   }
 
   public Event submit(ExecutionDescription executionDescription, String executionId) {

--- a/styx-common/src/test/java/com/spotify/styx/WorkflowInstanceEventFactory.java
+++ b/styx-common/src/test/java/com/spotify/styx/WorkflowInstanceEventFactory.java
@@ -26,6 +26,7 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.Trigger;
 import java.util.Optional;
+import java.util.Set;
 
 public class WorkflowInstanceEventFactory {
 
@@ -51,8 +52,8 @@ public class WorkflowInstanceEventFactory {
     return Event.created(workflowInstance, executionId, dockerImage);
   }
 
-  public Event dequeue() {
-    return Event.dequeue(workflowInstance);
+  public Event dequeue(Set<String> resourceRefs) {
+    return Event.dequeue(workflowInstance, resourceRefs);
   }
 
   public Event submit(ExecutionDescription executionDescription, String executionId) {

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.ImmutableSet;
 import com.spotify.styx.WorkflowInstanceEventFactory;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.SequenceEvent;
@@ -36,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.Test;
 
 public class WFIExecutionBuilderTest {
@@ -48,7 +50,7 @@ public class WFIExecutionBuilderTest {
       UNKNOWN_TRIGGER0 = com.spotify.styx.state.Trigger.unknown("trig0");
   private static final com.spotify.styx.state.Trigger
       UNKNOWN_TRIGGER1 = com.spotify.styx.state.Trigger.unknown("trig1");
-
+  private static final Set<String> RESOURCE_REFS = ImmutableSet.of("foo-resource", "bar-resource");
 
   private ExecutionDescription desc(String dockerImage) {
     return ExecutionDescription.builder()
@@ -129,7 +131,7 @@ public class WFIExecutionBuilderTest {
     long c = 0L;
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
-        SequenceEvent.create(E.dequeue(), c++, ts("07:55")),
+        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("07:55")),
         SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57")),
@@ -144,7 +146,7 @@ public class WFIExecutionBuilderTest {
         SequenceEvent.create(E.success(), c++, ts("08:59")),
 
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER1), c++, ts("09:55")),
-        SequenceEvent.create(E.dequeue(), c++, ts("09:55")),
+        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("09:55")),
         SequenceEvent.create(E.submit(desc("img3"), "exec-id-10"), c++, ts("09:55")),
         SequenceEvent.create(E.submitted("exec-id-10"), c++, ts("09:56")),
         SequenceEvent.create(E.started(), c++, ts("09:57")),
@@ -224,7 +226,7 @@ public class WFIExecutionBuilderTest {
     long c = 0L;
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
-        SequenceEvent.create(E.dequeue(), c++, ts("07:55")),
+        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("07:55")),
         SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57")),
@@ -265,7 +267,7 @@ public class WFIExecutionBuilderTest {
     long c = 0L;
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
-        SequenceEvent.create(E.dequeue(), c++, ts("07:55")),
+        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("07:55")),
         SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57")),
@@ -320,7 +322,7 @@ public class WFIExecutionBuilderTest {
     long c = 0L;
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
-        SequenceEvent.create(E.dequeue(), c++, ts("07:55")),
+        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("07:55")),
         SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.runError("First failure"), c++, ts("07:58")),
         SequenceEvent.create(E.retryAfter(10), c++, ts("07:59")),
@@ -373,13 +375,13 @@ public class WFIExecutionBuilderTest {
     long c = 0L;
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
-        SequenceEvent.create(E.dequeue(), c++, ts("07:55")),
+        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("07:55")),
         SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.halt(), c++, ts("07:57")),
 
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER1), c++, ts("08:56")),
-        SequenceEvent.create(E.dequeue(), c++, ts("08:56")),
+        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("08:56")),
         SequenceEvent.create(E.submit(desc("img2"), "exec-id-10"), c++, ts("08:55")),
         SequenceEvent.create(E.submitted("exec-id-10"), c++, ts("08:56")),
         SequenceEvent.create(E.started(), c++, ts("08:57"))

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
@@ -50,7 +50,7 @@ public class WFIExecutionBuilderTest {
       UNKNOWN_TRIGGER0 = com.spotify.styx.state.Trigger.unknown("trig0");
   private static final com.spotify.styx.state.Trigger
       UNKNOWN_TRIGGER1 = com.spotify.styx.state.Trigger.unknown("trig1");
-  private static final Set<String> RESOURCE_REFS = ImmutableSet.of("foo-resource", "bar-resource");
+  private static final Set<String> RESOURCE_IDS = ImmutableSet.of("foo-resource", "bar-resource");
 
   private ExecutionDescription desc(String dockerImage) {
     return ExecutionDescription.builder()
@@ -131,7 +131,7 @@ public class WFIExecutionBuilderTest {
     long c = 0L;
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
-        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("07:55")),
+        SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("07:55")),
         SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57")),
@@ -146,7 +146,7 @@ public class WFIExecutionBuilderTest {
         SequenceEvent.create(E.success(), c++, ts("08:59")),
 
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER1), c++, ts("09:55")),
-        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("09:55")),
+        SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("09:55")),
         SequenceEvent.create(E.submit(desc("img3"), "exec-id-10"), c++, ts("09:55")),
         SequenceEvent.create(E.submitted("exec-id-10"), c++, ts("09:56")),
         SequenceEvent.create(E.started(), c++, ts("09:57")),
@@ -226,7 +226,7 @@ public class WFIExecutionBuilderTest {
     long c = 0L;
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
-        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("07:55")),
+        SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("07:55")),
         SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57")),
@@ -267,7 +267,7 @@ public class WFIExecutionBuilderTest {
     long c = 0L;
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
-        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("07:55")),
+        SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("07:55")),
         SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57")),
@@ -322,7 +322,7 @@ public class WFIExecutionBuilderTest {
     long c = 0L;
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
-        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("07:55")),
+        SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("07:55")),
         SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.runError("First failure"), c++, ts("07:58")),
         SequenceEvent.create(E.retryAfter(10), c++, ts("07:59")),
@@ -375,13 +375,13 @@ public class WFIExecutionBuilderTest {
     long c = 0L;
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
-        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("07:55")),
+        SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("07:55")),
         SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.halt(), c++, ts("07:57")),
 
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER1), c++, ts("08:56")),
-        SequenceEvent.create(E.dequeue(RESOURCE_REFS), c++, ts("08:56")),
+        SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("08:56")),
         SequenceEvent.create(E.submit(desc("img2"), "exec-id-10"), c++, ts("08:55")),
         SequenceEvent.create(E.submitted("exec-id-10"), c++, ts("08:56")),
         SequenceEvent.create(E.started(), c++, ts("08:57"))

--- a/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
@@ -65,7 +65,7 @@ public class PersistentEventTest {
     assertRoundtrip(Event.info(INSTANCE1, Message.info("InfoMessage")));
     assertRoundtrip(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE));
     assertRoundtrip(Event.dequeue(INSTANCE1, ImmutableSet.of("some-resource")));
-    assertRoundtrip(Event.dequeue(INSTANCE1, null));
+    assertRoundtrip(Event.dequeue(INSTANCE1, ImmutableSet.of()));
     assertRoundtrip(Event.started(INSTANCE1));
     assertRoundtrip(Event.terminate(INSTANCE1, Optional.of(20)));
     assertRoundtrip(Event.runError(INSTANCE1, "ErrorMessage"));
@@ -85,7 +85,7 @@ public class PersistentEventTest {
     assertThat(deserializeEvent(json("dequeue", "\"resource_ids\":[\"quux\"]")),
         is(Event.dequeue(INSTANCE1, ImmutableSet.of("quux"))));
     assertThat(deserializeEvent(json("dequeue")),
-        is(Event.dequeue(INSTANCE1, null)));
+        is(Event.dequeue(INSTANCE1, ImmutableSet.of())));
     assertThat(deserializeEvent(json("started")), is(Event.started(INSTANCE1)));
     assertThat(deserializeEvent(json("success")), is(Event.success(INSTANCE1)));
     assertThat(deserializeEvent(json("retry")), is(Event.retry(INSTANCE1)));

--- a/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
@@ -25,6 +25,7 @@ import static com.spotify.styx.serialization.Json.serialize;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import com.google.common.collect.ImmutableSet;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.WorkflowConfiguration;
@@ -63,7 +64,7 @@ public class PersistentEventTest {
     assertRoundtrip(Event.triggerExecution(INSTANCE1, UNKNOWN_TRIGGER));
     assertRoundtrip(Event.info(INSTANCE1, Message.info("InfoMessage")));
     assertRoundtrip(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE));
-    assertRoundtrip(Event.dequeue(INSTANCE1));
+    assertRoundtrip(Event.dequeue(INSTANCE1, ImmutableSet.of("some-resource")));
     assertRoundtrip(Event.started(INSTANCE1));
     assertRoundtrip(Event.terminate(INSTANCE1, Optional.of(20)));
     assertRoundtrip(Event.runError(INSTANCE1, "ErrorMessage"));
@@ -80,7 +81,8 @@ public class PersistentEventTest {
   @Test
   public void testDeserializeFromJson() throws Exception {
     assertThat(deserializeEvent(json("timeTrigger")), is(Event.timeTrigger(INSTANCE1)));
-    assertThat(deserializeEvent(json("dequeue")), is(Event.dequeue(INSTANCE1)));
+    assertThat(deserializeEvent(json("dequeue", "\"resource_refs\":[\"quux\"]")),
+        is(Event.dequeue(INSTANCE1, ImmutableSet.of("quux"))));
     assertThat(deserializeEvent(json("started")), is(Event.started(INSTANCE1)));
     assertThat(deserializeEvent(json("success")), is(Event.success(INSTANCE1)));
     assertThat(deserializeEvent(json("retry")), is(Event.retry(INSTANCE1)));

--- a/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
@@ -65,6 +65,7 @@ public class PersistentEventTest {
     assertRoundtrip(Event.info(INSTANCE1, Message.info("InfoMessage")));
     assertRoundtrip(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE));
     assertRoundtrip(Event.dequeue(INSTANCE1, ImmutableSet.of("some-resource")));
+    assertRoundtrip(Event.dequeue(INSTANCE1, null));
     assertRoundtrip(Event.started(INSTANCE1));
     assertRoundtrip(Event.terminate(INSTANCE1, Optional.of(20)));
     assertRoundtrip(Event.runError(INSTANCE1, "ErrorMessage"));
@@ -83,6 +84,8 @@ public class PersistentEventTest {
     assertThat(deserializeEvent(json("timeTrigger")), is(Event.timeTrigger(INSTANCE1)));
     assertThat(deserializeEvent(json("dequeue", "\"resource_refs\":[\"quux\"]")),
         is(Event.dequeue(INSTANCE1, ImmutableSet.of("quux"))));
+    assertThat(deserializeEvent(json("dequeue")),
+        is(Event.dequeue(INSTANCE1, null)));
     assertThat(deserializeEvent(json("started")), is(Event.started(INSTANCE1)));
     assertThat(deserializeEvent(json("success")), is(Event.success(INSTANCE1)));
     assertThat(deserializeEvent(json("retry")), is(Event.retry(INSTANCE1)));

--- a/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
@@ -82,7 +82,7 @@ public class PersistentEventTest {
   @Test
   public void testDeserializeFromJson() throws Exception {
     assertThat(deserializeEvent(json("timeTrigger")), is(Event.timeTrigger(INSTANCE1)));
-    assertThat(deserializeEvent(json("dequeue", "\"resource_refs\":[\"quux\"]")),
+    assertThat(deserializeEvent(json("dequeue", "\"resource_ids\":[\"quux\"]")),
         is(Event.dequeue(INSTANCE1, ImmutableSet.of("quux"))));
     assertThat(deserializeEvent(json("dequeue")),
         is(Event.dequeue(INSTANCE1, null)));

--- a/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
@@ -43,7 +43,6 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.Message.MessageLevel;
 import com.spotify.styx.testdata.TestData;
 import com.spotify.styx.util.TriggerUtil;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -98,7 +97,7 @@ public class RunStateTest {
   public void testTimeTriggerAndRetry2() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
+    transitioner.receive(eventFactory.dequeue(null));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, "exec1"));
     transitioner.receive(eventFactory.submitted("exec1"));
     transitioner.receive(eventFactory.started());
@@ -108,7 +107,7 @@ public class RunStateTest {
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(QUEUED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().retryDelayMillis(), hasValue(777L));
 
-    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
+    transitioner.receive(eventFactory.dequeue(null));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, "exec2"));
     transitioner.receive(eventFactory.submitted("exec2"));
     transitioner.receive(eventFactory.started());
@@ -180,7 +179,7 @@ public class RunStateTest {
   public void testSubmitSetsExecutionId() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
+    transitioner.receive(eventFactory.dequeue(null));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, TEST_EXECUTION_ID_1));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTING));
@@ -196,7 +195,7 @@ public class RunStateTest {
 
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retryAfter(999));
-    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
+    transitioner.receive(eventFactory.dequeue(null));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, TEST_EXECUTION_ID_2));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().executionId().get(), equalTo(TEST_EXECUTION_ID_2));
   }
@@ -228,7 +227,7 @@ public class RunStateTest {
   public void testRetryDelayFromQueued() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
+    transitioner.receive(eventFactory.dequeue(null));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retryAfter(777));
 
@@ -240,7 +239,7 @@ public class RunStateTest {
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(QUEUED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().retryDelayMillis(), hasValue(0L));
 
-    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
+    transitioner.receive(eventFactory.dequeue(null));
 
     assertThat(outputs, contains(QUEUED, PREPARE, FAILED, QUEUED, QUEUED, PREPARE));
   }
@@ -489,13 +488,13 @@ public class RunStateTest {
   public void testRunErrorEmitsMessage() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
+    transitioner.receive(eventFactory.dequeue(null));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, TEST_EXECUTION_ID_1));
     transitioner.receive(eventFactory.submitted(TEST_EXECUTION_ID_1));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(20));
     transitioner.receive(eventFactory.retryAfter(0));
-    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
+    transitioner.receive(eventFactory.dequeue(null));
     transitioner.receive(eventFactory.runError("Error"));
 
     final Message expectedMessage = Message.create(MessageLevel.ERROR, "Error");

--- a/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
@@ -41,6 +41,7 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.Message.MessageLevel;
 import com.spotify.styx.testdata.TestData;
 import com.spotify.styx.util.TriggerUtil;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -95,7 +96,7 @@ public class RunStateTest {
   public void testTimeTriggerAndRetry2() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.dequeue());
+    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, "exec1"));
     transitioner.receive(eventFactory.submitted("exec1"));
     transitioner.receive(eventFactory.started());
@@ -105,7 +106,7 @@ public class RunStateTest {
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(QUEUED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().retryDelayMillis(), hasValue(777L));
 
-    transitioner.receive(eventFactory.dequeue());
+    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, "exec2"));
     transitioner.receive(eventFactory.submitted("exec2"));
     transitioner.receive(eventFactory.started());
@@ -177,7 +178,7 @@ public class RunStateTest {
   public void testSubmitSetsExecutionId() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.dequeue());
+    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, TEST_EXECUTION_ID_1));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTING));
@@ -193,7 +194,7 @@ public class RunStateTest {
 
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retryAfter(999));
-    transitioner.receive(eventFactory.dequeue());
+    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, TEST_EXECUTION_ID_2));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().executionId().get(), equalTo(TEST_EXECUTION_ID_2));
   }
@@ -225,7 +226,7 @@ public class RunStateTest {
   public void testRetryDelayFromQueued() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.dequeue());
+    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retryAfter(777));
 
@@ -237,7 +238,7 @@ public class RunStateTest {
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(QUEUED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().retryDelayMillis(), hasValue(0L));
 
-    transitioner.receive(eventFactory.dequeue());
+    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
 
     assertThat(outputs, contains(QUEUED, PREPARE, FAILED, QUEUED, QUEUED, PREPARE));
   }
@@ -486,13 +487,13 @@ public class RunStateTest {
   public void testRunErrorEmitsMessage() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.dequeue());
+    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, TEST_EXECUTION_ID_1));
     transitioner.receive(eventFactory.submitted(TEST_EXECUTION_ID_1));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(20));
     transitioner.receive(eventFactory.retryAfter(0));
-    transitioner.receive(eventFactory.dequeue());
+    transitioner.receive(eventFactory.dequeue(Collections.emptySet()));
     transitioner.receive(eventFactory.runError("Error"));
 
     final Message expectedMessage = Message.create(MessageLevel.ERROR, "Error");

--- a/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
@@ -97,7 +97,7 @@ public class RunStateTest {
   public void testTimeTriggerAndRetry2() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.dequeue(null));
+    transitioner.receive(eventFactory.dequeue(ImmutableSet.of()));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, "exec1"));
     transitioner.receive(eventFactory.submitted("exec1"));
     transitioner.receive(eventFactory.started());
@@ -107,7 +107,7 @@ public class RunStateTest {
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(QUEUED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().retryDelayMillis(), hasValue(777L));
 
-    transitioner.receive(eventFactory.dequeue(null));
+    transitioner.receive(eventFactory.dequeue(ImmutableSet.of()));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, "exec2"));
     transitioner.receive(eventFactory.submitted("exec2"));
     transitioner.receive(eventFactory.started());
@@ -179,7 +179,7 @@ public class RunStateTest {
   public void testSubmitSetsExecutionId() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.dequeue(null));
+    transitioner.receive(eventFactory.dequeue(ImmutableSet.of()));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, TEST_EXECUTION_ID_1));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTING));
@@ -195,7 +195,7 @@ public class RunStateTest {
 
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retryAfter(999));
-    transitioner.receive(eventFactory.dequeue(null));
+    transitioner.receive(eventFactory.dequeue(ImmutableSet.of()));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, TEST_EXECUTION_ID_2));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().executionId().get(), equalTo(TEST_EXECUTION_ID_2));
   }
@@ -227,7 +227,7 @@ public class RunStateTest {
   public void testRetryDelayFromQueued() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.dequeue(null));
+    transitioner.receive(eventFactory.dequeue(ImmutableSet.of()));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retryAfter(777));
 
@@ -239,7 +239,7 @@ public class RunStateTest {
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(QUEUED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().retryDelayMillis(), hasValue(0L));
 
-    transitioner.receive(eventFactory.dequeue(null));
+    transitioner.receive(eventFactory.dequeue(ImmutableSet.of()));
 
     assertThat(outputs, contains(QUEUED, PREPARE, FAILED, QUEUED, QUEUED, PREPARE));
   }
@@ -488,13 +488,13 @@ public class RunStateTest {
   public void testRunErrorEmitsMessage() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.dequeue(null));
+    transitioner.receive(eventFactory.dequeue(ImmutableSet.of()));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, TEST_EXECUTION_ID_1));
     transitioner.receive(eventFactory.submitted(TEST_EXECUTION_ID_1));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(20));
     transitioner.receive(eventFactory.retryAfter(0));
-    transitioner.receive(eventFactory.dequeue(null));
+    transitioner.receive(eventFactory.dequeue(ImmutableSet.of()));
     transitioner.receive(eventFactory.runError("Error"));
 
     final Message expectedMessage = Message.create(MessageLevel.ERROR, "Error");

--- a/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
@@ -568,7 +568,7 @@ public class RunStateTest {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
 
-    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceRefs(), isEmpty());
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceIds(), isEmpty());
 
     transitioner.receive(eventFactory.dequeue(ImmutableSet.of("r1")));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, "exec1"));
@@ -577,15 +577,15 @@ public class RunStateTest {
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(FAILED));
-    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceRefs(), hasValue(contains("r1")));
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceIds(), hasValue(contains("r1")));
 
     transitioner.receive(eventFactory.retryAfter(12));
 
-    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceRefs(), isEmpty());
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceIds(), isEmpty());
 
     transitioner.receive(eventFactory.dequeue(ImmutableSet.of("r2")));
 
-    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceRefs(), hasValue(contains("r2")));
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceIds(), hasValue(contains("r2")));
   }
 
   @Test
@@ -593,7 +593,7 @@ public class RunStateTest {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
 
-    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceRefs(), isEmpty());
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceIds(), isEmpty());
 
     transitioner.receive(eventFactory.dequeue(ImmutableSet.of("r1")));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, "exec1"));
@@ -602,7 +602,7 @@ public class RunStateTest {
     transitioner.receive(eventFactory.terminate(RunState.MISSING_DEPS_EXIT_CODE));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(TERMINATED));
-    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceRefs(), hasValue(contains("r1")));
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceIds(), hasValue(contains("r1")));
   }
 
   @Test
@@ -610,14 +610,14 @@ public class RunStateTest {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
 
-    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceRefs(), isEmpty());
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceIds(), isEmpty());
 
     transitioner.receive(eventFactory.dequeue(ImmutableSet.of("r1")));
     transitioner.receive(eventFactory.submit(EXECUTION_DESCRIPTION, "exec1"));
     transitioner.receive(eventFactory.timeout());
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(FAILED));
-    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceRefs(), hasValue(contains("r1")));
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceIds(), hasValue(contains("r1")));
   }
 
   @Test
@@ -625,11 +625,11 @@ public class RunStateTest {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
 
-    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceRefs(), isEmpty());
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceIds(), isEmpty());
 
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(FAILED));
-    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceRefs(), isEmpty());
+    assertThat(transitioner.get(WORKFLOW_INSTANCE).data().resourceIds(), isEmpty());
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -58,6 +58,7 @@ import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StringValue;
 import com.google.cloud.datastore.Transaction;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import com.google.common.collect.ImmutableSet;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.StyxConfig;
@@ -154,6 +155,7 @@ public class DatastoreStorageTest {
               .serviceAccount("foo@bar.baz")
               .commitSha("2d2bfa926b94508de5aab47b5f305659ead2274a")
               .build())
+          .resourceIds(ImmutableSet.of("GLOBAL_STYX_CLUSTER", "foo-resource", "bar-resource"))
           .addMessage(Message.info("foo"))
           .addMessage(Message.warning("bar"))
           .addMessage(Message.error("baz"))

--- a/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
@@ -27,7 +27,7 @@ import static com.spotify.styx.state.RunState.State.DONE;
 import static com.spotify.styx.state.RunState.State.RUNNING;
 import static com.spotify.styx.state.RunState.State.SUBMITTED;
 import static com.spotify.styx.testdata.TestData.EXECUTION_DESCRIPTION;
-import static com.spotify.styx.testdata.TestData.RESOURCE_REFS;
+import static com.spotify.styx.testdata.TestData.RESOURCE_IDS;
 import static com.spotify.styx.testdata.TestData.WORKFLOW_INSTANCE;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -70,7 +70,7 @@ public class ReplayEventsTest {
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.natural()),        0L, 0L));
     events.add(SequenceEvent.create(Event.halt(WORKFLOW_INSTANCE),                                       1L, 1L));
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.backfill("bf-1")), 2L, 2L));
-    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_REFS),                     3L, 3L));
+    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_IDS),                      3L, 3L));
     events.add(SequenceEvent.create(Event.submit(WORKFLOW_INSTANCE, EXECUTION_DESCRIPTION, "exec-1"),    4L, 4L));
     events.add(SequenceEvent.create(Event.submitted(WORKFLOW_INSTANCE, "exec-1"),                        5L, 5L));
     events.add(SequenceEvent.create(Event.started(WORKFLOW_INSTANCE),                                    6L, 6L));
@@ -91,14 +91,14 @@ public class ReplayEventsTest {
   public void restoreRunStateForInactiveBackfill() throws Exception {
     SortedSet<SequenceEvent> events = newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.backfill("bf-1")), 1L, 1L));
-    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_REFS),                                    2L, 2L));
+    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_IDS),                      2L, 2L));
     events.add(SequenceEvent.create(Event.submit(WORKFLOW_INSTANCE, EXECUTION_DESCRIPTION, "exec-1"),    3L, 3L));
     events.add(SequenceEvent.create(Event.submitted(WORKFLOW_INSTANCE, "exec-1"),                        4L, 4L));
     events.add(SequenceEvent.create(Event.started(WORKFLOW_INSTANCE),                                    5L, 5L));
     events.add(SequenceEvent.create(Event.terminate(WORKFLOW_INSTANCE, Optional.of(0)),                  6L, 6L));
     events.add(SequenceEvent.create(Event.success(WORKFLOW_INSTANCE),                                    7L, 7L));
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.adhoc("ad-hoc")),  8L, 8L));
-    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_REFS),                     9L, 9L));
+    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_IDS),                      9L, 9L));
     events.add(SequenceEvent.create(Event.halt(WORKFLOW_INSTANCE),                                     10L, 10L));
 
     when(storage.readEvents(WORKFLOW_INSTANCE)).thenReturn(events);
@@ -115,7 +115,7 @@ public class ReplayEventsTest {
   public void returnsEmptyWithMissingBackfill() throws Exception {
     SortedSet<SequenceEvent> events = newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.backfill("bf-1")), 1L, 1L));
-    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_REFS),                     2L, 2L));
+    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_IDS),                      2L, 2L));
 
     when(storage.readEvents(WORKFLOW_INSTANCE)).thenReturn(events);
 
@@ -137,7 +137,7 @@ public class ReplayEventsTest {
   public void restoreRunStateForActiveInstance(long counter, State expectedState, boolean printLogs) throws Exception {
     SortedSet<SequenceEvent> events = newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.natural()),        0L, 0L));
-    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_REFS),                     1L, 1L));
+    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_IDS),                      1L, 1L));
     events.add(SequenceEvent.create(Event.submit(WORKFLOW_INSTANCE, EXECUTION_DESCRIPTION, "exec-1"),    2L, 2L));
     events.add(SequenceEvent.create(Event.submitted(WORKFLOW_INSTANCE, "exec-1"),                        3L, 3L));
     events.add(SequenceEvent.create(Event.started(WORKFLOW_INSTANCE),                                    4L, 4L));

--- a/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
@@ -27,6 +27,7 @@ import static com.spotify.styx.state.RunState.State.DONE;
 import static com.spotify.styx.state.RunState.State.RUNNING;
 import static com.spotify.styx.state.RunState.State.SUBMITTED;
 import static com.spotify.styx.testdata.TestData.EXECUTION_DESCRIPTION;
+import static com.spotify.styx.testdata.TestData.RESOURCE_REFS;
 import static com.spotify.styx.testdata.TestData.WORKFLOW_INSTANCE;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -69,7 +70,7 @@ public class ReplayEventsTest {
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.natural()),        0L, 0L));
     events.add(SequenceEvent.create(Event.halt(WORKFLOW_INSTANCE),                                       1L, 1L));
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.backfill("bf-1")), 2L, 2L));
-    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE),                                    3L, 3L));
+    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_REFS),                     3L, 3L));
     events.add(SequenceEvent.create(Event.submit(WORKFLOW_INSTANCE, EXECUTION_DESCRIPTION, "exec-1"),    4L, 4L));
     events.add(SequenceEvent.create(Event.submitted(WORKFLOW_INSTANCE, "exec-1"),                        5L, 5L));
     events.add(SequenceEvent.create(Event.started(WORKFLOW_INSTANCE),                                    6L, 6L));
@@ -90,14 +91,14 @@ public class ReplayEventsTest {
   public void restoreRunStateForInactiveBackfill() throws Exception {
     SortedSet<SequenceEvent> events = newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.backfill("bf-1")), 1L, 1L));
-    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE),                                    2L, 2L));
+    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_REFS),                                    2L, 2L));
     events.add(SequenceEvent.create(Event.submit(WORKFLOW_INSTANCE, EXECUTION_DESCRIPTION, "exec-1"),    3L, 3L));
     events.add(SequenceEvent.create(Event.submitted(WORKFLOW_INSTANCE, "exec-1"),                        4L, 4L));
     events.add(SequenceEvent.create(Event.started(WORKFLOW_INSTANCE),                                    5L, 5L));
     events.add(SequenceEvent.create(Event.terminate(WORKFLOW_INSTANCE, Optional.of(0)),                  6L, 6L));
     events.add(SequenceEvent.create(Event.success(WORKFLOW_INSTANCE),                                    7L, 7L));
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.adhoc("ad-hoc")),  8L, 8L));
-    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE),                                    9L, 9L));
+    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_REFS),                     9L, 9L));
     events.add(SequenceEvent.create(Event.halt(WORKFLOW_INSTANCE),                                     10L, 10L));
 
     when(storage.readEvents(WORKFLOW_INSTANCE)).thenReturn(events);
@@ -114,7 +115,7 @@ public class ReplayEventsTest {
   public void returnsEmptyWithMissingBackfill() throws Exception {
     SortedSet<SequenceEvent> events = newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.backfill("bf-1")), 1L, 1L));
-    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE),                                    2L, 2L));
+    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_REFS),                     2L, 2L));
 
     when(storage.readEvents(WORKFLOW_INSTANCE)).thenReturn(events);
 
@@ -136,7 +137,7 @@ public class ReplayEventsTest {
   public void restoreRunStateForActiveInstance(long counter, State expectedState, boolean printLogs) throws Exception {
     SortedSet<SequenceEvent> events = newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
     events.add(SequenceEvent.create(Event.triggerExecution(WORKFLOW_INSTANCE, Trigger.natural()),        0L, 0L));
-    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE),                                    1L, 1L));
+    events.add(SequenceEvent.create(Event.dequeue(WORKFLOW_INSTANCE, RESOURCE_REFS),                     1L, 1L));
     events.add(SequenceEvent.create(Event.submit(WORKFLOW_INSTANCE, EXECUTION_DESCRIPTION, "exec-1"),    2L, 2L));
     events.add(SequenceEvent.create(Event.submitted(WORKFLOW_INSTANCE, "exec-1"),                        3L, 3L));
     events.add(SequenceEvent.create(Event.started(WORKFLOW_INSTANCE),                                    4L, 4L));

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -269,7 +269,7 @@ public class Scheduler {
     final Set<String> workflowResourceRefs =
         workflowResourceReferences.getOrDefault(instance.workflowInstance().workflowId(), emptySet());
 
-    // TODO persist instanceResourceRefs in persistent state
+    // TODO move to ShardedCounter being authoritative for resource accounting
     final Set<String> instanceResourceRefs = workflowCache.workflow(instance.workflowInstance().workflowId())
         .map(workflow -> resourceDecorator.decorateResources(
             instance.runState(), workflow.configuration(), workflowResourceRefs))
@@ -355,7 +355,7 @@ public class Scheduler {
     return !deadline.isAfter(now);
   }
 
-  private void sendDequeue(InstanceState instanceState, Set<String> resourceRefs) {
+  private void sendDequeue(InstanceState instanceState, Set<String> resourceIds) {
     final WorkflowInstance workflowInstance = instanceState.workflowInstance();
     final RunState state = instanceState.runState();
 
@@ -364,7 +364,7 @@ public class Scheduler {
     } else {
       LOG.info("{} executing retry #{}", workflowInstance.toKey(), state.data().tries());
     }
-    stateManager.receiveIgnoreClosed(Event.dequeue(workflowInstance, resourceRefs));
+    stateManager.receiveIgnoreClosed(Event.dequeue(workflowInstance, resourceIds));
   }
 
   private boolean hasTimedOut(RunState runState) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -269,6 +269,7 @@ public class Scheduler {
     final Set<String> workflowResourceRefs =
         workflowResourceReferences.getOrDefault(instance.workflowInstance().workflowId(), emptySet());
 
+    // TODO persist instanceResourceRefs in persistent state
     final Set<String> instanceResourceRefs = workflowCache.workflow(instance.workflowInstance().workflowId())
         .map(workflow -> resourceDecorator.decorateResources(
             instance.runState(), workflow.configuration(), workflowResourceRefs))
@@ -313,7 +314,7 @@ public class Scheduler {
       }
       instanceResourceRefs.forEach(id -> currentResourceUsage.computeIfAbsent(id, id_ -> 0L));
       instanceResourceRefs.forEach(id -> currentResourceUsage.compute(id, (id_, l) -> l + 1));
-      sendDequeue(instance);
+      sendDequeue(instance, instanceResourceRefs);
     }
 
     return true;
@@ -354,7 +355,7 @@ public class Scheduler {
     return !deadline.isAfter(now);
   }
 
-  private void sendDequeue(InstanceState instanceState) {
+  private void sendDequeue(InstanceState instanceState, Set<String> resourceRefs) {
     final WorkflowInstance workflowInstance = instanceState.workflowInstance();
     final RunState state = instanceState.runState();
 
@@ -363,7 +364,7 @@ public class Scheduler {
     } else {
       LOG.info("{} executing retry #{}", workflowInstance.toKey(), state.data().tries());
     }
-    stateManager.receiveIgnoreClosed(Event.dequeue(workflowInstance));
+    stateManager.receiveIgnoreClosed(Event.dequeue(workflowInstance, resourceRefs));
   }
 
   private boolean hasTimedOut(RunState runState) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -358,7 +358,7 @@ class KubernetesDockerRunner implements DockerRunner {
     }
   }
 
-  private void cleanup(WorkflowInstance workflowInstance, String executionId, 
+  private void cleanup(WorkflowInstance workflowInstance, String executionId,
                        Consumer<Pod> cleaner) {
     Optional.ofNullable(client.pods().withName(executionId).get()).ifPresent(pod -> {
       final List<ContainerStatus> containerStatuses = pod.getStatus().getContainerStatuses();
@@ -370,12 +370,12 @@ class KubernetesDockerRunner implements DockerRunner {
       }
     });
   }
-  
+
   static Optional<ContainerStatus> getStyxContainer(Pod pod) {
     return readPodWorkflowInstance(pod)
         .flatMap(wfi -> pod.getStatus().getContainerStatuses().stream().findFirst());
   }
-  
+
   private boolean isNonDeletePeriodExpired(ContainerStatus containerStatus) {
     return Optional.ofNullable(containerStatus.getState().getTerminated().getFinishedAt())
         .map(finishedAt -> Instant.parse(finishedAt)
@@ -383,7 +383,7 @@ class KubernetesDockerRunner implements DockerRunner {
                 Duration.ofSeconds(podDeletionDelaySeconds))))
         .orElse(true);
   }
-  
+
   private void deletePod(WorkflowInstance workflowInstance, String executionId) {
     if (!debug.get()) {
       client.pods().withName(executionId).delete();
@@ -632,7 +632,7 @@ class KubernetesDockerRunner implements DockerRunner {
     }
 
     @Override
-    public Boolean dequeue(WorkflowInstance workflowInstance) {
+    public Boolean dequeue(WorkflowInstance workflowInstance, Set<String> resourceRefs) {
       return false;
     }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -632,7 +632,7 @@ class KubernetesDockerRunner implements DockerRunner {
     }
 
     @Override
-    public Boolean dequeue(WorkflowInstance workflowInstance, Set<String> resourceRefs) {
+    public Boolean dequeue(WorkflowInstance workflowInstance, Set<String> resourceIds) {
       return false;
     }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -582,7 +582,8 @@ public class SchedulerTest {
     verify(stateManager).receiveIgnoreClosed(Event.info(INSTANCE_1,
         Message.info("Resource limit reached for: [Resource{id=baz, concurrency=0}]")));
 
-    verify(stateManager, never()).receiveIgnoreClosed(Event.dequeue(INSTANCE_1, ImmutableSet.of("foo", "bar", "baz", "GLOBAL_STYX_CLUSTER")));
+    verify(stateManager, never()).receiveIgnoreClosed(Event.dequeue(INSTANCE_1,
+        ImmutableSet.of("foo", "bar", "baz", "GLOBAL_STYX_CLUSTER")));
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -93,7 +93,6 @@ public class SchedulerTest {
       WorkflowId.create("styx2", "example2");
   private static final WorkflowInstance INSTANCE_1 =
       WorkflowInstance.create(WORKFLOW_ID1, "2016-12-02T01");
-  private static final Set<String> RESOURCE_REFS = ImmutableSet.of("foo-resource", "bar-resource");
 
   private WorkflowCache workflowCache;
   private Scheduler scheduler;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
@@ -28,6 +28,7 @@ import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
 import static com.spotify.styx.serialization.Json.serialize;
 import static com.spotify.styx.testdata.TestData.FULL_WORKFLOW_CONFIGURATION;
 import static com.spotify.styx.testdata.TestData.INVALID_SHA;
+import static com.spotify.styx.testdata.TestData.RESOURCE_REFS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -200,7 +201,7 @@ public class SchedulerResourceTest {
 
   @Test
   public void testInjectDequeueEvent() throws Exception {
-    Event injectedEvent = Event.dequeue(WFI);
+    Event injectedEvent = Event.dequeue(WFI, RESOURCE_REFS);
     ByteString eventPayload = serialize(injectedEvent);
     CompletionStage<Response<ByteString>> post =
         serviceHelper.request("POST", BASE + "/events", eventPayload);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
@@ -28,7 +28,7 @@ import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
 import static com.spotify.styx.serialization.Json.serialize;
 import static com.spotify.styx.testdata.TestData.FULL_WORKFLOW_CONFIGURATION;
 import static com.spotify.styx.testdata.TestData.INVALID_SHA;
-import static com.spotify.styx.testdata.TestData.RESOURCE_REFS;
+import static com.spotify.styx.testdata.TestData.RESOURCE_IDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -201,7 +201,7 @@ public class SchedulerResourceTest {
 
   @Test
   public void testInjectDequeueEvent() throws Exception {
-    Event injectedEvent = Event.dequeue(WFI, RESOURCE_REFS);
+    Event injectedEvent = Event.dequeue(WFI, RESOURCE_IDS);
     ByteString eventPayload = serialize(injectedEvent);
     CompletionStage<Response<ByteString>> post =
         serviceHelper.request("POST", BASE + "/events", eventPayload);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
@@ -428,14 +428,14 @@ public class QueuedStateManagerTest {
         .data(StateData.zero())
         .build()));
 
-    stateManager.receive(Event.dequeue(INSTANCE, null))
+    stateManager.receive(Event.dequeue(INSTANCE, ImmutableSet.of()))
         .toCompletableFuture().get(1, MINUTES);
 
     verify(transaction).updateActiveState(INSTANCE, PersistentWorkflowInstanceState.builder()
         .counter(18)
         .timestamp(NOW)
         .state(State.PREPARE)
-        .data(StateData.zero())
+        .data(StateData.newBuilder().resourceIds(ImmutableSet.of()).build())
         .build());
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
@@ -428,7 +428,7 @@ public class QueuedStateManagerTest {
         .data(StateData.zero())
         .build()));
 
-    stateManager.receive(Event.dequeue(INSTANCE, ImmutableSet.of()))
+    stateManager.receive(Event.dequeue(INSTANCE, null))
         .toCompletableFuture().get(1, MINUTES);
 
     verify(transaction).updateActiveState(INSTANCE, PersistentWorkflowInstanceState.builder()

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.datastore.DatastoreException;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.spotify.styx.RepeatRule;
 import com.spotify.styx.model.Event;
@@ -335,7 +336,7 @@ public class QueuedStateManagerTest {
       return a.getArgumentAt(0, TransactionFunction.class).apply(transaction);
     });
 
-    CompletableFuture<Void> f = stateManager.receive(Event.dequeue(INSTANCE))
+    CompletableFuture<Void> f = stateManager.receive(Event.dequeue(INSTANCE, ImmutableSet.of()))
         .toCompletableFuture();
 
     CompletableFuture.runAsync(() -> {
@@ -427,7 +428,7 @@ public class QueuedStateManagerTest {
         .data(StateData.zero())
         .build()));
 
-    stateManager.receive(Event.dequeue(INSTANCE))
+    stateManager.receive(Event.dequeue(INSTANCE, ImmutableSet.of()))
         .toCompletableFuture().get(1, MINUTES);
 
     verify(transaction).updateActiveState(INSTANCE, PersistentWorkflowInstanceState.builder()
@@ -537,7 +538,7 @@ public class QueuedStateManagerTest {
 
     final RuntimeException rootCause = new RuntimeException("foo!");
     doThrow(rootCause).when(outputHandler).transitionInto(any());
-    CompletableFuture<Void> f = stateManager.receive(Event.dequeue(INSTANCE)).toCompletableFuture();
+    CompletableFuture<Void> f = stateManager.receive(Event.dequeue(INSTANCE, ImmutableSet.of())).toCompletableFuture();
     try {
       f.get(1, MINUTES);
       fail();
@@ -551,7 +552,7 @@ public class QueuedStateManagerTest {
     final IOException exception = new IOException();
     when(storage.getLatestStoredCounter(any())).thenReturn(Optional.empty());
     doThrow(exception).when(storage).runInTransaction(any());
-    CompletableFuture<Void> f = stateManager.receive(Event.dequeue(INSTANCE)).toCompletableFuture();
+    CompletableFuture<Void> f = stateManager.receive(Event.dequeue(INSTANCE, ImmutableSet.of())).toCompletableFuture();
     try {
       f.get(1, MINUTES);
       fail();


### PR DESCRIPTION
Needed for upcoming use of ShardedCounters (https://github.com/spotify/styx/pull/378) - so that we can consistently decrement the right resources (that were incremented upon dequeue), when the execution finishes.