### PR TITLE
to report invalid execution exception

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/MeteredProxy.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/MeteredProxy.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.monitoring;
 
 import com.spotify.styx.docker.DockerRunner;
+import com.spotify.styx.docker.InvalidExecutionException;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.Time;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -107,7 +108,12 @@ public class MeteredProxy implements InvocationHandler {
           : "kubernetes-client";
       stats.recordDockerOperationError(operation, type, kubernetesClientException.getCode(), durationMillis);
     } else {
-      stats.recordDockerOperationError(operation, "unknown", 0, durationMillis);
+      final InvalidExecutionException invalidExecutionException = findCause(e, InvalidExecutionException.class);
+      if (invalidExecutionException != null) {
+        stats.recordDockerOperationError(operation, "invalid-execution", 0, durationMillis);
+      } else {
+        stats.recordDockerOperationError(operation, "unknown", 0, durationMillis);
+      }
     }
   }
 


### PR DESCRIPTION
This kind of exception we would prefer not to get alert. With a specific type we can then filter out.

@danielnorberg PTAL