### PR TITLE
strongly consistent wfi listing using shards

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/model/StyxConfig.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/StyxConfig.java
@@ -48,6 +48,11 @@ public interface StyxConfig {
   boolean resourcesSyncEnabled();
 
   /**
+   * Get the flag for enabling bootstrap of activeWFI indexes at startup.
+   */
+  boolean bootstrapActiveWFIEnabled();
+
+  /**
    * Controls whether workflow instance execution gating should be performed. If set to false,
    * instances will be executed without checking for blockers.
    */

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -60,6 +60,11 @@ public class AggregateStorage implements Storage {
     this.datastoreStorage = Objects.requireNonNull(datastoreStorage, "datastoreStorage");
   }
 
+  @Override
+  public void close() {
+    datastoreStorage.close();
+  }
+
   // TODO: remove after bootstrapping the indexes once
   @Override
   public void indexActiveWorkflowInstances() {

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -60,6 +60,12 @@ public class AggregateStorage implements Storage {
     this.datastoreStorage = Objects.requireNonNull(datastoreStorage, "datastoreStorage");
   }
 
+  // TODO: remove after bootstrapping the indexes once
+  @Override
+  public void indexActiveWorkflowInstances() {
+    datastoreStorage.indexActiveWorkflowInstances();
+  }
+
   @Override
   public SortedSet<SequenceEvent> readEvents(WorkflowInstance workflowInstance) throws IOException {
     return bigtableStorage.readEvents(workflowInstance);

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -67,6 +67,11 @@ public class AggregateStorage implements Storage {
   }
 
   @Override
+  public void concurrentlyIndexActiveWorkflowInstances() {
+    datastoreStorage.concurrentlyIndexActiveWorkflowInstances();
+  }
+
+  @Override
   public SortedSet<SequenceEvent> readEvents(WorkflowInstance workflowInstance) throws IOException {
     return bigtableStorage.readEvents(workflowInstance);
   }

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -188,10 +188,6 @@ public class DatastoreStorage {
     this.retryBaseDelay = Objects.requireNonNull(retryBaseDelay);
     this.storageTransactionFactory = Objects.requireNonNull(storageTransactionFactory);
     this.forkJoinPool = new ForkJoinPool(REQUEST_CONCURRENCY);
-
-    // TODO: remove after bootstrapping the indexes once
-    // XXX: bootstrap indexes as an offline operation instead of here in the styx scheduler process?
-    indexActiveWorkflowInstances();
   }
 
   void indexActiveWorkflowInstances() {

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -57,6 +57,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.BackfillBuilder;
 import com.spotify.styx.model.ExecutionDescription;
@@ -73,10 +74,12 @@ import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.util.FnWithException;
 import com.spotify.styx.util.ResourceNotFoundException;
+import com.spotify.styx.util.StreamUtil;
 import com.spotify.styx.util.TimeUtil;
 import com.spotify.styx.util.TriggerInstantSpec;
 import com.spotify.styx.util.TriggerUtil;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -108,6 +111,8 @@ public class DatastoreStorage {
   public static final String KIND_COMPONENT = "Component";
   public static final String KIND_WORKFLOW = "Workflow";
   public static final String KIND_ACTIVE_WORKFLOW_INSTANCE = "ActiveWorkflowInstance";
+  public static final String KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD = "ActiveWorkflowInstanceIndexShard";
+  public static final String KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD_ENTRY = "ActiveWorkflowInstanceIndexShardEntry";
   public static final String KIND_RESOURCE = "Resource";
   public static final String KIND_BACKFILL = "Backfill";
 
@@ -160,6 +165,8 @@ public class DatastoreStorage {
   public static final boolean DEFAULT_CONFIG_EXECUTION_GATING_ENABLED = false;
   public static final boolean DEFAULT_CONFIG_RESOURCES_SYNC_ENABLED = false;
 
+  public static final int ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARDS = 128;
+
   public static final int MAX_RETRIES = 100;
   public static final int MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH = 1000;
 
@@ -181,6 +188,24 @@ public class DatastoreStorage {
     this.retryBaseDelay = Objects.requireNonNull(retryBaseDelay);
     this.storageTransactionFactory = Objects.requireNonNull(storageTransactionFactory);
     this.forkJoinPool = new ForkJoinPool(REQUEST_CONCURRENCY);
+
+    // TODO: remove after bootstrapping the indexes once
+    // XXX: bootstrap indexes as an offline operation instead of here in the styx scheduler process?
+    indexActiveWorkflowInstances();
+  }
+
+  void indexActiveWorkflowInstances() {
+    // XXX: this listing is not strongly consistent
+    final List<Entity> indexEntries = StreamUtil.stream(
+        datastore.run(Query.newKeyQueryBuilder().setKind(KIND_ACTIVE_WORKFLOW_INSTANCE).build()))
+        .map(Key::getName)
+        .map(wfiKey -> activeWorkflowInstanceIndexShardEntryKey(datastore.newKeyFactory(), wfiKey))
+        .map(indexEntryKey -> Entity.newBuilder(indexEntryKey).build())
+        .collect(toList());
+
+    for (List<Entity> batch : Lists.partition(indexEntries, MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH)) {
+      datastore.put(batch.toArray(new Entity[0]));
+    }
   }
 
   StyxConfig config() {
@@ -377,14 +402,18 @@ public class DatastoreStorage {
   }
 
   /**
-   * Eventually consistently list all active states and strongly consistently fetch their values.
-   *
-   * <p>This method will return a map of active states that might be missing some recently created
-   * states, but the values of all the states returned should be fresh.
+   * Strongly consistently read all active states
    */
   Map<WorkflowInstance, RunState> readActiveStates() throws IOException {
-    // Eventually consistently read active state keys
-    final List<Key> keys = readActiveInstanceKeys();
+    // Strongly read active state keys from index shards
+    final List<Key> keys = activeWorkflowInstanceIndexShardKeys(datastore.newKeyFactory()).stream()
+        .map(key -> forkJoinPool.submit(() ->
+            datastore.run(Query.newEntityQueryBuilder().setFilter(PropertyFilter.hasAncestor(key)).build())))
+        .collect(toList()).stream() // collect here to execute batch reads in parallel
+        .flatMap(task -> StreamUtil.stream(task.join()))
+        .map(entity -> entity.getKey().getName())
+        .map(name -> activeWorkflowInstanceKey(datastore.newKeyFactory(), name))
+        .collect(toList());
 
     // Strongly consistently read values for the above keys
     return Lists.partition(keys, MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH).stream()
@@ -392,17 +421,6 @@ public class DatastoreStorage {
         .collect(toList()).stream() // collect here to execute batch reads in parallel
         .flatMap(task -> task.join().stream())
         .collect(toMap(RunState::workflowInstance, Function.identity()));
-  }
-
-  /**
-   * Eventually consistently query for the keys of all active workflow instances.
-   */
-  private List<Key> readActiveInstanceKeys() {
-    final List<Key> keys = new ArrayList<>();
-    final QueryResults<Key> keyResults = datastore
-        .run(Query.newKeyQueryBuilder().setKind(KIND_ACTIVE_WORKFLOW_INSTANCE).build());
-    keyResults.forEachRemaining(keys::add);
-    return keys;
   }
 
   /**
@@ -486,10 +504,42 @@ public class DatastoreStorage {
     return RunState.create(instance, state, data, Instant.ofEpochMilli(timestamp), counter);
   }
 
-  void writeActiveState(WorkflowInstance workflowInstance, RunState state)
+  WorkflowInstance writeActiveState(WorkflowInstance workflowInstance, RunState state)
       throws IOException {
-    storeWithRetries(() -> datastore.put(
-        runStateToEntity(datastore.newKeyFactory(), workflowInstance, state)));
+    return storeWithRetries(() -> runInTransaction(tx -> tx.writeActiveState(workflowInstance, state)));
+  }
+
+  static List<Key> activeWorkflowInstanceIndexShardKeys(KeyFactory keyFactory) {
+    return IntStream.range(0, ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARDS)
+        .mapToObj(DatastoreStorage::activeWorkflowInstanceIndexShardName)
+        .map(name -> keyFactory.setKind(KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD).newKey(name))
+        .collect(toList());
+  }
+
+  static String activeWorkflowInstanceIndexShardName(WorkflowInstance workflowInstance) {
+    return activeWorkflowInstanceIndexShardName(workflowInstance.toKey());
+  }
+
+  private static String activeWorkflowInstanceIndexShardName(String workflowInstanceKey) {
+    final long hash = Hashing.murmur3_32().hashString(workflowInstanceKey, StandardCharsets.UTF_8).asInt();
+    final long index = Long.remainderUnsigned(hash, ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARDS);
+    return activeWorkflowInstanceIndexShardName(index);
+  }
+
+  private static String activeWorkflowInstanceIndexShardName(long index) {
+    return "shard-" + index;
+  }
+
+  static Key activeWorkflowInstanceIndexShardEntryKey(KeyFactory keyFactory, WorkflowInstance workflowInstance) {
+    final String workflowInstanceKey = workflowInstance.toKey();
+    return activeWorkflowInstanceIndexShardEntryKey(keyFactory, workflowInstanceKey);
+  }
+
+  private static Key activeWorkflowInstanceIndexShardEntryKey(KeyFactory keyFactory, String workflowInstanceKey) {
+    return keyFactory.setKind(KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD_ENTRY)
+        .addAncestor(PathElement.of(KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD,
+            activeWorkflowInstanceIndexShardName(workflowInstanceKey)))
+        .newKey(workflowInstanceKey);
   }
 
   static Entity runStateToEntity(KeyFactory keyFactory, WorkflowInstance wfi, RunState state)
@@ -529,10 +579,7 @@ public class DatastoreStorage {
   }
 
   void deleteActiveState(WorkflowInstance workflowInstance) throws IOException {
-    storeWithRetries(() -> {
-      datastore.delete(activeWorkflowInstanceKey(workflowInstance));
-      return null;
-    });
+    storeWithRetries(() -> runInTransaction(tx -> tx.deleteActiveState(workflowInstance)));
   }
 
   void patchState(WorkflowId workflowId, WorkflowState state) throws IOException {
@@ -589,9 +636,14 @@ public class DatastoreStorage {
   }
 
   static Key activeWorkflowInstanceKey(KeyFactory keyFactory, WorkflowInstance workflowInstance) {
+    final String name = workflowInstance.toKey();
+    return activeWorkflowInstanceKey(keyFactory, name);
+  }
+
+  private static Key activeWorkflowInstanceKey(KeyFactory keyFactory, String name) {
     return keyFactory
         .setKind(KIND_ACTIVE_WORKFLOW_INSTANCE)
-        .newKey(workflowInstance.toKey());
+        .newKey(name);
   }
 
   private WorkflowInstance parseWorkflowInstance(Entity activeWorkflowInstance) {

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -225,7 +225,8 @@ public class DatastoreStorage {
     // Fetch index entries in batches
     for (List<Entity> expectedEntryBatch : Lists.partition(expectedIndexEntries, MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH)) {
 
-      final List<Entity> actualEntryBatch = datastore.fetch(expectedEntryBatch.stream().map(Entity::getKey).toArray(Key[]::new));
+      final List<Entity> actualEntryBatch = datastore.fetch(expectedEntryBatch.stream()
+          .map(Entity::getKey).toArray(Key[]::new));
       assert actualEntryBatch.size() == expectedEntryBatch.size();
 
       for (int i = 0; i < expectedEntryBatch.size(); i++) {

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -582,10 +582,6 @@ public class DatastoreStorage implements Closeable {
         .collect(toList());
   }
 
-  static String activeWorkflowInstanceIndexShardName(WorkflowInstance workflowInstance) {
-    return activeWorkflowInstanceIndexShardName(workflowInstance.toKey());
-  }
-
   private static String activeWorkflowInstanceIndexShardName(String workflowInstanceKey) {
     final long hash = Hashing.murmur3_32().hashString(workflowInstanceKey, StandardCharsets.UTF_8).asInt();
     final long index = Long.remainderUnsigned(hash, ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARDS);

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -458,7 +458,10 @@ public class DatastoreStorage {
     // Strongly read active state keys from index shards
     final List<Key> keys = activeWorkflowInstanceIndexShardKeys(datastore.newKeyFactory()).stream()
         .map(key -> forkJoinPool.submit(() ->
-            datastore.run(Query.newEntityQueryBuilder().setFilter(PropertyFilter.hasAncestor(key)).build())))
+            datastore.run(Query.newEntityQueryBuilder()
+                .setFilter(PropertyFilter.hasAncestor(key))
+                .setKind(KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD_ENTRY)
+                .build())))
         .collect(toList()).stream() // collect here to execute batch reads in parallel
         .flatMap(task -> StreamUtil.stream(task.join()))
         .map(entity -> entity.getKey().getName())

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -125,6 +125,7 @@ public class DatastoreStorage implements Closeable {
   public static final String PROPERTY_CONFIG_EXECUTION_GATING_ENABLED = "executionGatingEnabled";
   public static final String PROPERTY_CONFIG_DEBUG_ENABLED = "debug";
   public static final String PROPERTY_CONFIG_RESOURCES_SYNC_ENABLED = "resourcesSyncEnabled";
+  public static final String PROPERTY_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED = "bootstrapActiveWFIEnabled";
 
   public static final String PROPERTY_WORKFLOW_JSON = "json";
   public static final String PROPERTY_WORKFLOW_ENABLED = "enabled";
@@ -166,6 +167,7 @@ public class DatastoreStorage implements Closeable {
   public static final boolean DEFAULT_CONFIG_DEBUG_ENABLED = false;
   public static final boolean DEFAULT_CONFIG_EXECUTION_GATING_ENABLED = false;
   public static final boolean DEFAULT_CONFIG_RESOURCES_SYNC_ENABLED = false;
+  private static final boolean DEFAULT_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED = false;
 
   public static final int ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARDS = 128;
 
@@ -293,6 +295,8 @@ public class DatastoreStorage implements Closeable {
             .collect(toList()))
         .executionGatingEnabled(
             read(entity, PROPERTY_CONFIG_EXECUTION_GATING_ENABLED, DEFAULT_CONFIG_EXECUTION_GATING_ENABLED))
+        .bootstrapActiveWFIEnabled(
+            read(entity, PROPERTY_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED, DEFAULT_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED))
         .build();
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -305,6 +305,10 @@ public class InMemStorage implements Storage {
   }
 
   @Override
+  public void indexActiveWorkflowInstances() {
+  }
+
+  @Override
   public SortedSet<SequenceEvent> readEvents(WorkflowInstance workflowInstance) {
     final SortedSet<SequenceEvent> events = Sets.newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
     writtenEvents.stream()

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -76,6 +76,10 @@ public class InMemStorage implements Storage {
   }
 
   @Override
+  public void close() {
+  }
+
+  @Override
   public StyxConfig config() {
     return StyxConfig.newBuilder()
         .globalEnabled(true)

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -309,6 +309,10 @@ public class InMemStorage implements Storage {
   }
 
   @Override
+  public void concurrentlyIndexActiveWorkflowInstances() {
+  }
+
+  @Override
   public SortedSet<SequenceEvent> readEvents(WorkflowInstance workflowInstance) {
     final SortedSet<SequenceEvent> events = Sets.newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
     writtenEvents.stream()

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -31,6 +31,7 @@ import com.spotify.styx.model.WorkflowState;
 import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.util.TriggerInstantSpec;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +42,7 @@ import java.util.SortedSet;
 /**
  * The interface to the persistence layer.
  */
-public interface Storage {
+public interface Storage extends Closeable {
 
   // TODO: remove after bootstrapping the indexes once
   void indexActiveWorkflowInstances();

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -46,6 +46,9 @@ public interface Storage {
   // TODO: remove after bootstrapping the indexes once
   void indexActiveWorkflowInstances();
 
+
+  void concurrentlyIndexActiveWorkflowInstances();
+
   /**
    * Returns all {@link SequenceEvent} for a {@link WorkflowInstance} in time order.
    *

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -43,6 +43,9 @@ import java.util.SortedSet;
  */
 public interface Storage {
 
+  // TODO: remove after bootstrapping the indexes once
+  void indexActiveWorkflowInstances();
+
   /**
    * Returns all {@link SequenceEvent} for a {@link WorkflowInstance} in time order.
    *

--- a/styx-common/src/main/java/com/spotify/styx/util/StreamUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/StreamUtil.java
@@ -21,7 +21,10 @@
 package com.spotify.styx.util;
 
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Spliterators;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public final class StreamUtil {
 
@@ -39,5 +42,9 @@ public final class StreamUtil {
   @SafeVarargs
   public static <T> Stream<T> cat(Stream<T>... streams) {
     return Arrays.stream(streams).reduce(Stream.empty(), Stream::concat);
+  }
+
+  public static <T> Stream<T> stream(Iterator<T> iterator) {
+    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false);
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -23,6 +23,7 @@ package com.spotify.styx.storage;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.hasValue;
 import static com.spotify.styx.model.Schedule.DAYS;
 import static com.spotify.styx.model.Schedule.HOURS;
+import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_CONFIG_RESOURCES_SYNC_ENABLED;
 import static com.spotify.styx.storage.DatastoreStorage.activeWorkflowInstanceIndexShardEntryKey;
 import static com.spotify.styx.testdata.TestData.FULL_WORKFLOW_CONFIGURATION;
@@ -518,6 +519,16 @@ public class DatastoreStorageTest {
     helper.getOptions().getService().put(config);
 
     assertThat(storage.config().resourcesSyncEnabled(), is(true));
+  }
+
+  @Test
+  public void getsBootstrapActiveWFIEnabled() {
+    Entity config = Entity.newBuilder(DatastoreStorage.globalConfigKey(datastore.newKeyFactory()))
+        .set(PROPERTY_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED, true)
+        .build();
+    helper.getOptions().getService().put(config);
+
+    assertThat(storage.config().bootstrapActiveWFIEnabled(), is(true));
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -401,8 +401,7 @@ public class DatastoreStorageTest {
     assertThat(datastore.get(indexEntryKey1), is(nullValue()));
     assertThat(datastore.get(indexEntryKey2), is(nullValue()));
 
-    // reinstantiate storage to reindex
-    storage = new DatastoreStorage(datastore, Duration.ZERO);
+    storage.indexActiveWorkflowInstances();
 
     assertThat(datastore.get(indexEntryKey1), notNullValue());
     assertThat(datastore.get(indexEntryKey2), notNullValue());

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -323,6 +323,10 @@ public class StyxScheduler implements AppInit {
     final Stats stats = statsFactory.apply(environment);
     final Storage storage = instrument(Storage.class, storageFactory.apply(environment), stats, time);
 
+    // XXX: bootstrap indexes as an offline operation instead of here in the styx scheduler process?
+    // TODO: remove after bootstrapping the indexes once
+    storage.indexActiveWorkflowInstances();
+
     final CounterSnapshotFactory counterSnapshotFactory = new ShardedCounterSnapshotFactory(storage);
     final ShardedCounter shardedCounter = new ShardedCounter(storage, counterSnapshotFactory);
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -322,6 +322,7 @@ public class StyxScheduler implements AppInit {
 
     final Stats stats = statsFactory.apply(environment);
     final Storage storage = instrument(Storage.class, storageFactory.apply(environment), stats, time);
+    closer.register(storage);
 
     // XXX: bootstrap indexes as an offline operation instead of here in the styx scheduler process?
     // TODO: remove after bootstrapping the indexes once

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -141,6 +141,7 @@ public class StyxScheduler implements AppInit {
   public static final int SCHEDULER_TICK_INTERVAL_SECONDS = 2;
   public static final int TRIGGER_MANAGER_TICK_INTERVAL_SECONDS = 1;
   public static final long CLEANER_TICK_INTERVAL_SECONDS = MINUTES.toSeconds(30);
+  public static final long CONCURRENT_WORKFLOW_INSTANCE_INDEXING_INTERVAL_SECONDS = MINUTES.toSeconds(30);
   public static final int RUNTIME_CONFIG_UPDATE_INTERVAL_SECONDS = 5;
   public static final Duration DEFAULT_RETRY_BASE_DELAY = Duration.ofMinutes(3);
   public static final int DEFAULT_RETRY_MAX_EXPONENT = 4;
@@ -393,6 +394,7 @@ public class StyxScheduler implements AppInit {
     startScheduler(scheduler, executor);
     startRuntimeConfigUpdate(styxConfig, executor, dequeueRateLimiter);
     startCleaner(cleaner, executor);
+    startConcurrentWorkflowInstanceIndexing(storage, executor);
     setupMetrics(stateManager, workflowCache, storage, dequeueRateLimiter, stats);
 
     final SchedulerResource schedulerResource =
@@ -541,6 +543,14 @@ public class StyxScheduler implements AppInit {
         guard(cleaner::tick),
         0,
         CLEANER_TICK_INTERVAL_SECONDS,
+        SECONDS);
+  }
+
+  private static void startConcurrentWorkflowInstanceIndexing(Storage storage, ScheduledExecutorService exec) {
+    exec.scheduleWithFixedDelay(
+        guard(storage::concurrentlyIndexActiveWorkflowInstances),
+        CONCURRENT_WORKFLOW_INSTANCE_INDEXING_INTERVAL_SECONDS,
+        CONCURRENT_WORKFLOW_INSTANCE_INDEXING_INTERVAL_SECONDS,
         SECONDS);
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -327,7 +327,7 @@ public class StyxScheduler implements AppInit {
 
     // XXX: bootstrap indexes as an offline operation instead of here in the styx scheduler process?
     // TODO: remove after bootstrapping the indexes once
-    storage.indexActiveWorkflowInstances();
+    indexActiveWorkflowInstances(storage);
 
     final CounterSnapshotFactory counterSnapshotFactory = new ShardedCounterSnapshotFactory(storage);
     final ShardedCounter shardedCounter = new ShardedCounter(storage, counterSnapshotFactory);
@@ -411,6 +411,17 @@ public class StyxScheduler implements AppInit {
     this.backfillTriggerManager = backfillTriggerManager;
     this.workflowRemoveListener = workflowRemoveListener;
     this.workflowChangeListener = workflowChangeListener;
+  }
+
+  private void indexActiveWorkflowInstances(Storage storage) {
+    try {
+      if (storage.config().bootstrapActiveWFIEnabled()) {
+        storage.indexActiveWorkflowInstances();
+      }
+    } catch (IOException e) {
+      LOG.error("Error while bootstrapping active workflow instances", e);
+      throw new RuntimeException(e);
+    }
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Active workflow instances are indexed using 128 entity groups (index shards).

The id's of the instances are stored as the names of child entities in the index shards. The entities themselves are empty.

This avoids the 1MB max entity size limit that might be hit if instance id's are stored as list properties.