### PR TITLE
[HOLD] strongly consistent wfi listing using shards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           environment:
             # Configure datastore emulator heap size
-            JAVA: java -Xmx256m -Xms256m
+            JAVA: java -Xmx512m -Xms512m
             # Maven heap size
             MAVEN_OPTS: -Xmx256m -Xms256m
           command: mvn verify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     docker:
       - image: maven:3.5.2-jdk-8
     steps:
+      - run: ulimit -a
       - checkout
       - restore_cache:
           key: v1-deps-{{ checksum "pom.xml" }}
@@ -35,6 +36,7 @@ jobs:
     docker:
       - image: maven:3.5.2-jdk-9-slim
     steps:
+      - run: ulimit -a
       - checkout
       - restore_cache:
           key: v1-deps-jdk9-{{ checksum "pom.xml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,11 @@ jobs:
           key: v1-deps-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
-      - run: mvn verify
+      - run:
+          environment:
+            # Configure datastore emulator heap size
+            JAVA: java -Xmx256m -Xms256m
+          command: mvn verify
       - run: bash <(curl -s https://codecov.io/bash) -f '!**/jacoco-aggregate/**'
       - run: |
           mkdir test-reports
@@ -37,7 +41,11 @@ jobs:
           key: v1-deps-jdk9-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
-      - run: mvn verify
+      - run:
+          environment:
+            # Configure datastore emulator heap size
+            JAVA: java -Xmx256m -Xms256m
+          command: mvn verify
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ jobs:
           environment:
             # Configure datastore emulator heap size
             JAVA: java -Xmx256m -Xms256m
+            # Maven heap size
+            MAVEN_OPTS: -Xmx128m -Xms128m
           command: mvn verify
       - run: bash <(curl -s https://codecov.io/bash) -f '!**/jacoco-aggregate/**'
       - run: |
@@ -45,6 +47,8 @@ jobs:
           environment:
             # Configure datastore emulator heap size
             JAVA: java -Xmx256m -Xms256m
+            # Maven heap size
+            MAVEN_OPTS: -Xmx128m -Xms128m
           command: mvn verify
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run:
           environment:
             # Configure datastore emulator heap size
-            JAVA: java -Xmx256m -Xms256m
+            JAVA: java -Xmx512m -Xms512m
             # Maven heap size
             MAVEN_OPTS: -Xmx256m -Xms256m
           command: mvn verify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             # Configure datastore emulator heap size
             JAVA: java -Xmx256m -Xms256m
             # Maven heap size
-            MAVEN_OPTS: -Xmx128m -Xms128m
+            MAVEN_OPTS: -Xmx256m -Xms256m
           command: mvn verify
       - run: bash <(curl -s https://codecov.io/bash) -f '!**/jacoco-aggregate/**'
       - run: |
@@ -48,7 +48,7 @@ jobs:
             # Configure datastore emulator heap size
             JAVA: java -Xmx256m -Xms256m
             # Maven heap size
-            MAVEN_OPTS: -Xmx128m -Xms128m
+            MAVEN_OPTS: -Xmx256m -Xms256m
           command: mvn verify
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -424,6 +424,7 @@
         <version>2.19.1</version>
         <configuration>
           <argLine>-Xmx256m ${argLine}</argLine>
+          <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -425,6 +425,7 @@
         <configuration>
           <argLine>-Xmx256m ${argLine}</argLine>
           <reuseForks>false</reuseForks>
+          <forkCount>1</forkCount>
         </configuration>
       </plugin>
 

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -64,13 +64,14 @@ import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.AggregateStorage;
 import com.spotify.styx.storage.BigtableMocker;
 import com.spotify.styx.storage.BigtableStorage;
-import com.spotify.styx.util.WorkflowValidator;
 import com.spotify.styx.util.ShardedCounter;
+import com.spotify.styx.util.WorkflowValidator;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.logging.Level;
 import okio.ByteString;
 import org.apache.hadoop.hbase.client.Connection;
 import org.junit.After;
@@ -140,6 +141,10 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @BeforeClass
   public static void setUpClass() throws Exception {
+    final java.util.logging.Logger datastoreEmulatorLogger =
+        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    datastoreEmulatorLogger.setLevel(Level.OFF);
+
     localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency
     localDatastore.start();
   }

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -37,11 +37,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
-import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.Key;
-import com.google.cloud.datastore.KeyQuery;
-import com.google.cloud.datastore.Query;
-import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -189,13 +184,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @After
   public void tearDown() throws Exception {
-    // clear datastore after each test
-    Datastore datastore = localDatastore.getOptions().getService();
-    KeyQuery query = Query.newKeyQueryBuilder().build();
-    final QueryResults<Key> keys = datastore.run(query);
-    while (keys.hasNext()) {
-      datastore.delete(keys.next());
-    }
+    localDatastore.reset();
   }
 
   @Test

--- a/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
@@ -34,11 +34,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.Key;
-import com.google.cloud.datastore.KeyQuery;
-import com.google.cloud.datastore.Query;
-import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.apollo.Environment;
@@ -112,13 +107,7 @@ public class ResourceResourceTest extends VersionedApiTest {
 
   @After
   public void tearDown() throws Exception {
-    // clear datastore after each test
-    Datastore datastore = localDatastore.getOptions().getService();
-    KeyQuery query = Query.newKeyQueryBuilder().build();
-    final QueryResults<Key> keys = datastore.run(query);
-    while (keys.hasNext()) {
-      datastore.delete(keys.next());
-    }
+    localDatastore.reset();
   }
 
   @Test

--- a/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
@@ -43,6 +43,7 @@ import com.spotify.styx.model.Resource;
 import com.spotify.styx.storage.AggregateStorage;
 import com.spotify.styx.util.ShardedCounter;
 import java.time.Duration;
+import java.util.logging.Level;
 import okio.ByteString;
 import org.apache.hadoop.hbase.client.Connection;
 import org.junit.After;
@@ -84,6 +85,10 @@ public class ResourceResourceTest extends VersionedApiTest {
 
   @BeforeClass
   public static void setUpClass() throws Exception {
+    final java.util.logging.Logger datastoreEmulatorLogger =
+        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    datastoreEmulatorLogger.setLevel(Level.OFF);
+
     localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency
     localDatastore.start();
   }

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -64,6 +64,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.logging.Level;
 import okio.ByteString;
 import org.apache.hadoop.hbase.client.Connection;
 import org.junit.After;
@@ -135,6 +136,10 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @BeforeClass
   public static void setUpClass() throws Exception {
+    final java.util.logging.Logger datastoreEmulatorLogger =
+        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    datastoreEmulatorLogger.setLevel(Level.OFF);
+
     localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency
     localDatastore.start();
   }

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -41,10 +41,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.Key;
-import com.google.cloud.datastore.KeyQuery;
-import com.google.cloud.datastore.Query;
-import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -161,13 +157,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @After
   public void tearDown() throws Exception {
-    // clear datastore after each test
-    Datastore datastore = localDatastore.getOptions().getService();
-    KeyQuery query = Query.newKeyQueryBuilder().build();
-    final QueryResults<Key> keys = datastore.run(query);
-    while (keys.hasNext()) {
-      datastore.delete(keys.next());
-    }
+    localDatastore.reset();
     serviceHelper.stubClient().clear();
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/model/StyxConfig.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/StyxConfig.java
@@ -48,6 +48,11 @@ public interface StyxConfig {
   boolean resourcesSyncEnabled();
 
   /**
+   * Get the flag for enabling bootstrap of activeWFI indexes at startup.
+   */
+  boolean bootstrapActiveWFIEnabled();
+
+  /**
    * Controls whether workflow instance execution gating should be performed. If set to false,
    * instances will be executed without checking for blockers.
    */

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -60,6 +60,11 @@ public class AggregateStorage implements Storage {
     this.datastoreStorage = Objects.requireNonNull(datastoreStorage, "datastoreStorage");
   }
 
+  @Override
+  public void close() {
+    datastoreStorage.close();
+  }
+
   // TODO: remove after bootstrapping the indexes once
   @Override
   public void indexActiveWorkflowInstances() {

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -60,6 +60,12 @@ public class AggregateStorage implements Storage {
     this.datastoreStorage = Objects.requireNonNull(datastoreStorage, "datastoreStorage");
   }
 
+  // TODO: remove after bootstrapping the indexes once
+  @Override
+  public void indexActiveWorkflowInstances() {
+    datastoreStorage.indexActiveWorkflowInstances();
+  }
+
   @Override
   public SortedSet<SequenceEvent> readEvents(WorkflowInstance workflowInstance) throws IOException {
     return bigtableStorage.readEvents(workflowInstance);

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -67,6 +67,11 @@ public class AggregateStorage implements Storage {
   }
 
   @Override
+  public void concurrentlyIndexActiveWorkflowInstances() {
+    datastoreStorage.concurrentlyIndexActiveWorkflowInstances();
+  }
+
+  @Override
   public SortedSet<SequenceEvent> readEvents(WorkflowInstance workflowInstance) throws IOException {
     return bigtableStorage.readEvents(workflowInstance);
   }

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -188,10 +188,6 @@ public class DatastoreStorage {
     this.retryBaseDelay = Objects.requireNonNull(retryBaseDelay);
     this.storageTransactionFactory = Objects.requireNonNull(storageTransactionFactory);
     this.forkJoinPool = new ForkJoinPool(REQUEST_CONCURRENCY);
-
-    // TODO: remove after bootstrapping the indexes once
-    // XXX: bootstrap indexes as an offline operation instead of here in the styx scheduler process?
-    indexActiveWorkflowInstances();
   }
 
   void indexActiveWorkflowInstances() {

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -172,7 +172,7 @@ public class DatastoreStorage implements Closeable {
   public static final int MAX_RETRIES = 100;
   public static final int MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH = 1000;
 
-  private static final int REQUEST_CONCURRENCY = 2;
+  private static final int REQUEST_CONCURRENCY = 32;
 
   private final Datastore datastore;
   private final Duration retryBaseDelay;

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -57,6 +57,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.BackfillBuilder;
 import com.spotify.styx.model.ExecutionDescription;
@@ -73,10 +74,12 @@ import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.util.FnWithException;
 import com.spotify.styx.util.ResourceNotFoundException;
+import com.spotify.styx.util.StreamUtil;
 import com.spotify.styx.util.TimeUtil;
 import com.spotify.styx.util.TriggerInstantSpec;
 import com.spotify.styx.util.TriggerUtil;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -108,6 +111,8 @@ public class DatastoreStorage {
   public static final String KIND_COMPONENT = "Component";
   public static final String KIND_WORKFLOW = "Workflow";
   public static final String KIND_ACTIVE_WORKFLOW_INSTANCE = "ActiveWorkflowInstance";
+  public static final String KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD = "ActiveWorkflowInstanceIndexShard";
+  public static final String KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD_ENTRY = "ActiveWorkflowInstanceIndexShardEntry";
   public static final String KIND_RESOURCE = "Resource";
   public static final String KIND_BACKFILL = "Backfill";
 
@@ -160,6 +165,8 @@ public class DatastoreStorage {
   public static final boolean DEFAULT_CONFIG_EXECUTION_GATING_ENABLED = false;
   public static final boolean DEFAULT_CONFIG_RESOURCES_SYNC_ENABLED = false;
 
+  public static final int ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARDS = 128;
+
   public static final int MAX_RETRIES = 100;
   public static final int MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH = 1000;
 
@@ -181,6 +188,24 @@ public class DatastoreStorage {
     this.retryBaseDelay = Objects.requireNonNull(retryBaseDelay);
     this.storageTransactionFactory = Objects.requireNonNull(storageTransactionFactory);
     this.forkJoinPool = new ForkJoinPool(REQUEST_CONCURRENCY);
+
+    // TODO: remove after bootstrapping the indexes once
+    // XXX: bootstrap indexes as an offline operation instead of here in the styx scheduler process?
+    indexActiveWorkflowInstances();
+  }
+
+  void indexActiveWorkflowInstances() {
+    // XXX: this listing is not strongly consistent
+    final List<Entity> indexEntries = StreamUtil.stream(
+        datastore.run(Query.newKeyQueryBuilder().setKind(KIND_ACTIVE_WORKFLOW_INSTANCE).build()))
+        .map(Key::getName)
+        .map(wfiKey -> activeWorkflowInstanceIndexShardEntryKey(datastore.newKeyFactory(), wfiKey))
+        .map(indexEntryKey -> Entity.newBuilder(indexEntryKey).build())
+        .collect(toList());
+
+    for (List<Entity> batch : Lists.partition(indexEntries, MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH)) {
+      datastore.put(batch.toArray(new Entity[0]));
+    }
   }
 
   StyxConfig config() {
@@ -377,14 +402,18 @@ public class DatastoreStorage {
   }
 
   /**
-   * Eventually consistently list all active states and strongly consistently fetch their values.
-   *
-   * <p>This method will return a map of active states that might be missing some recently created
-   * states, but the values of all the states returned should be fresh.
+   * Strongly consistently read all active states
    */
   Map<WorkflowInstance, RunState> readActiveStates() throws IOException {
-    // Eventually consistently read active state keys
-    final List<Key> keys = readActiveInstanceKeys();
+    // Strongly read active state keys from index shards
+    final List<Key> keys = activeWorkflowInstanceIndexShardKeys(datastore.newKeyFactory()).stream()
+        .map(key -> forkJoinPool.submit(() ->
+            datastore.run(Query.newEntityQueryBuilder().setFilter(PropertyFilter.hasAncestor(key)).build())))
+        .collect(toList()).stream() // collect here to execute batch reads in parallel
+        .flatMap(task -> StreamUtil.stream(task.join()))
+        .map(entity -> entity.getKey().getName())
+        .map(name -> activeWorkflowInstanceKey(datastore.newKeyFactory(), name))
+        .collect(toList());
 
     // Strongly consistently read values for the above keys
     return Lists.partition(keys, MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH).stream()
@@ -392,17 +421,6 @@ public class DatastoreStorage {
         .collect(toList()).stream() // collect here to execute batch reads in parallel
         .flatMap(task -> task.join().stream())
         .collect(toMap(RunState::workflowInstance, Function.identity()));
-  }
-
-  /**
-   * Eventually consistently query for the keys of all active workflow instances.
-   */
-  private List<Key> readActiveInstanceKeys() {
-    final List<Key> keys = new ArrayList<>();
-    final QueryResults<Key> keyResults = datastore
-        .run(Query.newKeyQueryBuilder().setKind(KIND_ACTIVE_WORKFLOW_INSTANCE).build());
-    keyResults.forEachRemaining(keys::add);
-    return keys;
   }
 
   /**
@@ -486,10 +504,42 @@ public class DatastoreStorage {
     return RunState.create(instance, state, data, Instant.ofEpochMilli(timestamp), counter);
   }
 
-  void writeActiveState(WorkflowInstance workflowInstance, RunState state)
+  WorkflowInstance writeActiveState(WorkflowInstance workflowInstance, RunState state)
       throws IOException {
-    storeWithRetries(() -> datastore.put(
-        runStateToEntity(datastore.newKeyFactory(), workflowInstance, state)));
+    return storeWithRetries(() -> runInTransaction(tx -> tx.writeActiveState(workflowInstance, state)));
+  }
+
+  static List<Key> activeWorkflowInstanceIndexShardKeys(KeyFactory keyFactory) {
+    return IntStream.range(0, ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARDS)
+        .mapToObj(DatastoreStorage::activeWorkflowInstanceIndexShardName)
+        .map(name -> keyFactory.setKind(KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD).newKey(name))
+        .collect(toList());
+  }
+
+  static String activeWorkflowInstanceIndexShardName(WorkflowInstance workflowInstance) {
+    return activeWorkflowInstanceIndexShardName(workflowInstance.toKey());
+  }
+
+  private static String activeWorkflowInstanceIndexShardName(String workflowInstanceKey) {
+    final long hash = Hashing.murmur3_32().hashString(workflowInstanceKey, StandardCharsets.UTF_8).asInt();
+    final long index = Long.remainderUnsigned(hash, ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARDS);
+    return activeWorkflowInstanceIndexShardName(index);
+  }
+
+  private static String activeWorkflowInstanceIndexShardName(long index) {
+    return "shard-" + index;
+  }
+
+  static Key activeWorkflowInstanceIndexShardEntryKey(KeyFactory keyFactory, WorkflowInstance workflowInstance) {
+    final String workflowInstanceKey = workflowInstance.toKey();
+    return activeWorkflowInstanceIndexShardEntryKey(keyFactory, workflowInstanceKey);
+  }
+
+  private static Key activeWorkflowInstanceIndexShardEntryKey(KeyFactory keyFactory, String workflowInstanceKey) {
+    return keyFactory.setKind(KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD_ENTRY)
+        .addAncestor(PathElement.of(KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD,
+            activeWorkflowInstanceIndexShardName(workflowInstanceKey)))
+        .newKey(workflowInstanceKey);
   }
 
   static Entity runStateToEntity(KeyFactory keyFactory, WorkflowInstance wfi, RunState state)
@@ -529,10 +579,7 @@ public class DatastoreStorage {
   }
 
   void deleteActiveState(WorkflowInstance workflowInstance) throws IOException {
-    storeWithRetries(() -> {
-      datastore.delete(activeWorkflowInstanceKey(workflowInstance));
-      return null;
-    });
+    storeWithRetries(() -> runInTransaction(tx -> tx.deleteActiveState(workflowInstance)));
   }
 
   void patchState(WorkflowId workflowId, WorkflowState state) throws IOException {
@@ -589,9 +636,14 @@ public class DatastoreStorage {
   }
 
   static Key activeWorkflowInstanceKey(KeyFactory keyFactory, WorkflowInstance workflowInstance) {
+    final String name = workflowInstance.toKey();
+    return activeWorkflowInstanceKey(keyFactory, name);
+  }
+
+  private static Key activeWorkflowInstanceKey(KeyFactory keyFactory, String name) {
     return keyFactory
         .setKind(KIND_ACTIVE_WORKFLOW_INSTANCE)
-        .newKey(workflowInstance.toKey());
+        .newKey(name);
   }
 
   private WorkflowInstance parseWorkflowInstance(Entity activeWorkflowInstance) {

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -225,7 +225,8 @@ public class DatastoreStorage {
     // Fetch index entries in batches
     for (List<Entity> expectedEntryBatch : Lists.partition(expectedIndexEntries, MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH)) {
 
-      final List<Entity> actualEntryBatch = datastore.fetch(expectedEntryBatch.stream().map(Entity::getKey).toArray(Key[]::new));
+      final List<Entity> actualEntryBatch = datastore.fetch(expectedEntryBatch.stream()
+          .map(Entity::getKey).toArray(Key[]::new));
       assert actualEntryBatch.size() == expectedEntryBatch.size();
 
       for (int i = 0; i < expectedEntryBatch.size(); i++) {

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -582,10 +582,6 @@ public class DatastoreStorage implements Closeable {
         .collect(toList());
   }
 
-  static String activeWorkflowInstanceIndexShardName(WorkflowInstance workflowInstance) {
-    return activeWorkflowInstanceIndexShardName(workflowInstance.toKey());
-  }
-
   private static String activeWorkflowInstanceIndexShardName(String workflowInstanceKey) {
     final long hash = Hashing.murmur3_32().hashString(workflowInstanceKey, StandardCharsets.UTF_8).asInt();
     final long index = Long.remainderUnsigned(hash, ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARDS);

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -458,7 +458,10 @@ public class DatastoreStorage {
     // Strongly read active state keys from index shards
     final List<Key> keys = activeWorkflowInstanceIndexShardKeys(datastore.newKeyFactory()).stream()
         .map(key -> forkJoinPool.submit(() ->
-            datastore.run(Query.newEntityQueryBuilder().setFilter(PropertyFilter.hasAncestor(key)).build())))
+            datastore.run(Query.newEntityQueryBuilder()
+                .setFilter(PropertyFilter.hasAncestor(key))
+                .setKind(KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD_ENTRY)
+                .build())))
         .collect(toList()).stream() // collect here to execute batch reads in parallel
         .flatMap(task -> StreamUtil.stream(task.join()))
         .map(entity -> entity.getKey().getName())

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -172,7 +172,7 @@ public class DatastoreStorage implements Closeable {
   public static final int MAX_RETRIES = 100;
   public static final int MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH = 1000;
 
-  private static final int REQUEST_CONCURRENCY = 32;
+  private static final int REQUEST_CONCURRENCY = 2;
 
   private final Datastore datastore;
   private final Duration retryBaseDelay;

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -125,6 +125,7 @@ public class DatastoreStorage implements Closeable {
   public static final String PROPERTY_CONFIG_EXECUTION_GATING_ENABLED = "executionGatingEnabled";
   public static final String PROPERTY_CONFIG_DEBUG_ENABLED = "debug";
   public static final String PROPERTY_CONFIG_RESOURCES_SYNC_ENABLED = "resourcesSyncEnabled";
+  public static final String PROPERTY_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED = "bootstrapActiveWFIEnabled";
 
   public static final String PROPERTY_WORKFLOW_JSON = "json";
   public static final String PROPERTY_WORKFLOW_ENABLED = "enabled";
@@ -166,6 +167,7 @@ public class DatastoreStorage implements Closeable {
   public static final boolean DEFAULT_CONFIG_DEBUG_ENABLED = false;
   public static final boolean DEFAULT_CONFIG_EXECUTION_GATING_ENABLED = false;
   public static final boolean DEFAULT_CONFIG_RESOURCES_SYNC_ENABLED = false;
+  private static final boolean DEFAULT_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED = false;
 
   public static final int ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARDS = 128;
 
@@ -293,6 +295,8 @@ public class DatastoreStorage implements Closeable {
             .collect(toList()))
         .executionGatingEnabled(
             read(entity, PROPERTY_CONFIG_EXECUTION_GATING_ENABLED, DEFAULT_CONFIG_EXECUTION_GATING_ENABLED))
+        .bootstrapActiveWFIEnabled(
+            read(entity, PROPERTY_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED, DEFAULT_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED))
         .build();
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -305,6 +305,10 @@ public class InMemStorage implements Storage {
   }
 
   @Override
+  public void indexActiveWorkflowInstances() {
+  }
+
+  @Override
   public SortedSet<SequenceEvent> readEvents(WorkflowInstance workflowInstance) {
     final SortedSet<SequenceEvent> events = Sets.newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
     writtenEvents.stream()

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -76,6 +76,10 @@ public class InMemStorage implements Storage {
   }
 
   @Override
+  public void close() {
+  }
+
+  @Override
   public StyxConfig config() {
     return StyxConfig.newBuilder()
         .globalEnabled(true)

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -309,6 +309,10 @@ public class InMemStorage implements Storage {
   }
 
   @Override
+  public void concurrentlyIndexActiveWorkflowInstances() {
+  }
+
+  @Override
   public SortedSet<SequenceEvent> readEvents(WorkflowInstance workflowInstance) {
     final SortedSet<SequenceEvent> events = Sets.newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
     writtenEvents.stream()

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -31,6 +31,7 @@ import com.spotify.styx.model.WorkflowState;
 import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.util.TriggerInstantSpec;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +42,7 @@ import java.util.SortedSet;
 /**
  * The interface to the persistence layer.
  */
-public interface Storage {
+public interface Storage extends Closeable {
 
   // TODO: remove after bootstrapping the indexes once
   void indexActiveWorkflowInstances();

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -46,6 +46,9 @@ public interface Storage {
   // TODO: remove after bootstrapping the indexes once
   void indexActiveWorkflowInstances();
 
+
+  void concurrentlyIndexActiveWorkflowInstances();
+
   /**
    * Returns all {@link SequenceEvent} for a {@link WorkflowInstance} in time order.
    *

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -43,6 +43,9 @@ import java.util.SortedSet;
  */
 public interface Storage {
 
+  // TODO: remove after bootstrapping the indexes once
+  void indexActiveWorkflowInstances();
+
   /**
    * Returns all {@link SequenceEvent} for a {@link WorkflowInstance} in time order.
    *

--- a/styx-common/src/main/java/com/spotify/styx/util/StreamUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/StreamUtil.java
@@ -21,7 +21,10 @@
 package com.spotify.styx.util;
 
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Spliterators;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public final class StreamUtil {
 
@@ -39,5 +42,9 @@ public final class StreamUtil {
   @SafeVarargs
   public static <T> Stream<T> cat(Stream<T>... streams) {
     return Arrays.stream(streams).reduce(Stream.empty(), Stream::concat);
+  }
+
+  public static <T> Stream<T> stream(Iterator<T> iterator) {
+    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false);
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -90,6 +90,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.logging.Level;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -172,6 +173,10 @@ public class DatastoreStorageTest {
 
   @BeforeClass
   public static void setUpClass() throws Exception {
+    final java.util.logging.Logger datastoreEmulatorLogger =
+        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    datastoreEmulatorLogger.setLevel(Level.OFF);
+
     // TODO: the datastore emulator behavior wrt conflicts etc differs from the real datastore
     helper = LocalDatastoreHelper.create(1.0); // 100% global consistency
     helper.start();

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -57,7 +57,6 @@ import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.EntityQuery;
 import com.google.cloud.datastore.Key;
-import com.google.cloud.datastore.KeyQuery;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StringValue;
@@ -197,12 +196,7 @@ public class DatastoreStorageTest {
 
   @After
   public void tearDown() throws Exception {
-    // clear datastore after each test
-    KeyQuery query = Query.newKeyQueryBuilder().build();
-    final QueryResults<Key> keys = datastore.run(query);
-    while (keys.hasNext()) {
-      datastore.delete(keys.next());
-    }
+    helper.reset();
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -23,6 +23,7 @@ package com.spotify.styx.storage;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.hasValue;
 import static com.spotify.styx.model.Schedule.DAYS;
 import static com.spotify.styx.model.Schedule.HOURS;
+import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_CONFIG_RESOURCES_SYNC_ENABLED;
 import static com.spotify.styx.storage.DatastoreStorage.activeWorkflowInstanceIndexShardEntryKey;
 import static com.spotify.styx.testdata.TestData.FULL_WORKFLOW_CONFIGURATION;
@@ -517,6 +518,16 @@ public class DatastoreStorageTest {
     helper.getOptions().getService().put(config);
 
     assertThat(storage.config().resourcesSyncEnabled(), is(true));
+  }
+
+  @Test
+  public void getsBootstrapActiveWFIEnabled() {
+    Entity config = Entity.newBuilder(DatastoreStorage.globalConfigKey(datastore.newKeyFactory()))
+        .set(PROPERTY_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED, true)
+        .build();
+    helper.getOptions().getService().put(config);
+
+    assertThat(storage.config().bootstrapActiveWFIEnabled(), is(true));
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -401,8 +401,7 @@ public class DatastoreStorageTest {
     assertThat(datastore.get(indexEntryKey1), is(nullValue()));
     assertThat(datastore.get(indexEntryKey2), is(nullValue()));
 
-    // reinstantiate storage to reindex
-    storage = new DatastoreStorage(datastore, Duration.ZERO);
+    storage.indexActiveWorkflowInstances();
 
     assertThat(datastore.get(indexEntryKey1), notNullValue());
     assertThat(datastore.get(indexEntryKey2), notNullValue());

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTransactionTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTransactionTest.java
@@ -40,9 +40,6 @@ import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.KeyFactory;
-import com.google.cloud.datastore.KeyQuery;
-import com.google.cloud.datastore.Query;
-import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.Transaction;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import com.spotify.styx.model.Backfill;
@@ -100,12 +97,7 @@ public class DatastoreStorageTransactionTest {
 
   @After
   public void tearDown() throws Exception {
-    // clear datastore after each test
-    KeyQuery query = Query.newKeyQueryBuilder().build();
-    final QueryResults<Key> keys = datastore.run(query);
-    while (keys.hasNext()) {
-      datastore.delete(keys.next());
-    }
+    helper.reset();
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTransactionTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTransactionTest.java
@@ -56,6 +56,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Level;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -73,6 +74,10 @@ public class DatastoreStorageTransactionTest {
 
   @BeforeClass
   public static void setUpClass() throws Exception {
+    final java.util.logging.Logger datastoreEmulatorLogger =
+        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    datastoreEmulatorLogger.setLevel(Level.OFF);
+
     // TODO: the datastore emulator behavior wrt conflicts etc differs from the real datastore
     helper = LocalDatastoreHelper.create(1.0); // 100% global consistency
     helper.start();

--- a/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterSnapshotFactoryTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterSnapshotFactoryTest.java
@@ -22,7 +22,6 @@ package com.spotify.styx.util;
 
 import static com.spotify.styx.util.ShardedCounter.NUM_SHARDS;
 import static com.spotify.styx.util.ShardedCounterSnapshotFactory.TRANSACTION_GROUP_SIZE;
-import static com.spotify.styx.util.ShardedCounterTest.clearDatastore;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.spy;
@@ -83,8 +82,8 @@ public class ShardedCounterSnapshotFactoryTest {
   }
 
   @After
-  public void tearDown() {
-    clearDatastore(datastore);
+  public void tearDown() throws IOException {
+    helper.reset();
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterSnapshotFactoryTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterSnapshotFactoryTest.java
@@ -34,6 +34,7 @@ import com.spotify.styx.storage.AggregateStorage;
 import com.spotify.styx.storage.Storage;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.logging.Level;
 import org.apache.hadoop.hbase.client.Connection;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -57,6 +58,10 @@ public class ShardedCounterSnapshotFactoryTest {
 
   @BeforeClass
   public static void setUpClass() throws IOException, InterruptedException {
+    final java.util.logging.Logger datastoreEmulatorLogger =
+        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    datastoreEmulatorLogger.setLevel(Level.OFF);
+
     helper = LocalDatastoreHelper.create(1.0);
     helper.start();
     datastore = helper.getOptions().getService();

--- a/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
@@ -56,6 +56,7 @@ import com.spotify.styx.storage.Storage;
 import com.spotify.styx.storage.StorageTransaction;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.logging.Level;
 import java.util.stream.IntStream;
 import org.apache.hadoop.hbase.client.Connection;
 import org.junit.After;
@@ -82,6 +83,10 @@ public class ShardedCounterTest {
 
   @BeforeClass
   public static void setUpClass() throws IOException, InterruptedException {
+    final java.util.logging.Logger datastoreEmulatorLogger =
+        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    datastoreEmulatorLogger.setLevel(Level.OFF);
+
     helper = LocalDatastoreHelper.create(1.0);
     helper.start();
     datastore = helper.getOptions().getService();

--- a/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
@@ -108,8 +108,8 @@ public class ShardedCounterTest {
   }
 
   @After
-  public void tearDown() {
-    clearDatastore(datastore);
+  public void tearDown() throws IOException {
+    helper.reset();
   }
 
   @Test
@@ -432,11 +432,6 @@ public class ShardedCounterTest {
   private Key getKey(String counterId, int shardIndex) {
     return datastore.newKeyFactory().setKind(KIND_COUNTER_SHARD)
         .newKey(counterId + "-" + shardIndex);
-  }
-
-  public static void clearDatastore(Datastore datastore) {
-    deleteAllOfKind(datastore, KIND_COUNTER_SHARD);
-    deleteAllOfKind(datastore, KIND_COUNTER_LIMIT);
   }
 
   private static void deleteAllOfKind(Datastore datastore, String kind) {

--- a/styx-scheduler-service/pom.xml
+++ b/styx-scheduler-service/pom.xml
@@ -122,5 +122,10 @@
       <artifactId>JUnitParams</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -323,6 +323,10 @@ public class StyxScheduler implements AppInit {
     final Stats stats = statsFactory.apply(environment);
     final Storage storage = instrument(Storage.class, storageFactory.apply(environment), stats, time);
 
+    // XXX: bootstrap indexes as an offline operation instead of here in the styx scheduler process?
+    // TODO: remove after bootstrapping the indexes once
+    storage.indexActiveWorkflowInstances();
+
     final CounterSnapshotFactory counterSnapshotFactory = new ShardedCounterSnapshotFactory(storage);
     final ShardedCounter shardedCounter = new ShardedCounter(storage, counterSnapshotFactory);
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -322,6 +322,7 @@ public class StyxScheduler implements AppInit {
 
     final Stats stats = statsFactory.apply(environment);
     final Storage storage = instrument(Storage.class, storageFactory.apply(environment), stats, time);
+    closer.register(storage);
 
     // XXX: bootstrap indexes as an offline operation instead of here in the styx scheduler process?
     // TODO: remove after bootstrapping the indexes once

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -327,7 +327,7 @@ public class StyxScheduler implements AppInit {
 
     // XXX: bootstrap indexes as an offline operation instead of here in the styx scheduler process?
     // TODO: remove after bootstrapping the indexes once
-    storage.indexActiveWorkflowInstances();
+    indexActiveWorkflowInstances(storage);
 
     final CounterSnapshotFactory counterSnapshotFactory = new ShardedCounterSnapshotFactory(storage);
     final ShardedCounter shardedCounter = new ShardedCounter(storage, counterSnapshotFactory);
@@ -411,6 +411,17 @@ public class StyxScheduler implements AppInit {
     this.backfillTriggerManager = backfillTriggerManager;
     this.workflowRemoveListener = workflowRemoveListener;
     this.workflowChangeListener = workflowChangeListener;
+  }
+
+  private void indexActiveWorkflowInstances(Storage storage) {
+    try {
+      if (storage.config().bootstrapActiveWFIEnabled()) {
+        storage.indexActiveWorkflowInstances();
+      }
+    } catch (IOException e) {
+      LOG.error("Error while bootstrapping active workflow instances", e);
+      throw new RuntimeException(e);
+    }
   }
 
   @VisibleForTesting

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -120,9 +120,9 @@ public class StyxSchedulerServiceFixture {
   @Before
   public void setUp() throws Exception {
 
-//    final java.util.logging.Logger datastoreEmulatorLogger =
-//        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
-//    datastoreEmulatorLogger.setLevel(Level.OFF);
+    final java.util.logging.Logger datastoreEmulatorLogger =
+        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    datastoreEmulatorLogger.setLevel(Level.OFF);
 
     // TODO: the datastore emulator behavior wrt conflicts etc differs from the real datastore
     localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -69,7 +69,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-//import java.util.logging.Level;
+import java.util.logging.Level;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import org.apache.hadoop.hbase.client.Connection;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -69,7 +69,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
+//import java.util.logging.Level;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import org.apache.hadoop.hbase.client.Connection;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -30,6 +30,10 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 
 import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyQuery;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -75,7 +79,9 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.awaitility.core.ConditionTimeoutException;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,11 +93,11 @@ public class StyxSchedulerServiceFixture {
   private static final Logger LOG = LoggerFactory.getLogger(StyxSchedulerServiceFixture.class);
 
   private Instant now = Instant.parse("1970-01-01T00:00:00Z");
-  private final LocalDatastoreHelper localDatastore;
+  private static LocalDatastoreHelper localDatastore;
 
-  private Datastore datastore;
+  private Datastore datastore = localDatastore.getOptions().getService();
   private Connection bigtable = setupBigTableMockTable(0);
-  protected AggregateStorage storage;
+  protected AggregateStorage storage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
   private DeterministicScheduler executor = new QuietDeterministicScheduler();
   private Set<String> resourceIdsToDecorateWith = Sets.newHashSet();
 
@@ -109,24 +115,30 @@ public class StyxSchedulerServiceFixture {
   private StyxScheduler styxScheduler;
   private ServiceHelper serviceHelper;
 
-  public StyxSchedulerServiceFixture() {
+  @BeforeClass
+  public static void setUpClass() throws Exception {
     final java.util.logging.Logger datastoreEmulatorLogger =
-        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
     datastoreEmulatorLogger.setLevel(Level.OFF);
-
+      
+    // TODO: the datastore emulator behavior wrt conflicts etc differs from the real datastore
     localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency
-    try {
-      localDatastore.start();
-    } catch (IOException | InterruptedException e) {
-      throw new RuntimeException(e);
+    localDatastore.start();
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+    if (localDatastore != null) {
+      try {
+        localDatastore.stop(org.threeten.bp.Duration.ofSeconds(30));
+      } catch (Throwable e) {
+        e.printStackTrace();
+      }
     }
-    datastore = localDatastore.getOptions().getService();
-    storage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
   }
 
   @Before
   public void setUp() throws Exception {
-
     StorageFactory storageFactory = (env) -> storage;
     Time time = () -> now;
     StyxScheduler.StatsFactory statsFactory = (env) -> Stats.NOOP;
@@ -162,12 +174,12 @@ public class StyxSchedulerServiceFixture {
   public void tearDown() throws Exception {
     serviceHelper.close();
 
-    if (localDatastore != null) {
-      try {
-        localDatastore.stop(org.threeten.bp.Duration.ofSeconds(30));
-      } catch (Throwable e) {
-        e.printStackTrace();
-      }
+    // clear datastore after each test
+    Datastore datastore = localDatastore.getOptions().getService();
+    KeyQuery query = Query.newKeyQueryBuilder().build();
+    final QueryResults<Key> keys = datastore.run(query);
+    while (keys.hasNext()) {
+      datastore.delete(keys.next());
     }
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -68,6 +68,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import org.apache.hadoop.hbase.client.Connection;
@@ -109,6 +110,10 @@ public class StyxSchedulerServiceFixture {
   private ServiceHelper serviceHelper;
 
   public StyxSchedulerServiceFixture() {
+    final java.util.logging.Logger datastoreEmulatorLogger =
+        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    datastoreEmulatorLogger.setLevel(Level.OFF);
+
     localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency
     try {
       localDatastore.start();

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -113,6 +113,10 @@ public class StyxSchedulerServiceFixture {
 
   @BeforeClass
   public static void setUpClass() throws Exception {
+    // Schedule a full GC to run every second to mitigate off-heap/direct memory usage.
+    // Without this, the system tests cause the test process memory usage (according to the system) to
+    // balloon to several GB even though the JVM itself is configured to and reports that it is only using a few
+    // hundred MB.
     // (T-T)
     Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(System::gc, 1, 1, SECONDS);
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -75,9 +75,7 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.awaitility.core.ConditionTimeoutException;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,11 +87,11 @@ public class StyxSchedulerServiceFixture {
   private static final Logger LOG = LoggerFactory.getLogger(StyxSchedulerServiceFixture.class);
 
   private Instant now = Instant.parse("1970-01-01T00:00:00Z");
-  private static LocalDatastoreHelper localDatastore;
+  private LocalDatastoreHelper localDatastore;
 
-  private Datastore datastore = localDatastore.getOptions().getService();
+  private Datastore datastore;
   private Connection bigtable = setupBigTableMockTable(0);
-  protected AggregateStorage storage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
+  protected AggregateStorage storage;
   private DeterministicScheduler executor = new QuietDeterministicScheduler();
   private Set<String> resourceIdsToDecorateWith = Sets.newHashSet();
 
@@ -111,30 +109,23 @@ public class StyxSchedulerServiceFixture {
   private StyxScheduler styxScheduler;
   private ServiceHelper serviceHelper;
 
-  @BeforeClass
-  public static void setUpClass() throws Exception {
-    final java.util.logging.Logger datastoreEmulatorLogger =
-    java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
-    datastoreEmulatorLogger.setLevel(Level.OFF);
-      
-    // TODO: the datastore emulator behavior wrt conflicts etc differs from the real datastore
-    localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency
-    localDatastore.start();
-  }
-
-  @AfterClass
-  public static void tearDownClass() throws Exception {
-    if (localDatastore != null) {
-      try {
-        localDatastore.stop(org.threeten.bp.Duration.ofSeconds(30));
-      } catch (Throwable e) {
-        e.printStackTrace();
-      }
-    }
-  }
-
   @Before
   public void setUp() throws Exception {
+
+    final java.util.logging.Logger datastoreEmulatorLogger =
+        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    datastoreEmulatorLogger.setLevel(Level.OFF);
+
+    // TODO: the datastore emulator behavior wrt conflicts etc differs from the real datastore
+    localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency
+    try {
+      localDatastore.start();
+    } catch (IOException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    datastore = localDatastore.getOptions().getService();
+    storage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
+
     StorageFactory storageFactory = (env) -> storage;
     Time time = () -> now;
     StyxScheduler.StatsFactory statsFactory = (env) -> Stats.NOOP;
@@ -170,7 +161,14 @@ public class StyxSchedulerServiceFixture {
   @After
   public void tearDown() throws Exception {
     serviceHelper.close();
-    localDatastore.reset();
+
+    if (localDatastore != null) {
+      try {
+        localDatastore.stop(org.threeten.bp.Duration.ofSeconds(30));
+      } catch (Throwable e) {
+        e.printStackTrace();
+      }
+    }
   }
 
   void injectEvent(Event event) throws IsClosedException, InterruptedException, ExecutionException, TimeoutException {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -30,10 +30,6 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 
 import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.Key;
-import com.google.cloud.datastore.KeyQuery;
-import com.google.cloud.datastore.Query;
-import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -167,20 +163,14 @@ public class StyxSchedulerServiceFixture {
         .setWorkflowConsumerFactory(workflowConsumerFactory)
         .build();
 
-    serviceHelper = ServiceHelper.create(styxScheduler, StyxScheduler.SERVICE_NAME);
+    serviceHelper = ServiceHelper.create(styxScheduler, StyxScheduler.SERVICE_NAME)
+        .startTimeoutSeconds(30);
   }
 
   @After
   public void tearDown() throws Exception {
     serviceHelper.close();
-
-    // clear datastore after each test
-    Datastore datastore = localDatastore.getOptions().getService();
-    KeyQuery query = Query.newKeyQueryBuilder().build();
-    final QueryResults<Key> keys = datastore.run(query);
-    while (keys.hasNext()) {
-      datastore.delete(keys.next());
-    }
+    localDatastore.reset();
   }
 
   void injectEvent(Event event) throws IsClosedException, InterruptedException, ExecutionException, TimeoutException {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -76,7 +76,6 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.awaitility.core.ConditionTimeoutException;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
@@ -90,11 +89,11 @@ public class StyxSchedulerServiceFixture {
   private static final Logger LOG = LoggerFactory.getLogger(StyxSchedulerServiceFixture.class);
 
   private Instant now = Instant.parse("1970-01-01T00:00:00Z");
-  private static LocalDatastoreHelper localDatastore;
+  private LocalDatastoreHelper localDatastore;
 
-  private Datastore datastore = localDatastore.getOptions().getService();
+  private Datastore datastore;
   private Connection bigtable = setupBigTableMockTable(0);
-  protected AggregateStorage storage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
+  protected AggregateStorage storage;
   private DeterministicScheduler executor = new QuietDeterministicScheduler();
   private Set<String> resourceIdsToDecorateWith = Sets.newHashSet();
 
@@ -116,29 +115,25 @@ public class StyxSchedulerServiceFixture {
   public static void setUpClass() throws Exception {
     // (T-T)
     Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(System::gc, 1, 1, SECONDS);
-
-    final java.util.logging.Logger datastoreEmulatorLogger =
-    java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
-    datastoreEmulatorLogger.setLevel(Level.OFF);
-      
-    // TODO: the datastore emulator behavior wrt conflicts etc differs from the real datastore
-    localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency
-    localDatastore.start();
-  }
-
-  @AfterClass
-  public static void tearDownClass() throws Exception {
-    if (localDatastore != null) {
-      try {
-        localDatastore.stop(org.threeten.bp.Duration.ofSeconds(30));
-      } catch (Throwable e) {
-        e.printStackTrace();
-      }
-    }
   }
 
   @Before
   public void setUp() throws Exception {
+
+    final java.util.logging.Logger datastoreEmulatorLogger =
+        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    datastoreEmulatorLogger.setLevel(Level.OFF);
+
+    // TODO: the datastore emulator behavior wrt conflicts etc differs from the real datastore
+    localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency
+    try {
+      localDatastore.start();
+    } catch (IOException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    datastore = localDatastore.getOptions().getService();
+    storage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
+
     StorageFactory storageFactory = (env) -> storage;
     Time time = () -> now;
     StyxScheduler.StatsFactory statsFactory = (env) -> Stats.NOOP;
@@ -174,7 +169,14 @@ public class StyxSchedulerServiceFixture {
   @After
   public void tearDown() throws Exception {
     serviceHelper.close();
-    localDatastore.reset();
+
+    if (localDatastore != null) {
+      try {
+        localDatastore.stop(org.threeten.bp.Duration.ofSeconds(30));
+      } catch (Throwable e) {
+        e.printStackTrace();
+      }
+    }
   }
 
   void injectEvent(Event event) throws IsClosedException, InterruptedException, ExecutionException, TimeoutException {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -120,9 +120,9 @@ public class StyxSchedulerServiceFixture {
   @Before
   public void setUp() throws Exception {
 
-    final java.util.logging.Logger datastoreEmulatorLogger =
-        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
-    datastoreEmulatorLogger.setLevel(Level.OFF);
+//    final java.util.logging.Logger datastoreEmulatorLogger =
+//        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+//    datastoreEmulatorLogger.setLevel(Level.OFF);
 
     // TODO: the datastore emulator behavior wrt conflicts etc differs from the real datastore
     localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -65,6 +65,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -76,6 +77,7 @@ import org.awaitility.core.ConditionTimeoutException;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,6 +110,12 @@ public class StyxSchedulerServiceFixture {
   // service and helper
   private StyxScheduler styxScheduler;
   private ServiceHelper serviceHelper;
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    // (T-T)
+    Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(System::gc, 1, 1, SECONDS);
+  }
 
   @Before
   public void setUp() throws Exception {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -60,11 +60,22 @@ import java.util.List;
 import java.util.Optional;
 import junitparams.JUnitParamsRunner;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 @RunWith(JUnitParamsRunner.class)
 public class SystemTest extends StyxSchedulerServiceFixture {
+
+  @Rule
+  public TestRule watcher = new TestWatcher() {
+    protected void starting(Description description) {
+      System.out.println("Starting test: " + description.getMethodName());
+    }
+  };
 
   private static final WorkflowConfiguration WORKFLOW_CONFIGURATION_HOURLY =
       WorkflowConfiguration.builder()

--- a/styx-scheduler-service/src/test/resources/logback.xml
+++ b/styx-scheduler-service/src/test/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+  <root level="info">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+      <name>STDOUT</name>
+      <encoder>
+        <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      </encoder>
+    </appender>
+  </root>
+</configuration>

--- a/styx-scheduler-service/src/test/resources/logback.xml
+++ b/styx-scheduler-service/src/test/resources/logback.xml
@@ -1,5 +1,5 @@
 <configuration>
-  <root level="info">
+  <root level="warn">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
       <name>STDOUT</name>
       <encoder>


### PR DESCRIPTION
Active workflow instances are indexed using 128 entity groups (index shards). 

The id's of the instances are stored as the names of child entities in the index shards. The entities themselves are empty.

This avoids the 1MB max entity size limit that might be hit if instance id's are stored as list properties.