### PR TITLE
Mark completed backfills as allTriggered

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
@@ -165,6 +165,9 @@ class BackfillTriggerManager {
 
     if (momentNextTrigger.equals(momentBackfill.end())) {
       LOG.debug("Backfill {} all triggered", momentBackfill);
+      tx.store(momentBackfill.builder()
+          .allTriggered(true)
+          .build());
       return false;
     }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/BackfillTriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/BackfillTriggerManagerTest.java
@@ -250,7 +250,7 @@ public class BackfillTriggerManagerTest {
   }
 
   @Test
-  public void shouldNotTriggerIfAllTriggered() {
+  public void shouldNotTriggerIfAllTriggered() throws IOException {
     final Workflow workflow = createWorkflow(WORKFLOW_ID1);
     initWorkflow(workflow);
 
@@ -261,6 +261,22 @@ public class BackfillTriggerManagerTest {
 
     backfillTriggerManager.tick();
 
+    verifyZeroInteractions(triggerListener);
+  }
+
+  @Test
+  public void shouldMarkedAsAllTriggeredIfEndOfBackfillEncountered() throws IOException {
+    final Workflow workflow = createWorkflow(WORKFLOW_ID1);
+    initWorkflow(workflow);
+
+    final Backfill completedBackfill =
+        BACKFILL_2.builder().nextTrigger(BACKFILL_2.end()).allTriggered(false).build();
+
+    backfills.put(completedBackfill.id(), completedBackfill);
+
+    backfillTriggerManager.tick();
+
+    verify(transaction).store(completedBackfill.builder().allTriggered(true).build());
     verifyZeroInteractions(triggerListener);
   }
 


### PR DESCRIPTION
It is possible (maybe it shouldn't) to create backfills that have start=end, for which `allTriggered` will never be reached. Complements #402 

@honnix @ulzha PTAL