### PR TITLE
ignore events from previous executions

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -545,8 +545,9 @@ class KubernetesDockerRunner implements DockerRunner {
         runState.data().executionId().ifPresent(stats::recordRunning);
       }
 
+      final String executionId = pod.getMetadata().getName();
       try {
-        stateManager.receive(event, runState.counter() + i);
+        stateManager.receive(event, executionId);
       } catch (IsClosedException isClosedException) {
         LOG.warn("Could not receive kubernetes event", isClosedException);
         throw new RuntimeException(isClosedException);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/StateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/StateManager.java
@@ -64,6 +64,16 @@ public interface StateManager extends Closeable {
   CompletionStage<Void> receive(Event event, long counter) throws IsClosedException;
 
   /**
+   * Receive an {@link Event} and route it to the corresponding active {@link RunState} based on
+   * the {@link Event#workflowInstance()} key of the event.
+   *
+   * @param event   The event to receive
+   * @param executionId The execution ID of the origin of the event.
+   * @throws IsClosedException if the state receiver is closed and can not handle events
+   */
+  CompletionStage<Void> receive(Event event, String executionId) throws IsClosedException;
+
+  /**
    * Get a map of all active {@link WorkflowInstance} states filtered by triggerId.
    */
   Map<WorkflowInstance, RunState> getActiveStatesByTriggerId(String triggerId);


### PR DESCRIPTION
Ugly but does the job. Might want to consider passing in a lambda into `receive` to inspect the run state and decide whether the event should be processed or not inside the transaction.