### PR TITLE
Shardedcounter refactoring

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -117,7 +117,8 @@ public class StyxApi implements AppInit {
     final BackfillResource backfillResource = new BackfillResource(schedulerServiceBaseUrl,
                                                                    storage,
                                                                    new WorkflowValidator(new DockerImageValidator()));
-    final ResourceResource resourceResource = new ResourceResource(storage);
+    final ShardedCounter shardedCounter = new ShardedCounter(storage);
+    final ResourceResource resourceResource = new ResourceResource(storage, shardedCounter);
     final StatusResource statusResource = new StatusResource(storage);
     final SchedulerProxyResource schedulerProxyResource = new SchedulerProxyResource(
         schedulerServiceBaseUrl, environment.client());
@@ -146,7 +147,6 @@ public class StyxApi implements AppInit {
 
     final Connection bigTable = closer.register(createBigTableConnection(config));
     final Datastore datastore = createDatastore(config);
-    final ShardedCounter shardedCounter = new ShardedCounter(datastore);
-    return new AggregateStorage(bigTable, datastore, DEFAULT_RETRY_BASE_DELAY_BT, shardedCounter);
+    return new AggregateStorage(bigTable, datastore, DEFAULT_RETRY_BASE_DELAY_BT);
   }
 }

--- a/styx-api-service/src/main/java/com/spotify/styx/api/ResourceResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/ResourceResource.java
@@ -34,6 +34,7 @@ import com.spotify.apollo.route.Route;
 import com.spotify.styx.model.Resource;
 import com.spotify.styx.serialization.Json;
 import com.spotify.styx.storage.Storage;
+import com.spotify.styx.util.ShardedCounter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -45,9 +46,11 @@ public final class ResourceResource {
   static final String BASE = "/resources";
 
   private final Storage storage;
+  private ShardedCounter shardedCounter;
 
-  public ResourceResource(Storage storage) {
+  public ResourceResource(Storage storage, ShardedCounter shardedCounter) {
     this.storage = Objects.requireNonNull(storage);
+    this.shardedCounter = shardedCounter;
   }
 
   public Stream<Route<AsyncHandler<Response<ByteString>>>> routes() {
@@ -111,6 +114,10 @@ public final class ResourceResource {
   private Resource postResource(Resource resource) {
     try {
       storage.storeResource(resource);
+      storage.runInTransaction(tx -> {
+        shardedCounter.updateLimit(tx, resource.id(), resource.concurrency());
+        return null;
+      });
       return resource;
     } catch (IOException e) {
       throw Throwables.propagate(e);
@@ -125,6 +132,10 @@ public final class ResourceResource {
 
     try {
       storage.storeResource(resource);
+      storage.runInTransaction(tx -> {
+        shardedCounter.updateLimit(tx, resource.id(), resource.concurrency());
+        return null;
+      });
     } catch (IOException e) {
       return Response
           .forStatus(

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -137,7 +137,7 @@ public class BackfillResourceTest extends VersionedApiTest {
   @Override
   protected void init(Environment environment) {
     storage = new AggregateStorage(bigtable, localDatastore.getOptions().getService(),
-                                   Duration.ZERO, shardedCounter);
+                                   Duration.ZERO);
 
     environment.routingEngine()
         .registerRoutes(Api.withCommonMiddleware(

--- a/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
@@ -76,9 +76,9 @@ public class ResourceResourceTest extends VersionedApiTest {
     storage = new AggregateStorage(
         mock(Connection.class),
         localDatastore.getOptions().getService(),
-        Duration.ZERO, shardedCounter);
+        Duration.ZERO);
 
-    ResourceResource resourceResource = new ResourceResource(storage);
+    ResourceResource resourceResource = new ResourceResource(storage, shardedCounter);
 
     environment.routingEngine()
         .registerRoutes(Api.withCommonMiddleware(

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -126,7 +126,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Override
   protected void init(Environment environment) {
-    storage = new AggregateStorage(bigtable, datastore, Duration.ZERO, shardedCounter);
+    storage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
     when(workflowValidator.validateWorkflow(any())).thenReturn(Collections.emptyList());
     when(workflowValidator.validateWorkflowConfiguration(any())).thenReturn(Collections.emptyList());
     WorkflowResource workflowResource = new WorkflowResource(storage, SCHEDULER_BASE, workflowValidator,

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -216,7 +216,7 @@ public class AggregateStorage implements Storage {
 
   @Override
   public void deleteShardsForCounter(String counterId) {
-
+    datastoreStorage.deleteShardsForCounter(counterId);
   }
 
   @Override
@@ -257,5 +257,10 @@ public class AggregateStorage implements Storage {
   @Override
   public <T, E extends Exception> T runInTransaction(TransactionFunction<T, E> f) throws IOException, E {
     return datastoreStorage.runInTransaction(f);
+  }
+
+  @Override
+  public void deleteLimitForCounter(String counterId) throws IOException {
+    datastoreStorage.deleteLimitForCounter(counterId);
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -31,7 +31,6 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
 import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import com.spotify.styx.serialization.PersistentWorkflowInstanceState;
-import com.spotify.styx.util.ShardedCounter;
 import com.spotify.styx.util.TriggerInstantSpec;
 import java.io.IOException;
 import java.time.Duration;
@@ -51,10 +50,9 @@ public class AggregateStorage implements Storage {
   private final BigtableStorage bigtableStorage;
   private final DatastoreStorage datastoreStorage;
 
-  public AggregateStorage(Connection connection, Datastore datastore, Duration retryBaseDelay,
-                          ShardedCounter shardedCounter) {
+  public AggregateStorage(Connection connection, Datastore datastore, Duration retryBaseDelay) {
     this(new BigtableStorage(connection, retryBaseDelay),
-         new DatastoreStorage(datastore, retryBaseDelay, shardedCounter));
+         new DatastoreStorage(datastore, retryBaseDelay));
   }
 
   AggregateStorage(BigtableStorage bigtableStorage, DatastoreStorage datastoreStorage) {
@@ -209,6 +207,21 @@ public class AggregateStorage implements Storage {
   @Override
   public void storeBackfill(Backfill backfill) throws IOException {
     datastoreStorage.storeBackfill(backfill);
+  }
+
+  @Override
+  public Map<Integer, Long> shardsForCounter(String counterId) {
+    return datastoreStorage.shardsForCounter(counterId);
+  }
+
+  @Override
+  public void deleteShardsForCounter(String counterId) {
+
+  }
+
+  @Override
+  public long getLimitForCounter(String counterId) {
+    return datastoreStorage.getLimitForCounter(counterId);
   }
 
   @Override

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -21,6 +21,13 @@
 package com.spotify.styx.storage;
 
 import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
+import static com.spotify.styx.util.ShardedCounter.KIND_COUNTER_LIMIT;
+import static com.spotify.styx.util.ShardedCounter.KIND_COUNTER_SHARD;
+import static com.spotify.styx.util.ShardedCounter.NUM_SHARDS;
+import static com.spotify.styx.util.ShardedCounter.PROPERTY_COUNTER_ID;
+import static com.spotify.styx.util.ShardedCounter.PROPERTY_LIMIT;
+import static com.spotify.styx.util.ShardedCounter.PROPERTY_SHARD_INDEX;
+import static com.spotify.styx.util.ShardedCounter.PROPERTY_SHARD_VALUE;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -64,7 +71,6 @@ import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.util.FnWithException;
 import com.spotify.styx.util.ResourceNotFoundException;
-import com.spotify.styx.util.ShardedCounter;
 import com.spotify.styx.util.TimeUtil;
 import com.spotify.styx.util.TriggerInstantSpec;
 import com.spotify.styx.util.TriggerUtil;
@@ -73,6 +79,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -86,7 +93,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A backend for {@link AggregateStorage} backed by Google Datastore
  */
-class DatastoreStorage {
+public class DatastoreStorage {
 
   private static final Logger LOG = LoggerFactory.getLogger(DatastoreStorage.class);
 
@@ -148,18 +155,16 @@ class DatastoreStorage {
 
   private final Datastore datastore;
   private final Duration retryBaseDelay;
-  private final ShardedCounter shardedCounter;
   private final Function<Transaction, DatastoreStorageTransaction> storageTransactionFactory;
 
-  DatastoreStorage(Datastore datastore, Duration retryBaseDelay, ShardedCounter shardedCounter) {
-    this(datastore, retryBaseDelay, shardedCounter, DatastoreStorageTransaction::new);
+  DatastoreStorage(Datastore datastore, Duration retryBaseDelay) {
+    this(datastore, retryBaseDelay, DatastoreStorageTransaction::new);
   }
 
-  DatastoreStorage(Datastore datastore, Duration retryBaseDelay, ShardedCounter shardedCounter,
+  DatastoreStorage(Datastore datastore, Duration retryBaseDelay,
       Function<Transaction, DatastoreStorageTransaction> storageTransactionFactory) {
     this.datastore = Objects.requireNonNull(datastore);
     this.retryBaseDelay = Objects.requireNonNull(retryBaseDelay);
-    this.shardedCounter = Objects.requireNonNull(shardedCounter);
     this.storageTransactionFactory = Objects.requireNonNull(storageTransactionFactory);
   }
 
@@ -623,9 +628,9 @@ class DatastoreStorage {
   }
 
   void postResource(Resource resource) throws IOException {
-    storeWithRetries(() -> datastore.runInTransaction(transaction -> {
-      shardedCounter.updateLimit(transaction, resource.id(), resource.concurrency());
-      return transaction.put(resourceToEntity(resource));
+    storeWithRetries(() -> runInTransaction(transaction -> {
+      transaction.store(resource);
+      return null;
       // TODO store just in one place, eliminate one of the two calls ^?
     }));
   }
@@ -642,13 +647,6 @@ class DatastoreStorage {
 
   private Resource entityToResource(Entity entity) {
     return Resource.create(entity.getKey().getName(), entity.getLong(PROPERTY_CONCURRENCY));
-  }
-
-  private Entity resourceToEntity(Resource resource) {
-    final Key key = datastore.newKeyFactory().setKind(KIND_RESOURCE).newKey(resource.id());
-    return Entity.newBuilder(key)
-        .set(PROPERTY_CONCURRENCY, resource.concurrency())
-        .build();
   }
 
   void deleteResource(String id) throws IOException {
@@ -809,5 +807,32 @@ class DatastoreStorage {
       throw new TransactionException(e);
     }
     return storageTransactionFactory.apply(transaction);
+  }
+
+  Map<Integer,Long> shardsForCounter(String counterId) {
+    final EntityQuery queryShards = EntityQuery.newEntityQueryBuilder()
+        .setKind(KIND_COUNTER_SHARD)
+        .setFilter(PropertyFilter.eq(PROPERTY_COUNTER_ID, counterId))
+        .setLimit(NUM_SHARDS)
+        .build();
+    final QueryResults<Entity> shards = datastore.run(queryShards);
+    final Map<Integer, Long> fetchedShards = new HashMap<>();
+    while (shards.hasNext()) {
+      Entity shard = shards.next();
+      fetchedShards
+          .put((int) shard.getLong(PROPERTY_SHARD_INDEX), shard.getLong(PROPERTY_SHARD_VALUE));
+    }
+    return fetchedShards;
+  }
+
+  long getLimitForCounter(String counterId) {
+    final Key limitKey = datastore.newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(counterId);
+    final Entity limitEntity = datastore.get(limitKey);
+    if (limitEntity == null) {
+      return Long.MAX_VALUE;
+      // Or IllegalStateException("No limit found in Datastore for " + counterId);?
+    } else {
+      return limitEntity.getLong(PROPERTY_LIMIT);
+    }
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.storage;
 
 import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
+import static com.spotify.styx.storage.DatastoreStorage.KIND_RESOURCE;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_ALL_TRIGGERED;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_COMPONENT;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_CONCURRENCY;
@@ -39,29 +40,39 @@ import static com.spotify.styx.storage.DatastoreStorage.activeWorkflowInstanceKe
 import static com.spotify.styx.storage.DatastoreStorage.entityToBackfill;
 import static com.spotify.styx.storage.DatastoreStorage.instantToTimestamp;
 import static com.spotify.styx.storage.DatastoreStorage.readPersistentWorkflowInstanceState;
+import static com.spotify.styx.util.ShardedCounter.KIND_COUNTER_LIMIT;
+import static com.spotify.styx.util.ShardedCounter.KIND_COUNTER_SHARD;
+import static com.spotify.styx.util.ShardedCounter.PROPERTY_COUNTER_ID;
+import static com.spotify.styx.util.ShardedCounter.PROPERTY_LIMIT;
+import static com.spotify.styx.util.ShardedCounter.PROPERTY_SHARD_INDEX;
+import static com.spotify.styx.util.ShardedCounter.PROPERTY_SHARD_VALUE;
 
+import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.StringValue;
 import com.google.cloud.datastore.Transaction;
 import com.spotify.styx.model.Backfill;
+import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
 import com.spotify.styx.serialization.PersistentWorkflowInstanceState;
 import com.spotify.styx.util.ResourceNotFoundException;
+import com.spotify.styx.util.Shard;
+import com.spotify.styx.util.ShardedCounter;
 import com.spotify.styx.util.TriggerInstantSpec;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.Optional;
 
-class DatastoreStorageTransaction implements StorageTransaction {
+public class DatastoreStorageTransaction implements StorageTransaction {
 
   private final Transaction tx;
 
-  DatastoreStorageTransaction(Transaction transaction) {
+  public DatastoreStorageTransaction(Transaction transaction) {
     this.tx = Objects.requireNonNull(transaction);
   }
 
@@ -86,6 +97,52 @@ class DatastoreStorageTransaction implements StorageTransaction {
   @Override
   public boolean isActive() {
     return tx.isActive();
+  }
+
+  @Override
+  public void updateCounter(ShardedCounter shardedCounter, String resource, int delta) {
+    //shardedCounter.updateCounter(this, resource, delta);
+  }
+
+  @Override
+  public Optional<Shard> shard(String counterId, int shardIndex) {
+    // TODO there's no need for this to be transactional
+    final Key shardKey = tx.getDatastore().newKeyFactory().setKind(KIND_COUNTER_SHARD)
+        .newKey(counterId + "-" + shardIndex);
+    Entity shardEntity = tx.get(shardKey);
+    if (shardEntity == null) {
+      return Optional.empty();
+    }
+    return Optional.of(Shard.create(counterId, shardIndex,
+                                    (int) tx.get(shardKey).getLong(PROPERTY_SHARD_VALUE)));
+  }
+
+  @Override
+  public void store(Shard shard) {
+    tx.put(Entity.newBuilder(tx.getDatastore().newKeyFactory().setKind(KIND_COUNTER_SHARD)
+                                 .newKey(shard.counterId() + "-" + shard.index()))
+                        .set(PROPERTY_COUNTER_ID, shard.counterId())
+                        .set(PROPERTY_SHARD_INDEX, shard.index())
+                        .set(PROPERTY_SHARD_VALUE, 0)
+                        .build());
+  }
+
+  @Override
+  public void updateLimitForCounter(String counterId, long limit) {
+    final Key limitKey = tx.getDatastore().newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(counterId);
+    tx.put(Entity.newBuilder(limitKey).set(PROPERTY_LIMIT, limit).build());
+  }
+
+  @Override
+  public void store(Resource resource) {
+    tx.put(resourceToEntity(tx.getDatastore(), resource));
+  }
+
+  private Entity resourceToEntity(Datastore datastore, Resource resource) {
+    final Key key = datastore.newKeyFactory().setKind(KIND_RESOURCE).newKey(resource.id());
+    return Entity.newBuilder(key)
+        .set(PROPERTY_CONCURRENCY, resource.concurrency())
+        .build();
   }
 
   @Override

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
@@ -101,7 +101,7 @@ public class DatastoreStorageTransaction implements StorageTransaction {
 
   @Override
   public void updateCounter(ShardedCounter shardedCounter, String resource, int delta) {
-    //shardedCounter.updateCounter(this, resource, delta);
+    shardedCounter.updateCounter(this, resource, delta);
   }
 
   @Override
@@ -123,7 +123,7 @@ public class DatastoreStorageTransaction implements StorageTransaction {
                                  .newKey(shard.counterId() + "-" + shard.index()))
                         .set(PROPERTY_COUNTER_ID, shard.counterId())
                         .set(PROPERTY_SHARD_INDEX, shard.index())
-                        .set(PROPERTY_SHARD_VALUE, 0)
+                        .set(PROPERTY_SHARD_VALUE, shard.value())
                         .build());
   }
 
@@ -136,6 +136,11 @@ public class DatastoreStorageTransaction implements StorageTransaction {
   @Override
   public void store(Resource resource) {
     tx.put(resourceToEntity(tx.getDatastore(), resource));
+  }
+
+  @Override
+  public void deleteCounterLimit(String counterId) {
+    tx.delete(tx.getDatastore().newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(counterId));
   }
 
   private Entity resourceToEntity(Datastore datastore, Resource resource) {

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -290,6 +290,11 @@ public class InMemStorage implements Storage {
   }
 
   @Override
+  public void deleteLimitForCounter(String counterId) {
+    throw new NotImplementedException();
+  }
+
+  @Override
   public SortedSet<SequenceEvent> readEvents(WorkflowInstance workflowInstance) {
     final SortedSet<SequenceEvent> events = Sets.newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
     writtenEvents.stream()

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -48,6 +48,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /**
  * A Storage implementation with state stored in memory. For testing.
@@ -265,6 +266,21 @@ public class InMemStorage implements Storage {
   @Override
   public void storeBackfill(Backfill backfill) throws IOException {
     backfillStore.put(backfill.id(), backfill);
+  }
+
+  @Override
+  public Map<Integer, Long> shardsForCounter(String counterId) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public void deleteShardsForCounter(String counterId) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public long getLimitForCounter(String counterId) {
+    throw new NotImplementedException();
   }
 
   @Override

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -269,10 +269,17 @@ public interface Storage {
 
   void storeBackfill(Backfill backfill) throws IOException;
 
+  Map<Integer, Long> shardsForCounter(String counterId);
+
+  void deleteShardsForCounter(String counterId);
+
+  long getLimitForCounter(String counterId);
+
   /**
    * Run a function in a transaction that is committed if successful. Any exception thrown by the
    * passed in function will cause the transaction to be rolled back.
    */
   <T, E extends Exception> T runInTransaction(TransactionFunction<T, E> f)
       throws IOException, E;
+
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -282,4 +282,5 @@ public interface Storage {
   <T, E extends Exception> T runInTransaction(TransactionFunction<T, E> f)
       throws IOException, E;
 
+  void deleteLimitForCounter(String counterId) throws IOException;
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/StorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/StorageTransaction.java
@@ -21,11 +21,14 @@
 package com.spotify.styx.storage;
 
 import com.spotify.styx.model.Backfill;
+import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
 import com.spotify.styx.serialization.PersistentWorkflowInstanceState;
+import com.spotify.styx.util.Shard;
+import com.spotify.styx.util.ShardedCounter;
 import com.spotify.styx.util.TriggerInstantSpec;
 import java.io.IOException;
 import java.util.Optional;
@@ -127,4 +130,29 @@ public interface StorageTransaction {
    * Check if this transaction is still active (not yet committed or rolled back).
    */
   boolean isActive();
+
+  /**
+   * Update counter by delta for the specified resource.
+   */
+  void updateCounter(ShardedCounter shardedCounter, String resource, int delta);
+
+  /**
+   * Reads a counter shard
+   */
+  Optional<Shard> shard(String counterId, int shardIndex);
+
+  /**
+   * Stores a shard
+   */
+  void store(Shard shard);
+
+  /**
+   * Updates the limit for the given counter
+   */
+  void updateLimitForCounter(String counterId, long limit);
+
+  /**
+   * Stores a resource
+   */
+  void store(Resource resource);
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/StorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/StorageTransaction.java
@@ -155,4 +155,9 @@ public interface StorageTransaction {
    * Stores a resource
    */
   void store(Resource resource);
+
+  /**
+   * Deletes the limit configured for the given counter
+   */
+  void deleteCounterLimit(String counterId);
 }

--- a/styx-common/src/main/java/com/spotify/styx/util/Shard.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/Shard.java
@@ -1,0 +1,49 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.util;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+/**
+ * A value for a single shard of {@link ShardedCounter}.
+ */
+@AutoValue
+public abstract class Shard {
+
+  @JsonProperty
+  public abstract String counterId();
+
+  @JsonProperty
+  public abstract int index();
+
+  @JsonProperty
+  public abstract int value();
+
+  @JsonCreator
+  public static Shard create(@JsonProperty("counter_id") String counterId,
+                             @JsonProperty("index") int index,
+                             @JsonProperty("value") int value) {
+    return new AutoValue_Shard(counterId, index, value);
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/util/ShardedCounter.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ShardedCounter.java
@@ -264,12 +264,8 @@ public class ShardedCounter {
    * is trying to delete all shards, while another is creating/updating shards in between the
    * multiple transactions made by this method.
    */
-  public void deleteCounter(Storage storage, String counterId) {
+  public void deleteCounter(Storage storage, String counterId) throws IOException {
     storage.deleteShardsForCounter(counterId);
-    try {
-      storage.deleteLimitForCounter(counterId);
-    } catch (IOException e) {
-      LOG.debug("Error when trying to delete limit for counter {}: {}", counterId, e);
-    }
+    storage.deleteLimitForCounter(counterId);
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/util/ShardedCounter.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ShardedCounter.java
@@ -21,22 +21,22 @@
 package com.spotify.styx.util;
 
 import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.DatastoreReaderWriter;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.EntityQuery;
-import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery.PropertyFilter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Range;
+import com.spotify.styx.storage.Storage;
+import com.spotify.styx.storage.StorageTransaction;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
@@ -70,7 +70,7 @@ public class ShardedCounter {
   public static final String PROPERTY_SHARD_INDEX = "index";
   public static final String PROPERTY_COUNTER_ID = "counterId";
 
-  private final Datastore datastore;
+  private final Storage storage;
 
   /**
    * A weakly consistent view of the state in Datastore, refreshed by ShardedCounter on demand.
@@ -86,59 +86,41 @@ public class ShardedCounter {
     private final Long limit;
     private final Map<Integer, Long> shards;
 
-    public CounterSnapshot(Datastore datastore, String counterId) {
-      limit = getLimit(datastore, counterId);
+    public CounterSnapshot(Storage storage, String counterId) {
+      limit = getLimit(storage, counterId);
 
-      Map<Integer, Long> fetchedShards = fetchShards(datastore, counterId);
+      Map<Integer, Long> fetchedShards = storage.shardsForCounter(counterId);
       if (fetchedShards.size() < NUM_SHARDS) {
         // The counter probably has not been initialized (so we have empty QueryResults). Also
         // possible that a prior initialize() crashed halfway, or we got a partial list of shards in
         // QueryResults due to eventual consistency. In any case, repeated initialization eventually
         // creates all NUM_SHARDS shards.
-        initialize(datastore, counterId);
-        fetchedShards = fetchShards(datastore, counterId);
+        initialize(storage, counterId);
+        fetchedShards = storage.shardsForCounter(counterId);
       }
       this.counterId = counterId;
-      shards = fetchedShards;
+      this.shards = fetchedShards;
     }
 
     /**
      * Idempotent initialization, so that we don't reset an existing shard to zero - counterId may
      * have already been initialized and incremented by another process.
      */
-    private static void initialize(Datastore datastore, String counterId) {
+    private static void initialize(Storage storage, String counterId) {
       for (int i = 0; i < NUM_SHARDS; i++) {
         final int shardIndex = i;
-        final Key shardKey = datastore.newKeyFactory().setKind(KIND_COUNTER_SHARD)
-            .newKey(counterId + "-" + shardIndex);
-        datastore.runInTransaction(transaction -> {
-          final Entity shard = transaction.get(shardKey);
-          if (shard == null) {
-            transaction.put(Entity.newBuilder(shardKey)
-                                .set(PROPERTY_COUNTER_ID, counterId)
-                                .set(PROPERTY_SHARD_INDEX, shardIndex)
-                                .set(PROPERTY_SHARD_VALUE, 0)
-                                .build());
-          }
-          return null;
-        });
+        try {
+          storage.runInTransaction(tx -> {
+            final Optional<Shard> shard = tx.shard(counterId, shardIndex);
+            if (!shard.isPresent()) {
+              tx.store(Shard.create(counterId, shardIndex, 0));
+            }
+            return null;
+          });
+        } catch (IOException e) {
+          LOG.warn("Error when trying to create a shard entry in Datastore: ", e);
+        }
       }
-    }
-
-    private static Map<Integer, Long> fetchShards(Datastore datastore, String counterId) {
-      final EntityQuery queryShards = EntityQuery.newEntityQueryBuilder()
-          .setKind(KIND_COUNTER_SHARD)
-          .setFilter(PropertyFilter.eq(PROPERTY_COUNTER_ID, counterId))
-          .setLimit(NUM_SHARDS)
-          .build();
-      final QueryResults<Entity> shards = datastore.run(queryShards);
-      final Map<Integer, Long> fetchedShards = new HashMap<>();
-      while (shards.hasNext()) {
-        Entity shard = shards.next();
-        fetchedShards
-            .put((int) shard.getLong(PROPERTY_SHARD_INDEX), shard.getLong(PROPERTY_SHARD_VALUE));
-      }
-      return fetchedShards;
     }
 
     /**
@@ -185,8 +167,8 @@ public class ShardedCounter {
     }
   }
 
-  public ShardedCounter(Datastore datastore) {
-    this.datastore = Objects.requireNonNull(datastore);
+  public ShardedCounter(Storage storage) {
+    this.storage = storage;
   }
 
   /**
@@ -204,7 +186,7 @@ public class ShardedCounter {
    * Update cached snapshot with most recent state of counter in Datastore.
    */
   private CounterSnapshot refreshCounterSnapshot(String counterId) {
-    final CounterSnapshot newSnapshot = new CounterSnapshot(datastore, counterId);
+    final CounterSnapshot newSnapshot = new CounterSnapshot(storage, counterId);
     inMemSnapshot.put(counterId, newSnapshot);
     return newSnapshot;
   }
@@ -216,24 +198,15 @@ public class ShardedCounter {
    * there has been no preceding successful updateLimit operation, no limit is applied in
    * updateCounter operations on this counter.
    */
-  public void updateLimit(DatastoreReaderWriter transaction, String counterId, long limit) {
-    final Key limitKey = datastore.newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(counterId);
-
-    transaction.put(Entity.newBuilder(limitKey).set(PROPERTY_LIMIT, limit).build());
+  public void updateLimit(StorageTransaction tx, String counterId, long limit) {
+    tx.updateLimitForCounter(counterId, limit);
   }
 
   /**
    * Reads the latest limit value from Datastore, for the specified {@param counterId}
    */
-  public static long getLimit(Datastore datastore, String counterId) {
-    final Key limitKey = datastore.newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(counterId);
-    final Entity limitEntity = datastore.get(limitKey);
-    if (limitEntity == null) {
-      return Long.MAX_VALUE;
-      // Or IllegalStateException("No limit found in Datastore for " + counterId);?
-    } else {
-      return limitEntity.getLong(PROPERTY_LIMIT);
-    }
+  public static long getLimit(Storage storage, String counterId) {
+    return storage.getLimitForCounter(counterId);
   }
 
   /**
@@ -246,32 +219,27 @@ public class ShardedCounter {
    * Updates with a larger delta are prone to spuriously fail even when the counter is not near to
    * exceeding its limit. Failures are certain when delta >= limit / NUM_SHARDS + 1.
    */
-  public void updateCounter(DatastoreReaderWriter transaction, String counterId, long delta) {
+  public void updateCounter(StorageTransaction transaction, String counterId, long delta) {
     CounterSnapshot snapshot = getCounterSnapshot(counterId);
     int shardIndex = snapshot.pickShardWithSpareCapacity(delta);
 
-    final Key shardKey = datastore.newKeyFactory().setKind(KIND_COUNTER_SHARD)
-        .newKey(counterId + "-" + shardIndex);
-    final Entity shard = transaction.get(shardKey);
+    final Optional<Shard> shard = transaction.shard(counterId, shardIndex);
 
-    if (shard != null) {
-      final long newShardValue = shard.getLong(PROPERTY_SHARD_VALUE) + delta;
+    if (shard.isPresent()) {
+      final long newShardValue = shard.get().value() + delta;
       if (Range.closed(0L, snapshot.shardCapacity(shardIndex))
           .contains(newShardValue)) {
-        transaction.put(Entity.newBuilder(shard)
-                            .set(PROPERTY_SHARD_VALUE,
-                                 shard.getLong(PROPERTY_SHARD_VALUE) + delta)
-                            .build());
+        transaction.store(Shard.create(counterId, shardIndex, (int) (shard.get().value() + delta)));
       } else {
-        throw new CounterCapacityException("Chosen shard %s has no more capacity.",
-                                           shardKey.getName());
+        throw new CounterCapacityException("Chosen shard %s-%s has no more capacity.",
+                                           counterId, shardIndex);
       }
     } else {
       throw new ShardNotFoundException(
-          "Could not find shard %s. Unexpected Datastore corruption or our bug - the code should've "
+          "Could not find shard %s-%s. Unexpected Datastore corruption or our bug - the code should've "
           + "called initialize() before reaching this point, and any particular shard should "
           + "strongly be get()-able thereafter",
-          shardKey.getName());
+          counterId, shardIndex);
     }
   }
 
@@ -302,7 +270,9 @@ public class ShardedCounter {
    * is trying to delete all shards, while another is creating/updating shards in between the
    * multiple transactions made by this method.
    */
-  public void deleteCounter(Datastore datastore, String counterId) {
+  public void deleteCounter(Storage storage, Datastore datastore, String counterId) {
+    storage.deleteShardsForCounter(counterId);
+
     QueryResults<Entity> results = datastore.run(EntityQuery.newEntityQueryBuilder()
                                                      .setKind(KIND_COUNTER_SHARD)
                                                      .setFilter(PropertyFilter

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -203,7 +203,7 @@ public class DatastoreStorageTest {
   @Before
   public void setUp() throws Exception {
     datastore = helper.getOptions().getService();
-    storage = new DatastoreStorage(datastore, Duration.ZERO, shardedCounter);
+    storage = new DatastoreStorage(datastore, Duration.ZERO);
   }
 
   @After
@@ -611,7 +611,7 @@ public class DatastoreStorageTest {
 
   @Test
   public void runInTransactionShouldCallFunctionAndCommit() throws Exception {
-    final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, shardedCounter, storageTransactionFactory);
+    final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory);
     final Transaction transaction = datastore.newTransaction();
     final DatastoreStorageTransaction storageTransaction = spy(new DatastoreStorageTransaction(transaction));
     when(storageTransactionFactory.apply(any())).thenReturn(storageTransaction);
@@ -628,7 +628,7 @@ public class DatastoreStorageTest {
 
   @Test
   public void runInTransactionShouldCallFunctionAndRollbackOnFailure() throws Exception {
-    final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, shardedCounter, storageTransactionFactory);
+    final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory);
     final Transaction transaction = datastore.newTransaction();
     final DatastoreStorageTransaction storageTransaction = spy(new DatastoreStorageTransaction(transaction));
     when(storageTransactionFactory.apply(any())).thenReturn(storageTransaction);
@@ -652,7 +652,7 @@ public class DatastoreStorageTest {
 
   @Test
   public void runInTransactionShouldCallFunctionAndRollbackOnPreCommitConflict() throws Exception {
-    final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, shardedCounter, storageTransactionFactory);
+    final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory);
     final Transaction transaction = datastore.newTransaction();
     final DatastoreStorageTransaction storageTransaction = spy(new DatastoreStorageTransaction(transaction));
     when(storageTransactionFactory.apply(any())).thenReturn(storageTransaction);
@@ -674,7 +674,7 @@ public class DatastoreStorageTest {
 
   @Test
   public void runInTransactionShouldCallFunctionAndRollbackOnCommitConflict() throws Exception {
-    final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, shardedCounter, storageTransactionFactory);
+    final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory);
     final Transaction transaction = datastore.newTransaction();
     final DatastoreStorageTransaction storageTransaction = spy(new DatastoreStorageTransaction(transaction));
     when(storageTransactionFactory.apply(any())).thenReturn(storageTransaction);
@@ -697,7 +697,7 @@ public class DatastoreStorageTest {
 
   @Test
   public void runInTransactionShouldThrowIfRollbackFailsAfterConflict() throws Exception {
-    final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, shardedCounter, storageTransactionFactory);
+    final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory);
     final Transaction transaction = datastore.newTransaction();
     final DatastoreStorageTransaction storageTransaction = spy(new DatastoreStorageTransaction(transaction));
     when(storageTransactionFactory.apply(any())).thenReturn(storageTransaction);
@@ -723,7 +723,7 @@ public class DatastoreStorageTest {
   @Test
   public void runInTransactionShouldThrowIfDatastoreNewTransactionFails() throws Exception {
     Datastore datastore = mock(Datastore.class);
-    final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, shardedCounter, storageTransactionFactory);
+    final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory);
     when(datastore.newTransaction()).thenThrow(new DatastoreException(1, "", ""));
 
     when(transactionFunction.apply(any())).thenReturn("");

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTransactionTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTransactionTest.java
@@ -95,7 +95,7 @@ public class DatastoreStorageTransactionTest {
   @Before
   public void setUp() throws Exception {
     datastore = helper.getOptions().getService();
-    storage = new DatastoreStorage(datastore, Duration.ZERO, shardedCounter);
+    storage = new DatastoreStorage(datastore, Duration.ZERO);
   }
 
   @After

--- a/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
@@ -251,7 +251,7 @@ public class ShardedCounterTest {
   }
 
   @Test
-  public void shouldPassDeletingNonExistingCounterAndLimit() {
+  public void shouldPassDeletingNonExistingCounterAndLimit() throws IOException {
     shardedCounter.deleteCounter(storage, COUNTER_ID1);
 
     QueryResults<Entity> results = getShardsForCounter(COUNTER_ID1);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -213,9 +213,9 @@ public class QueuedStateManager implements StateManager {
               PersistentWorkflowInstanceState.of(nextRunState, nextCounter);
           tx.updateActiveState(event.workflowInstance(), nextPersistentState);
           // FIXME if event == dequeue and resourceIds is present
-          for (String resource : nextRunState.data().resourceIds().get()) {
-            tx.updateCounter(shardedCounter, resource, 1);
-          }
+          //for (String resource : nextRunState.data().resourceIds().get()) {
+          //  tx.updateCounter(shardedCounter, resource, 1);
+          //}
         }
 
         final SequenceEvent sequenceEvent =

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -85,10 +85,8 @@ public class StyxSchedulerServiceFixture {
   private static LocalDatastoreHelper localDatastore;
 
   private Datastore datastore = localDatastore.getOptions().getService();
-  private ShardedCounter shardedCounter = new ShardedCounter(datastore);
   private Connection bigtable = setupBigTableMockTable(0);
-  protected AggregateStorage storage = new AggregateStorage(bigtable, datastore, Duration.ZERO,
-                                                            shardedCounter);
+  protected AggregateStorage storage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
   private DeterministicScheduler executor = new QuietDeterministicScheduler();
 
   // circumstantial fields, set by test cases

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -50,7 +50,6 @@ import com.spotify.styx.storage.AggregateStorage;
 import com.spotify.styx.storage.BigtableMocker;
 import com.spotify.styx.storage.BigtableStorage;
 import com.spotify.styx.util.IsClosedException;
-import com.spotify.styx.util.ShardedCounter;
 import com.spotify.styx.util.StorageFactory;
 import com.spotify.styx.util.Time;
 import com.spotify.styx.util.TriggerInstantSpec;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
@@ -55,6 +55,7 @@ import com.spotify.styx.storage.TransactionFunction;
 import com.spotify.styx.testdata.TestData;
 import com.spotify.styx.util.AlreadyInitializedException;
 import com.spotify.styx.util.IsClosedException;
+import com.spotify.styx.util.ShardedCounter;
 import com.spotify.styx.util.Time;
 import eu.javaspecialists.tjsn.concurrency.stripedexecutor.StripedExecutorService;
 import java.io.IOException;
@@ -108,6 +109,7 @@ public class QueuedStateManagerTest {
   @Mock StorageTransaction transaction;
   @Mock OutputHandler outputHandler;
   @Mock Time time;
+  @Mock ShardedCounter shardedCounter;
 
   @Before
   public void setUp() throws Exception {
@@ -117,7 +119,7 @@ public class QueuedStateManagerTest {
     doNothing().when(outputHandler).transitionInto(runStateCaptor.capture());
     stateManager = new QueuedStateManager(
         time, eventTransitionExecutor, storage, eventConsumer,
-        eventConsumerExecutor, OutputHandler.fanOutput(outputHandler));
+        eventConsumerExecutor, OutputHandler.fanOutput(outputHandler), shardedCounter);
   }
 
   @After
@@ -271,7 +273,7 @@ public class QueuedStateManagerTest {
     reset(storage);
     stateManager = spy(new QueuedStateManager(
         time, eventTransitionExecutor, storage, eventConsumer,
-        eventConsumerExecutor, outputHandler));
+        eventConsumerExecutor, outputHandler, shardedCounter));
     when(storage.getLatestStoredCounter(any())).thenReturn(Optional.empty());
     when(transaction.workflow(INSTANCE.workflowId())).thenReturn(Optional.empty());
     doThrow(new IsClosedException()).when(stateManager).receive(any());
@@ -290,7 +292,7 @@ public class QueuedStateManagerTest {
     reset(storage);
     stateManager = spy(new QueuedStateManager(
         time, eventTransitionExecutor, storage, eventConsumer,
-        eventConsumerExecutor, outputHandler));
+        eventConsumerExecutor, outputHandler, shardedCounter));
     when(storage.getLatestStoredCounter(any())).thenReturn(Optional.empty());
     doThrow(new IOException()).when(storage).deleteActiveState(any());
     when(transaction.workflow(INSTANCE.workflowId())).thenReturn(Optional.empty());


### PR DESCRIPTION
Refactor `ShardedCounter` to depend on `Storage` and `StorageTransaction` instead of `Datastore`.

As per the current setup of how Styx communicates with Datastore, there are two places where read/write logic happens, in `DatastoreStorage` used by `AggregateStorage implements Storage` and `DatastoreStorageTransaction implements StorageTransaction`, so it was a bit confusing when deciding where to put the logic needed for `ShardedCounter`.  My approach was to put as much as I could in `DatastoreStorageTransaction` (whatever was required to be done in a transaction) and the rest in `DatastoreStorage`.