### PR TITLE
[Hold] shuffle workflow instances again

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -29,8 +29,8 @@ import static com.spotify.styx.state.StateUtil.getResourceUsage;
 import static com.spotify.styx.state.StateUtil.getTimedOutInstances;
 import static com.spotify.styx.state.StateUtil.workflowResources;
 import static java.util.Collections.emptySet;
-import static java.util.Comparator.comparingLong;
 import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
@@ -56,6 +56,7 @@ import com.spotify.styx.util.Time;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -164,8 +165,8 @@ public class Scheduler {
         activeStates.parallelStream()
             .filter(entry -> !timedOutInstances.contains(entry.workflowInstance()))
             .filter(entry -> shouldExecute(entry.runState()))
-            .sorted(comparingLong(i -> i.runState().timestamp()))
-            .collect(toList());
+            .collect(toCollection(Lists::newArrayList));
+    Collections.shuffle(eligibleInstances);
 
     timedOutInstances.forEach(wfi -> this.sendTimeout(wfi, activeStatesMap.get(wfi)));
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -279,29 +279,13 @@ public class SchedulerTest {
     initWorkflow(workflowUsingResources(WORKFLOW_ID1));
 
     StateData stateData = StateData.newBuilder().tries(0).build();
-
     populateActiveStates(RunState.create(INSTANCE_1, State.QUEUED, stateData, time.get()));
-
-    List<WorkflowInstance> workflowInstances = new ArrayList<>();
-
-    for (int i = 1; i <= 10; i++) {
-      WorkflowId workflowId = WorkflowId.create("styx2", "example" + i);
-      initWorkflow(workflowUsingResources(workflowId));
-      WorkflowInstance instance = WorkflowInstance.create(workflowId, "2016-12-02T01");
-      populateActiveStates(RunState.create(instance, State.QUEUED, stateData,
-          time.get().minus(i, ChronoUnit.SECONDS)));
-      workflowInstances.add(instance);
-    }
 
     scheduler.tick();
 
-    InOrder inOrder = inOrder(stateManager);
-
-    Lists.reverse(workflowInstances)
-        .forEach(x -> inOrder.verify(stateManager)
-            .receiveIgnoreClosed(eq(Event.dequeue(x, ImmutableSet.of())), anyLong()));
-    inOrder.verify(stateManager).receiveIgnoreClosed(eq(
-        Event.dequeue(INSTANCE_1, ImmutableSet.of())), anyLong());
+    verify(stateManager).receiveIgnoreClosed(
+        eq(Event.dequeue(INSTANCE_1, ImmutableSet.of())),
+        anyLong());
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -63,7 +62,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,7 +76,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InOrder;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -298,25 +295,11 @@ public class SchedulerTest {
 
     populateActiveStates(RunState.create(INSTANCE_1, State.QUEUED, stateData, time.get()));
 
-    List<WorkflowInstance> workflowInstances = new ArrayList<>();
-
-    for (int i = 1; i <= 10; i++) {
-      WorkflowId workflowId = WorkflowId.create("styx2", "example" + i);
-      WorkflowInstance instance = WorkflowInstance.create(workflowId, "2016-12-02T01");
-      populateActiveStates(RunState.create(instance, State.QUEUED, stateData,
-          time.get().minus(i, ChronoUnit.SECONDS)));
-      workflowInstances.add(instance);
-    }
-
     scheduler.tick();
 
-    InOrder inOrder = inOrder(stateManager);
-
-    Lists.reverse(workflowInstances)
-        .forEach(x -> inOrder.verify(stateManager)
-            .receiveIgnoreClosed(eq(Event.dequeue(x, ImmutableSet.of())), anyLong()));
-    inOrder.verify(stateManager).receiveIgnoreClosed(eq(
-        Event.dequeue(INSTANCE_1, ImmutableSet.of())), anyLong());
+    verify(stateManager).receiveIgnoreClosed(
+        eq(Event.dequeue(INSTANCE_1, ImmutableSet.of())),
+        anyLong());
   }
 
   @Test


### PR DESCRIPTION
This is more or less a revert of #411. Because of #415, starvation
wouldn't happen anymore. Shuffle the workflow instances to make
multi-scheduler setup happier.

@fabriziodemaria PTAL 

According to https://github.com/spotify/styx/pull/411#issuecomment-373725143