### PR TITLE
Do not use common FJP

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -363,6 +363,7 @@ public class StyxScheduler implements AppInit {
     final TriggerListener trigger =
         new StateInitializingTrigger(stateManager);
     final TriggerManager triggerManager = new TriggerManager(trigger, time, storage, stats);
+    closer.register(triggerManager);
 
     final BackfillTriggerManager backfillTriggerManager =
         new BackfillTriggerManager(stateManager, storage, trigger, stats, time);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
@@ -71,8 +71,9 @@ public class TriggerManagerTest {
   private final ExecutorService executor = Executors.newCachedThreadPool();
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     executor.shutdownNow();
+    triggerManager.close();
   }
 
   @Before


### PR DESCRIPTION
This is on critical path and trigger is usually very slow due to
datastore operation.

@danielnorberg Let's talk about this.