### PR TITLE
trigger backfill in reversed order

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
@@ -26,10 +26,11 @@ import static com.spotify.styx.serialization.Json.serialize;
 import static com.spotify.styx.util.ParameterUtil.toParameter;
 import static com.spotify.styx.util.StreamUtil.cat;
 import static com.spotify.styx.util.TimeUtil.instantsInRange;
-import static com.spotify.styx.util.TimeUtil.instantsInReversedRange;
+import static com.spotify.styx.util.TimeUtil.nextInstant;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.Iterables;
 import com.spotify.apollo.Client;
 import com.spotify.apollo.Request;
 import com.spotify.apollo.RequestContext;
@@ -272,6 +273,11 @@ public final class BackfillResource {
           + String.join(", ", errors)));
     }
 
+    if (!input.start().isBefore(input.end())) {
+      return Response.forStatus(
+          Status.BAD_REQUEST.withReasonPhrase("start must be before end"));
+    }
+
     if (!TimeUtil.isAligned(input.start(), schedule)) {
       return Response.forStatus(
           Status.BAD_REQUEST.withReasonPhrase("start parameter not aligned with schedule"));
@@ -282,8 +288,9 @@ public final class BackfillResource {
           Status.BAD_REQUEST.withReasonPhrase("end parameter not aligned with schedule"));
     }
 
+    final List<Instant> instants = instantsInRange(input.start(), input.end(), schedule);
     final List<WorkflowInstance> alreadyActive =
-        instants(input.start(), input.end(), schedule).stream()
+        instants.stream()
             .map(instant -> WorkflowInstance.create(workflowId, toParameter(schedule, instant)))
             .filter(activeWorkflowInstances::contains)
             .collect(toList());
@@ -305,8 +312,11 @@ public final class BackfillResource {
         .start(input.start())
         .end(input.end())
         .schedule(schedule)
-        .nextTrigger(input.start())
+        .nextTrigger(input.reverse()
+            ? Iterables.getLast(instants)
+            : input.start())
         .description(input.description())
+        .reverse(input.reverse())
         .halted(false);
 
     final Backfill backfill = builder.build();
@@ -348,8 +358,13 @@ public final class BackfillResource {
       throw new RuntimeException(e);
     }
 
-    final List<Instant> processedInstants = instants(
-        backfill.start(), backfill.nextTrigger(), backfill.schedule());
+    final List<Instant> processedInstants;
+    if (backfill.reverse()) {
+      final Instant firstInstant = nextInstant(backfill.nextTrigger(), backfill.schedule());
+      processedInstants = instantsInRange(firstInstant, backfill.end(), backfill.schedule());
+    } else {
+      processedInstants = instantsInRange(backfill.start(), backfill.nextTrigger(), backfill.schedule());
+    }
     processedStates = processedInstants.parallelStream()
         .map(instant -> {
           final WorkflowInstance wfi = WorkflowInstance
@@ -368,8 +383,13 @@ public final class BackfillResource {
         })
         .collect(toList());
 
-    final List<Instant> waitingInstants = instants(
-        backfill.nextTrigger(), backfill.end(), backfill.schedule());
+    final List<Instant> waitingInstants;
+    if (backfill.reverse()) {
+      final Instant lastInstant = nextInstant(backfill.nextTrigger(), backfill.schedule());
+      waitingInstants = instantsInRange(backfill.start(), lastInstant, backfill.schedule());
+    } else {
+      waitingInstants = instantsInRange(backfill.nextTrigger(), backfill.end(), backfill.schedule());
+    }
     waitingStates = waitingInstants.stream()
         .map(instant -> {
           final WorkflowInstance wfi = WorkflowInstance.create(
@@ -378,12 +398,9 @@ public final class BackfillResource {
         })
         .collect(toList());
 
-    return Stream.concat(processedStates.stream(), waitingStates.stream()).collect(toList());
+    return backfill.reverse()
+        ? Stream.concat(waitingStates.stream(), processedStates.stream()).collect(toList())
+        : Stream.concat(processedStates.stream(), waitingStates.stream()).collect(toList());
   }
 
-  private static List<Instant> instants(Instant start, Instant end, Schedule schedule) {
-    return start.isAfter(end)
-           ? instantsInReversedRange(start, end, schedule)
-           : instantsInRange(start, end, schedule);
-  }
 }

--- a/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
@@ -382,7 +382,8 @@ public final class BackfillResource {
   }
 
   private static List<Instant> instants(Instant start, Instant end, Schedule schedule) {
-    return start.isAfter(end) ? instantsInReversedRange(start, end, schedule) :
-           instantsInRange(start, end, schedule);
+    return start.isAfter(end)
+           ? instantsInReversedRange(start, end, schedule)
+           : instantsInRange(start, end, schedule);
   }
 }

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -430,6 +430,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     assertThat(postedBackfill.schedule(), equalTo(Schedule.HOURS));
     assertThat(postedBackfill.allTriggered(), equalTo(false));
     assertThat(postedBackfill.halted(), equalTo(false));
+    assertThat(postedBackfill.reverse(), equalTo(false));
   }
 
   @Test
@@ -460,6 +461,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     assertThat(postedBackfill.schedule(), equalTo(Schedule.HOURS));
     assertThat(postedBackfill.allTriggered(), equalTo(false));
     assertThat(postedBackfill.halted(), equalTo(false));
+    assertThat(postedBackfill.reverse(), equalTo(true));
   }
 
   @Test

--- a/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
@@ -47,6 +47,7 @@ import com.spotify.styx.client.ApiErrorException;
 import com.spotify.styx.client.ClientErrorException;
 import com.spotify.styx.client.StyxClient;
 import com.spotify.styx.model.Backfill;
+import com.spotify.styx.model.BackfillInput;
 import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowConfiguration;
@@ -197,14 +198,57 @@ public class CliMainTest {
         .schedule(Schedule.DAYS)
         .build();
 
-    when(client.backfillCreate(component, "foo", start,
-        end, 1, null))
+    final BackfillInput expectedInput = BackfillInput.newBuilder()
+        .component(backfill.workflowId().componentId())
+        .workflow(backfill.workflowId().id())
+        .start(backfill.start())
+        .end(backfill.end())
+        .reverse(backfill.reverse())
+        .concurrency(backfill.concurrency())
+        .build();
+
+    when(client.backfillCreate(expectedInput))
         .thenReturn(CompletableFuture.completedFuture(backfill));
 
     CliMain.run(cliContext, "backfill", "create", component, "foo", "2017-01-01", "2017-01-30",
         "1");
 
-    verify(client).backfillCreate(component, "foo", start, end, 1, null);
+    verify(client).backfillCreate(expectedInput);
+    verify(cliOutput).printBackfill(backfill, true);
+  }
+
+  @Test
+  public void testBackfillCreateReverse() throws Exception {
+    final String component = "quux";
+    final Instant start = Instant.parse("2017-01-01T00:00:00Z");
+    final Instant end = Instant.parse("2017-01-30T00:00:00Z");
+
+    final Backfill backfill = Backfill.newBuilder()
+        .id("backfill-2")
+        .start(start)
+        .end(end)
+        .reverse(true)
+        .workflowId(WorkflowId.create(component, "foo"))
+        .concurrency(1)
+        .nextTrigger(Instant.parse("2017-01-01T00:00:00Z"))
+        .schedule(Schedule.DAYS)
+        .build();
+
+    final BackfillInput expectedInput = BackfillInput.newBuilder()
+        .component(backfill.workflowId().componentId())
+        .workflow(backfill.workflowId().id())
+        .start(backfill.start())
+        .end(backfill.end())
+        .reverse(backfill.reverse())
+        .concurrency(backfill.concurrency())
+        .build();
+
+    when(client.backfillCreate(expectedInput))
+        .thenReturn(CompletableFuture.completedFuture(backfill));
+
+    CliMain.run(cliContext, "backfill", "create", component, "foo", "2017-01-01", "2017-01-30", "1", "--reverse");
+
+    verify(client).backfillCreate(expectedInput);
     verify(cliOutput).printBackfill(backfill, true);
   }
 
@@ -225,14 +269,22 @@ public class CliMainTest {
         .schedule(Schedule.DAYS)
         .build();
 
-    when(client.backfillCreate(component, "foo", start,
-        end, 1, "Description"))
+    final BackfillInput expectedInput = BackfillInput.newBuilder()
+        .component(backfill.workflowId().componentId())
+        .workflow(backfill.workflowId().id())
+        .start(backfill.start())
+        .end(backfill.end())
+        .concurrency(backfill.concurrency())
+        .description("Description")
+        .build();
+
+    when(client.backfillCreate(expectedInput))
         .thenReturn(CompletableFuture.completedFuture(backfill));
 
-    CliMain.run(cliContext, "backfill", "create", component, "foo", "2017-01-01", "2017-01-30",
-        "1", "-d", "Description");
+    CliMain.run(cliContext, "backfill", "create", component, "foo", "2017-01-01", "2017-01-30", "1",
+        "-d", "Description");
 
-    verify(client).backfillCreate(component, "foo", start, end, 1, "Description");
+    verify(client).backfillCreate(expectedInput);
     verify(cliOutput).printBackfill(backfill, true);
   }
   

--- a/styx-cli/src/test/java/com/spotify/styx/cli/JsonCliOutputTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/JsonCliOutputTest.java
@@ -58,6 +58,7 @@ public class JsonCliOutputTest {
       .description("Description")
       .nextTrigger(Instant.parse("2017-01-01T00:00:00Z"))
       .schedule(Schedule.DAYS)
+      .reverse(true)
       .build();
   
   private static final String EXPECTED_OUTPUT = "{\"id\":\"backfill-2\"," 
@@ -71,7 +72,8 @@ public class JsonCliOutputTest {
                                                + "\"next_trigger\":\"2017-01-01T00:00:00Z\"," 
                                                + "\"schedule\":\"days\"," 
                                                + "\"all_triggered\":false," 
-                                               + "\"halted\":false}";
+                                               + "\"halted\":false,"
+                                               + "\"reverse\":true}";
 
   private static final String EXPECTED_OUTPUT_WITH_STATUS = "{\"backfill\":"
                                                             + EXPECTED_OUTPUT

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
@@ -342,11 +342,17 @@ class StyxApolloClient implements StyxClient {
                                                   String start, String end,
                                                   int concurrency,
                                                   String description) {
+    final BackfillInput backfill = BackfillInput.create(
+        Instant.parse(start), Instant.parse(end), componentId, workflowId, concurrency,
+        Optional.ofNullable(description));
+    return backfillCreate(backfill);
+  }
+
+  @Override
+  public CompletionStage<Backfill> backfillCreate(BackfillInput backfill) {
     final HttpUrl.Builder urlBuilder = getUrlBuilder().addPathSegment("backfills");
     try {
-      final ByteString payload = serialize(BackfillInput.create(
-          Instant.parse(start), Instant.parse(end), componentId, workflowId, concurrency,
-          Optional.ofNullable(description)));
+      final ByteString payload = serialize(backfill);
       return executeRequest(Request.forUri(urlBuilder.build().toString(), "POST")
           .withPayload(payload), Backfill.class);
     } catch (JsonProcessingException e) {

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxBackfillClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxBackfillClient.java
@@ -23,6 +23,7 @@ package com.spotify.styx.client;
 import com.spotify.styx.api.BackfillPayload;
 import com.spotify.styx.api.BackfillsPayload;
 import com.spotify.styx.model.Backfill;
+import com.spotify.styx.model.BackfillInput;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
@@ -65,6 +66,14 @@ public interface StyxBackfillClient {
                                            final String end,
                                            final int concurrency,
                                            final String description);
+
+  /**
+   * Create a {@link Backfill}
+   *
+   * @param backfill The backfill configuration.
+   * @return The created {@link Backfill}
+   */
+  CompletionStage<Backfill> backfillCreate(BackfillInput backfill);
 
   /**
    * Edit concurrency value of existing {@link Backfill}

--- a/styx-client/src/test/java/com/spotify/styx/client/StyxApolloClientTest.java
+++ b/styx-client/src/test/java/com/spotify/styx/client/StyxApolloClientTest.java
@@ -87,6 +87,28 @@ public class StyxApolloClientTest {
 
   private static final Workflow WORKFLOW_2 = Workflow.create("foo-comp", WORKFLOW_CONFIGURATION_2);
 
+  private static final Instant START = Instant.parse("2017-01-01T00:00:00Z");
+  private static final Instant END = Instant.parse("2017-01-30T00:00:00Z");
+
+  private static final BackfillInput BACKFILL_INPUT =
+      BackfillInput.newBuilder()
+      .start(START)
+      .end(END)
+      .component("foo-comp")
+      .workflow("bar-wf")
+      .concurrency(1)
+      .build();
+
+  private static final Backfill BACKFILL = Backfill.newBuilder()
+      .id("backfill-2")
+      .start(START)
+      .end(END)
+      .workflowId(WorkflowId.create("foo-comp", "bar-wf"))
+      .concurrency(1)
+      .nextTrigger(Instant.parse("2017-01-01T00:00:00Z"))
+      .schedule(Schedule.DAYS)
+      .build();
+
   @Mock Client client;
   @Mock GoogleIdTokenAuth auth;
 
@@ -177,22 +199,8 @@ public class StyxApolloClientTest {
 
   @Test
   public void shouldCreateBackfill() throws Exception {
-    final Instant start = Instant.parse("2017-01-01T00:00:00Z");
-    final Instant end = Instant.parse("2017-01-30T00:00:00Z");
-    final BackfillInput backfillInput = BackfillInput.create(start, end,"foo-comp", "bar-wf",
-         1, Optional.empty());
-
-    final Backfill backfill = Backfill.newBuilder()
-        .id("backfill-2")
-        .start(start)
-        .end(end)
-        .workflowId(WorkflowId.create("foo-comp", "bar-wf"))
-        .concurrency(1)
-        .nextTrigger(Instant.parse("2017-01-01T00:00:00Z"))
-        .schedule(Schedule.DAYS)
-        .build();
     when(client.send(any(Request.class))).thenReturn(CompletableFuture.completedFuture(
-        Response.forStatus(Status.OK).withPayload(Json.serialize(backfill))));
+        Response.forStatus(Status.OK).withPayload(Json.serialize(BACKFILL))));
     final StyxApolloClient styx = new StyxApolloClient(client, CLIENT_HOST, auth);
     final CompletableFuture<Backfill> r = styx.backfillCreate("foo-comp", "bar-wf",
         "2017-01-01T00:00:00Z", "2017-01-30T00:00:00Z", 1)
@@ -202,35 +210,18 @@ public class StyxApolloClientTest {
     final Request request = requestCaptor.getValue();
     assertThat(request.uri(), is(API_URL + "/backfills"));
     assertThat(Json.deserialize(request.payload().get(), BackfillInput.class),
-        equalTo(backfillInput));
+        equalTo(BACKFILL_INPUT));
     assertThat(request.method(), is("POST"));
   }
 
   @Test
   public void shouldCreateBackfillFromInput() throws Exception {
-    final Instant start = Instant.parse("2017-01-01T00:00:00Z");
-    final Instant end = Instant.parse("2017-01-30T00:00:00Z");
-    final BackfillInput backfillInput = BackfillInput.newBuilder()
-        .start(start)
-        .end(end)
-        .component("foo-comp")
-        .workflow("bar-wf")
-        .concurrency(1)
+    final BackfillInput backfillInput = BACKFILL_INPUT.builder()
         .reverse(true)
         .build();
 
-    final Backfill backfill = Backfill.newBuilder()
-        .id("backfill-2")
-        .start(start)
-        .end(end)
-        .reverse(true)
-        .workflowId(WorkflowId.create("foo-comp", "bar-wf"))
-        .concurrency(1)
-        .nextTrigger(Instant.parse("2017-01-01T00:00:00Z"))
-        .schedule(Schedule.DAYS)
-        .build();
     when(client.send(any(Request.class))).thenReturn(CompletableFuture.completedFuture(
-        Response.forStatus(Status.OK).withPayload(Json.serialize(backfill))));
+        Response.forStatus(Status.OK).withPayload(Json.serialize(BACKFILL))));
     final StyxApolloClient styx = new StyxApolloClient(client, CLIENT_HOST, auth);
     final CompletableFuture<Backfill> r = styx.backfillCreate(backfillInput)
         .toCompletableFuture();
@@ -245,23 +236,11 @@ public class StyxApolloClientTest {
 
   @Test
   public void shouldCreateBackfillWithDescription() throws Exception {
-    final Instant start = Instant.parse("2017-01-01T00:00:00Z");
-    final Instant end = Instant.parse("2017-01-30T00:00:00Z");
-    final BackfillInput backfillInput = BackfillInput.create(start, end, "foo-comp", "bar-wf",
-                                                             1, Optional.of("Description"));
-
-    final Backfill backfill = Backfill.newBuilder()
-        .id("backfill-2")
-        .start(start)
-        .end(end)
-        .workflowId(WorkflowId.create("foo-comp", "bar-wf"))
-        .concurrency(1)
+    final BackfillInput backfillInput = BACKFILL_INPUT.builder()
         .description("Description")
-        .nextTrigger(Instant.parse("2017-01-01T00:00:00Z"))
-        .schedule(Schedule.DAYS)
         .build();
     when(client.send(any(Request.class))).thenReturn(CompletableFuture.completedFuture(
-        Response.forStatus(Status.OK).withPayload(Json.serialize(backfill))));
+        Response.forStatus(Status.OK).withPayload(Json.serialize(BACKFILL))));
     final StyxApolloClient styx = new StyxApolloClient(client, CLIENT_HOST, auth);
     final CompletableFuture<Backfill> r = styx.backfillCreate("foo-comp", "bar-wf",
                                                               "2017-01-01T00:00:00Z",

--- a/styx-common/src/main/java/com/spotify/styx/model/Backfill.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/Backfill.java
@@ -49,6 +49,8 @@ public interface Backfill {
 
   boolean halted();
 
+  boolean reverse();
+
   BackfillBuilder builder();
 
   static BackfillBuilder newBuilder() {

--- a/styx-common/src/main/java/com/spotify/styx/model/BackfillInput.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/BackfillInput.java
@@ -39,10 +39,16 @@ public interface BackfillInput {
 
   int concurrency();
 
+  boolean reverse();
+
   Optional<String> description();
 
   BackfillInputBuilder builder();
 
+  /**
+   * @deprecated Use {@link #newBuilder()} instead.
+   */
+  @Deprecated
   static BackfillInput create(Instant start, Instant end, String component, String workflow,
                               int concurrency, Optional<String> description) {
     return newBuilder()

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -141,6 +141,7 @@ public class DatastoreStorage implements Closeable {
   public static final String PROPERTY_SCHEDULE = "schedule";
   public static final String PROPERTY_ALL_TRIGGERED = "allTriggered";
   public static final String PROPERTY_HALTED = "halted";
+  public static final String PROPERTY_REVERSE = "reverse";
   public static final String PROPERTY_DESCRIPTION = "description";
   public static final String PROPERTY_SUBMISSION_RATE_LIMIT = "submissionRateLimit";
 
@@ -847,7 +848,8 @@ public class DatastoreStorage implements Closeable {
         .nextTrigger(timestampToInstant(entity.getTimestamp(PROPERTY_NEXT_TRIGGER)))
         .schedule(Schedule.parse(entity.getString(PROPERTY_SCHEDULE)))
         .allTriggered(entity.getBoolean(PROPERTY_ALL_TRIGGERED))
-        .halted(entity.getBoolean(PROPERTY_HALTED));
+        .halted(entity.getBoolean(PROPERTY_HALTED))
+        .reverse(Optional.ofNullable(entity.getBoolean(PROPERTY_REVERSE)).orElse(false));
 
     if (entity.contains(PROPERTY_DESCRIPTION)) {
       builder.description(entity.getString(PROPERTY_DESCRIPTION));

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
@@ -31,6 +31,7 @@ import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_HALTED;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_NEXT_NATURAL_OFFSET_TRIGGER;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_NEXT_NATURAL_TRIGGER;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_NEXT_TRIGGER;
+import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_REVERSE;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_SCHEDULE;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_START;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_WORKFLOW;
@@ -270,7 +271,8 @@ public class DatastoreStorageTransaction implements StorageTransaction {
         .set(PROPERTY_SCHEDULE, backfill.schedule().toString())
         .set(PROPERTY_NEXT_TRIGGER, instantToTimestamp(backfill.nextTrigger()))
         .set(PROPERTY_ALL_TRIGGERED, backfill.allTriggered())
-        .set(PROPERTY_HALTED, backfill.halted());
+        .set(PROPERTY_HALTED, backfill.halted())
+        .set(PROPERTY_REVERSE, backfill.reverse());
 
     backfill.description().ifPresent(x -> builder.set(PROPERTY_DESCRIPTION, StringValue
         .newBuilder(x).setExcludeFromIndexes(true).build()));

--- a/styx-common/src/main/java/com/spotify/styx/util/ParameterUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ParameterUtil.java
@@ -27,7 +27,6 @@ import static java.time.ZoneOffset.UTC;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
 
-import com.google.common.collect.Lists;
 import com.spotify.styx.model.Schedule;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -40,7 +39,6 @@ import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -126,31 +124,6 @@ public final class ParameterUtil {
       default:
         return formatDateTime(instant);
     }
-  }
-
-  /**
-   * Generates a list of {@link Instant}s obtained by partitioning a time range defined by a
-   * starting and a ending {@link Instant}s, and based on the provided {@link Schedule}.
-   *
-   * @param startInstant              Defines the start of the time range (inclusive)
-   * @param endInstant                Defines the end of the time range (exclusive)
-   * @param schedule                  The schedule unit to split the time range into
-   * @throws IllegalArgumentException If the starting {@link Instant} is later than the ending
-   *                                  {@link Instant}
-   */
-  public static List<Instant> rangeOfInstants(Instant startInstant, Instant endInstant, Schedule schedule) {
-    if (endInstant.isBefore(startInstant)) {
-      throw new IllegalArgumentException("End time cannot be earlier the start time");
-    }
-    final List<Instant> listOfInstants = Lists.newArrayList();
-
-    Instant instantToProcess = startInstant;
-    while (instantToProcess.isBefore(endInstant)) {
-      listOfInstants.add(instantToProcess);
-      instantToProcess = TimeUtil.nextInstant(instantToProcess, schedule);
-    }
-
-    return listOfInstants;
   }
 
   public static Instant parseAlignedInstant(String dateHour, Schedule schedule) {

--- a/styx-common/src/main/java/com/spotify/styx/util/TimeUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/TimeUtil.java
@@ -106,7 +106,7 @@ public class TimeUtil {
   }
 
   /**
-   * Gets the number of instants between firstInstant (inclusive) and lastInstant (exclusive)
+   * Gets an ordered list of instants between firstInstant (inclusive) and lastInstant (exclusive)
    * according to the {@link Schedule}.
    *
    * @param firstInstant The first instant
@@ -125,22 +125,22 @@ public class TimeUtil {
     }
 
     final ExecutionTime executionTime = ExecutionTime.forCron(cron(schedule));
-    final List<Instant> listOfInstants = new ArrayList<>();
+    final List<Instant> instants = new ArrayList<>();
 
     Instant currentInstant = firstInstant;
     while (currentInstant.isBefore(lastInstant)) {
-      listOfInstants.add(currentInstant);
+      instants.add(currentInstant);
       final ZonedDateTime utcDateTime = currentInstant.atZone(UTC);
       currentInstant = executionTime.nextExecution(utcDateTime)
           .orElseThrow(IllegalArgumentException::new) // with unix cron, this should not happen
           .toInstant();
     }
 
-    return listOfInstants;
+    return instants;
   }
 
   /**
-   * Gets the number of instants between firstInstant (inclusive) and lastInstant (exclusive)
+   * Gets an ordered list instants between firstInstant (inclusive) and lastInstant (exclusive)
    * according to the {@link Schedule}. This works in a reversed order, meaning firstInstant should
    * be after lastInstant.
    *
@@ -160,18 +160,18 @@ public class TimeUtil {
     }
 
     final ExecutionTime executionTime = ExecutionTime.forCron(cron(schedule));
-    final List<Instant> listOfInstants = new ArrayList<>();
+    final List<Instant> instants = new ArrayList<>();
 
     Instant currentInstant = firstInstant;
     while (currentInstant.isAfter(lastInstant)) {
-      listOfInstants.add(currentInstant);
+      instants.add(currentInstant);
       final ZonedDateTime utcDateTime = currentInstant.atZone(UTC);
       currentInstant = executionTime.lastExecution(utcDateTime)
           .orElseThrow(IllegalArgumentException::new) // with unix cron, this should not happen
           .toInstant();
     }
 
-    return listOfInstants;
+    return instants;
   }
 
   /**

--- a/styx-common/src/test/java/com/spotify/styx/util/ParameterUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ParameterUtilTest.java
@@ -26,10 +26,7 @@ import static com.spotify.styx.model.Schedule.MONTHS;
 import static com.spotify.styx.model.Schedule.WEEKS;
 import static com.spotify.styx.model.Schedule.YEARS;
 import static com.spotify.styx.util.ParameterUtil.parseAlignedInstant;
-import static com.spotify.styx.util.ParameterUtil.rangeOfInstants;
 import static java.time.Instant.parse;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -137,75 +134,6 @@ public class ParameterUtilTest {
     final Instant instant = ParameterUtil.parseDate("2016-01-19");
 
     assertThat(instant, is(parse("2016-01-19T00:00:00.000Z")));
-  }
-
-  @Test
-  public void shouldRangeOfInstantsHours() {
-    final Instant startInstant = parse("2016-12-31T23:00:00.00Z");
-    final Instant endInstant = parse("2017-01-01T02:00:00.00Z");
-
-    List<Instant> list = rangeOfInstants(startInstant, endInstant, HOURS);
-    assertThat(list, contains(
-        parse("2016-12-31T23:00:00.00Z"),
-        parse("2017-01-01T00:00:00.00Z"),
-        parse("2017-01-01T01:00:00.00Z"))
-    );
-  }
-
-  @Test
-  public void shouldRangeOfInstantsDays() {
-    final Instant startInstant = parse("2016-12-31T00:00:00.00Z");
-    final Instant endInstant = parse("2017-01-03T00:00:00.00Z");
-
-    List<Instant> list = rangeOfInstants(startInstant, endInstant, DAYS);
-    assertThat(list, contains(
-        parse("2016-12-31T00:00:00.00Z"),
-        parse("2017-01-01T00:00:00.00Z"),
-        parse("2017-01-02T00:00:00.00Z"))
-    );
-  }
-
-  @Test
-  public void shouldRangeOfInstantsWeeks() {
-    final Instant startInstant = parse("2016-12-26T00:00:00.00Z");
-    final Instant endInstant = parse("2017-01-16T00:00:00.00Z");
-
-    List<Instant> list = rangeOfInstants(startInstant, endInstant, WEEKS);
-    assertThat(list, contains(
-        parse("2016-12-26T00:00:00.00Z"),
-        parse("2017-01-02T00:00:00.00Z"),
-        parse("2017-01-09T00:00:00.00Z"))
-    );
-  }
-
-  @Test
-  public void shouldRangeOfInstantsMonths() {
-    final Instant startInstant = parse("2017-01-01T00:00:00.00Z");
-    final Instant endInstant = parse("2017-04-01T00:00:00.00Z");
-
-    List<Instant> list = rangeOfInstants(startInstant, endInstant, MONTHS);
-    assertThat(list, contains(
-        parse("2017-01-01T00:00:00.00Z"),
-        parse("2017-02-01T00:00:00.00Z"),
-        parse("2017-03-01T00:00:00.00Z"))
-    );
-  }
-
-  @Test
-  public void shouldReturnEmptyListStartEqualsEnd() {
-    final Instant startInstant = parse("2016-12-31T23:00:00.00Z");
-    final Instant endInstant = parse("2016-12-31T23:00:00.00Z");
-
-    List<Instant> list = rangeOfInstants(startInstant, endInstant, HOURS);
-    assertThat(list, hasSize(0));
-  }
-
-  @Test(expected=IllegalArgumentException.class)
-  public void shouldRaiseRangeOfInstantsStartAfterEnd() {
-    final Instant startInstant = parse("2016-12-31T23:00:00.00Z");
-    final Instant endInstant = parse("2016-01-01T01:00:00.00Z");
-
-    rangeOfInstants(startInstant, endInstant, HOURS);
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
@@ -33,16 +33,20 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.spotify.styx.model.Schedule;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class TimeUtilTest {
 
   private static final Instant TIME = parse("2016-01-19T09:11:22.333Z");
+
+  @Rule
+  public ExpectedException expect = ExpectedException.none();
 
   @Test
   public void shouldGetLastInstant() {
@@ -249,36 +253,33 @@ public class TimeUtilTest {
   public void shouldGetExceptionIfLastInstantIsBeforeFirstInstant() {
     final Instant firstTimeHours = parse("2016-01-19T10:00:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T09:00:00.00Z");
-    try {
-      instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), is("last instant should not be before first instant"));
-    }
+
+    expect.expect(IllegalArgumentException.class);
+    expect.expectMessage("last instant should not be before first instant");
+
+    instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
   }
 
   @Test
   public void shouldGetExceptionIfLastInstantIsNotAlignedWithSchedule() {
     final Instant firstTimeHours = parse("2016-01-19T08:00:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T09:10:00.00Z");
-    try {
-      instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), is("unaligned instant"));
-    }
+
+    expect.expect(IllegalArgumentException.class);
+    expect.expectMessage("unaligned instant");
+
+    instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
   }
 
   @Test
   public void shouldGetExceptionIfFirstInstantIsNotAlignedWithSchedule() {
     final Instant firstTimeHours = parse("2016-01-19T08:10:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T09:00:00.00Z");
-    try {
-      instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), is("unaligned instant"));
-    }
+
+    expect.expect(IllegalArgumentException.class);
+    expect.expectMessage("unaligned instant");
+
+    instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
   }
 
   @Test
@@ -336,35 +337,32 @@ public class TimeUtilTest {
   public void shouldGetExceptionIfLastInstantIsBeforeFirstInstantReversed() {
     final Instant firstTimeHours = parse("2016-01-19T09:00:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T10:00:00.00Z");
-    try {
-      instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), is("last instant should not be after first instant"));
-    }
+
+    expect.expect(IllegalArgumentException.class);
+    expect.expectMessage("last instant should not be after first instant");
+
+    instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
   }
 
   @Test
   public void shouldGetExceptionIfLastInstantIsNotAlignedWithScheduleReversed() {
     final Instant firstTimeHours = parse("2016-01-19T09:00:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T08:10:00.00Z");
-    try {
-      instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), is("unaligned instant"));
-    }
+
+    expect.expect(IllegalArgumentException.class);
+    expect.expectMessage("unaligned instant");
+
+    instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
   }
 
   @Test
   public void shouldGetExceptionIfFirstInstantIsNotAlignedWithScheduleReversed() {
     final Instant firstTimeHours = parse("2016-01-19T09:10:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T08:00:00.00Z");
-    try {
-      instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), is("unaligned instant"));
-    }
+
+    expect.expect(IllegalArgumentException.class);
+    expect.expectMessage("unaligned instant");
+
+    instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.spotify.styx.model.Schedule;
 import java.time.Instant;
@@ -195,7 +196,7 @@ public class TimeUtilTest {
   }
 
   @Test
-  public void shouldGetCorrectNumberOfInstants() {
+  public void shouldGetCorrectInstants() {
     final Instant firstTimeHours = parse("2016-01-19T00:00:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T03:00:00.00Z");
     final Instant firstTimeDays = parse("2016-01-10T00:00:00.00Z");
@@ -225,7 +226,7 @@ public class TimeUtilTest {
   }
 
   @Test
-  public void shouldGetCorrectNumberOfInstantsForCron() {
+  public void shouldGetCorrectInstantsForCron() {
     final Instant firstTimeHours = parse("2016-01-19T00:00:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T03:00:00.00Z");
 
@@ -244,29 +245,44 @@ public class TimeUtilTest {
         instantsInRange(firstTimeHours, lastTimeHours, Schedule.parse("0 * * * *")).isEmpty());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldGetExceptionIfLastInstantIsBeforeFirstInstant() {
     final Instant firstTimeHours = parse("2016-01-19T10:00:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T09:00:00.00Z");
-    instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldGetExceptionIfLastInstantIsNotAlignedWithSchedule() {
-    final Instant firstTimeHours = parse("2016-01-19T08:00:00.00Z");
-    final Instant lastTimeHours = parse("2016-01-19T09:10:00.00Z");
-    instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldGetExceptionIfFirstInstantIsNotAlignedWithSchedule() {
-    final Instant firstTimeHours = parse("2016-01-19T08:10:00.00Z");
-    final Instant lastTimeHours = parse("2016-01-19T09:00:00.00Z");
-    instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+    try {
+      instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("last instant should not be before first instant"));
+    }
   }
 
   @Test
-  public void shouldGetCorrectNumberOfInstantsReversed() {
+  public void shouldGetExceptionIfLastInstantIsNotAlignedWithSchedule() {
+    final Instant firstTimeHours = parse("2016-01-19T08:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T09:10:00.00Z");
+    try {
+      instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("unaligned instant"));
+    }
+  }
+
+  @Test
+  public void shouldGetExceptionIfFirstInstantIsNotAlignedWithSchedule() {
+    final Instant firstTimeHours = parse("2016-01-19T08:10:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T09:00:00.00Z");
+    try {
+      instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("unaligned instant"));
+    }
+  }
+
+  @Test
+  public void shouldGetCorrectInstantsReversed() {
     final Instant firstTimeHours = parse("2016-01-19T03:00:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T00:00:00.00Z");
     final Instant firstTimeDays = parse("2016-01-13T00:00:00.00Z");
@@ -296,7 +312,7 @@ public class TimeUtilTest {
   }
 
   @Test
-  public void shouldGetCorrectNumberOfInstantsForCronReversed() {
+  public void shouldGetCorrectInstantsForCronReversed() {
     final Instant firstTimeHours = parse("2016-01-19T03:00:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T00:00:00.00Z");
 
@@ -316,24 +332,39 @@ public class TimeUtilTest {
   }
 
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldGetExceptionIfLastInstantIsBeforeFirstInstantReversed() {
     final Instant firstTimeHours = parse("2016-01-19T09:00:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T10:00:00.00Z");
-    instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+    try {
+      instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("last instant should not be after first instant"));
+    }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldGetExceptionIfLastInstantIsNotAlignedWithScheduleReversed() {
     final Instant firstTimeHours = parse("2016-01-19T09:00:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T08:10:00.00Z");
-    instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+    try {
+      instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("unaligned instant"));
+    }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldGetExceptionIfFirstInstantIsNotAlignedWithScheduleReversed() {
     final Instant firstTimeHours = parse("2016-01-19T09:10:00.00Z");
     final Instant lastTimeHours = parse("2016-01-19T08:00:00.00Z");
-    instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+    try {
+      instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("unaligned instant"));
+    }
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
@@ -21,12 +21,16 @@
 package com.spotify.styx.util;
 
 import static com.spotify.styx.util.TimeUtil.addOffset;
-import static com.spotify.styx.util.TimeUtil.instancesInRange;
+import static com.spotify.styx.util.TimeUtil.instantsInRange;
+import static com.spotify.styx.util.TimeUtil.instantsInReversedRange;
 import static com.spotify.styx.util.TimeUtil.isAligned;
 import static com.spotify.styx.util.TimeUtil.lastInstant;
 import static com.spotify.styx.util.TimeUtil.nextInstant;
+import static java.time.Instant.parse;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -37,14 +41,14 @@ import org.junit.Test;
 
 public class TimeUtilTest {
 
-  private static final Instant TIME = Instant.parse("2016-01-19T09:11:22.333Z");
+  private static final Instant TIME = parse("2016-01-19T09:11:22.333Z");
 
   @Test
   public void shouldGetLastInstant() {
-    final Instant lastTimeHours = Instant.parse("2016-01-19T09:00:00.00Z");
-    final Instant lastTimeDays = Instant.parse("2016-01-19T00:00:00.00Z");
-    final Instant lastTimeWeeks = Instant.parse("2016-01-18T00:00:00.00Z");
-    final Instant lastTimeMonths = Instant.parse("2016-01-01T00:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T09:00:00.00Z");
+    final Instant lastTimeDays = parse("2016-01-19T00:00:00.00Z");
+    final Instant lastTimeWeeks = parse("2016-01-18T00:00:00.00Z");
+    final Instant lastTimeMonths = parse("2016-01-01T00:00:00.00Z");
 
     final Instant hour = lastInstant(TIME, Schedule.HOURS);
     assertThat(hour, is(lastTimeHours));
@@ -61,21 +65,21 @@ public class TimeUtilTest {
 
   @Test
   public void shouldWorkForComplexCron() {
-    final Instant lastInstant = lastInstant(Instant.parse("2016-01-19T09:00:00.00Z"),
+    final Instant lastInstant = lastInstant(parse("2016-01-19T09:00:00.00Z"),
                                             Schedule.parse("5-59/20 * * * *"));
-    assertThat(lastInstant, is(Instant.parse("2016-01-19T08:45:00.00Z")));
+    assertThat(lastInstant, is(parse("2016-01-19T08:45:00.00Z")));
 
-    final Instant nextInstance = nextInstant(Instant.parse("2016-01-19T09:00:00.00Z"),
+    final Instant nextInstance = nextInstant(parse("2016-01-19T09:00:00.00Z"),
                                              Schedule.parse("05-59/20 * * * *"));
-    assertThat(nextInstance, is(Instant.parse("2016-01-19T09:05:00.00Z")));
+    assertThat(nextInstance, is(parse("2016-01-19T09:05:00.00Z")));
   }
 
   @Test
   public void shouldReturnLastInstantUnchangedIfMatchingTime() {
-    final Instant lastTimeHours = Instant.parse("2016-01-19T09:00:00.00Z");
-    final Instant lastTimeDays = Instant.parse("2016-01-19T00:00:00.00Z");
-    final Instant lastTimeWeeks = Instant.parse("2016-01-18T00:00:00.00Z");
-    final Instant lastTimeMonths = Instant.parse("2016-01-01T00:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T09:00:00.00Z");
+    final Instant lastTimeDays = parse("2016-01-19T00:00:00.00Z");
+    final Instant lastTimeWeeks = parse("2016-01-18T00:00:00.00Z");
+    final Instant lastTimeMonths = parse("2016-01-01T00:00:00.00Z");
 
     final Instant hour = lastInstant(lastTimeHours, Schedule.HOURS);
     assertThat(hour, is(lastTimeHours));
@@ -92,10 +96,10 @@ public class TimeUtilTest {
 
   @Test
   public void shouldGetNextInstant() {
-    final Instant nextTimeHours = Instant.parse("2016-01-19T10:00:00.00Z");
-    final Instant nextTimeDays = Instant.parse("2016-01-20T00:00:00.00Z");
-    final Instant nextTimeWeeks = Instant.parse("2016-01-25T00:00:00.00Z");
-    final Instant nextTimeMonths = Instant.parse("2016-02-01T00:00:00.00Z");
+    final Instant nextTimeHours = parse("2016-01-19T10:00:00.00Z");
+    final Instant nextTimeDays = parse("2016-01-20T00:00:00.00Z");
+    final Instant nextTimeWeeks = parse("2016-01-25T00:00:00.00Z");
+    final Instant nextTimeMonths = parse("2016-02-01T00:00:00.00Z");
 
     final Instant hour = nextInstant(TIME, Schedule.HOURS);
     assertThat(hour, is(nextTimeHours));
@@ -112,32 +116,32 @@ public class TimeUtilTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void shouldFailIfNoNextInstance() {
-    lastInstant(Instant.parse("2018-01-19T09:00:00.00Z"),
+    lastInstant(parse("2018-01-19T09:00:00.00Z"),
                 Schedule.parse("* * * * * 2017"));
   }
 
   @Test
   public void shouldTestWellKnownAlignedInstants() {
-    assertTrue(isAligned(Instant.parse("2017-02-06T10:00:00.00Z"), Schedule.HOURS));
-    assertTrue(isAligned(Instant.parse("2017-02-06T00:00:00.00Z"), Schedule.DAYS));
-    assertTrue(isAligned(Instant.parse("2017-02-06T00:00:00.00Z"), Schedule.WEEKS));
-    assertTrue(isAligned(Instant.parse("2017-02-01T00:00:00.00Z"), Schedule.MONTHS));
-    assertTrue(isAligned(Instant.parse("2017-01-01T00:00:00.00Z"), Schedule.YEARS));
+    assertTrue(isAligned(parse("2017-02-06T10:00:00.00Z"), Schedule.HOURS));
+    assertTrue(isAligned(parse("2017-02-06T00:00:00.00Z"), Schedule.DAYS));
+    assertTrue(isAligned(parse("2017-02-06T00:00:00.00Z"), Schedule.WEEKS));
+    assertTrue(isAligned(parse("2017-02-01T00:00:00.00Z"), Schedule.MONTHS));
+    assertTrue(isAligned(parse("2017-01-01T00:00:00.00Z"), Schedule.YEARS));
 
-    assertFalse(isAligned(Instant.parse("2017-02-06T10:01:00.00Z"), Schedule.HOURS));
-    assertFalse(isAligned(Instant.parse("2017-02-06T01:00:00.00Z"), Schedule.DAYS));
-    assertFalse(isAligned(Instant.parse("2017-02-07T00:00:00.00Z"), Schedule.WEEKS));
-    assertFalse(isAligned(Instant.parse("2017-02-02T00:00:00.00Z"), Schedule.MONTHS));
-    assertFalse(isAligned(Instant.parse("2017-01-02T00:00:00.00Z"), Schedule.YEARS));
+    assertFalse(isAligned(parse("2017-02-06T10:01:00.00Z"), Schedule.HOURS));
+    assertFalse(isAligned(parse("2017-02-06T01:00:00.00Z"), Schedule.DAYS));
+    assertFalse(isAligned(parse("2017-02-07T00:00:00.00Z"), Schedule.WEEKS));
+    assertFalse(isAligned(parse("2017-02-02T00:00:00.00Z"), Schedule.MONTHS));
+    assertFalse(isAligned(parse("2017-01-02T00:00:00.00Z"), Schedule.YEARS));
   }
 
   @Test
   public void shouldTestCustomAlignedInstants() {
     Schedule custom = Schedule.parse("15,42 10 * * *");
-    assertTrue(isAligned(Instant.parse("2017-02-06T10:15:00.00Z"), custom));
-    assertTrue(isAligned(Instant.parse("2017-02-06T10:42:00.00Z"), custom));
-    assertFalse(isAligned(Instant.parse("2017-02-06T10:00:00.00Z"), custom));
-    assertFalse(isAligned(Instant.parse("2017-02-06T11:15:00.00Z"), custom));
+    assertTrue(isAligned(parse("2017-02-06T10:15:00.00Z"), custom));
+    assertTrue(isAligned(parse("2017-02-06T10:42:00.00Z"), custom));
+    assertFalse(isAligned(parse("2017-02-06T10:00:00.00Z"), custom));
+    assertFalse(isAligned(parse("2017-02-06T11:15:00.00Z"), custom));
   }
 
   @Test
@@ -187,53 +191,149 @@ public class TimeUtilTest {
 
   @Test
   public void cronScheduleShouldNotEqualEquivalentWellKnownSchedule() {
-    assertFalse(Schedule.parse("0 * * * *").equals(Schedule.HOURS));
+    assertNotEquals(Schedule.parse("0 * * * *"), Schedule.HOURS);
   }
 
   @Test
   public void shouldGetCorrectNumberOfInstants() {
-    final Instant firstTimeHours = Instant.parse("2016-01-19T00:00:00.00Z");
-    final Instant lastTimeHours = Instant.parse("2016-01-19T09:00:00.00Z");
-    final Instant firstTimeDays = Instant.parse("2016-01-10T00:00:00.00Z");
-    final Instant lastTimeDays = Instant.parse("2016-01-19T00:00:00.00Z");
-    final Instant firstTimeWeeks = Instant.parse("2016-01-11T00:00:00.00Z");
-    final Instant lastTimeWeeks = Instant.parse("2016-01-18T00:00:00.00Z");
-    final Instant firstTimeMonths = Instant.parse("2010-01-01T00:00:00.00Z");
-    final Instant lastTimeMonths = Instant.parse("2016-01-01T00:00:00.00Z");
+    final Instant firstTimeHours = parse("2016-01-19T00:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T03:00:00.00Z");
+    final Instant firstTimeDays = parse("2016-01-10T00:00:00.00Z");
+    final Instant lastTimeDays = parse("2016-01-13T00:00:00.00Z");
+    final Instant firstTimeWeeks = parse("2016-01-11T00:00:00.00Z");
+    final Instant lastTimeWeeks = parse("2016-01-18T00:00:00.00Z");
+    final Instant firstTimeMonths = parse("2010-01-01T00:00:00.00Z");
+    final Instant lastTimeMonths = parse("2013-01-01T00:00:00.00Z");
 
-    assertThat(instancesInRange(firstTimeHours, lastTimeHours, Schedule.HOURS), is(9));
-    assertThat(instancesInRange(firstTimeDays, lastTimeDays, Schedule.DAYS), is(9));
-    assertThat(instancesInRange(firstTimeWeeks, lastTimeWeeks, Schedule.WEEKS), is(1));
-    assertThat(instancesInRange(firstTimeMonths, lastTimeMonths, Schedule.YEARS), is(6));
+    assertThat(instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS),
+        contains(parse("2016-01-19T00:00:00.00Z"),
+            parse("2016-01-19T01:00:00.00Z"),
+            parse("2016-01-19T02:00:00.00Z")));
+
+    assertThat(instantsInRange(firstTimeDays, lastTimeDays, Schedule.DAYS),
+        contains(parse("2016-01-10T00:00:00.00Z"),
+            parse("2016-01-11T00:00:00.00Z"),
+            parse("2016-01-12T00:00:00.00Z")));
+
+    assertThat(instantsInRange(firstTimeWeeks, lastTimeWeeks, Schedule.WEEKS),
+        contains(parse("2016-01-11T00:00:00.00Z")));
+
+    assertThat(instantsInRange(firstTimeMonths, lastTimeMonths, Schedule.YEARS),
+        contains(parse("2010-01-01T00:00:00.00Z"),
+            parse("2011-01-01T00:00:00.00Z"),
+            parse("2012-01-01T00:00:00.00Z")));
   }
 
   @Test
   public void shouldGetCorrectNumberOfInstantsForCron() {
-    final Instant firstTimeHours = Instant.parse("2016-01-19T00:00:00.00Z");
-    final Instant lastTimeHours = Instant.parse("2016-01-19T09:00:00.00Z");
+    final Instant firstTimeHours = parse("2016-01-19T00:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T03:00:00.00Z");
 
-    assertThat(instancesInRange(firstTimeHours, lastTimeHours, Schedule.parse("0 * * * *")),
-               is(9));
+    assertThat(instantsInRange(firstTimeHours, lastTimeHours, Schedule.parse("0 * * * *")),
+        contains(parse("2016-01-19T00:00:00.00Z"),
+            parse("2016-01-19T01:00:00.00Z"),
+            parse("2016-01-19T02:00:00.00Z")));
+  }
+
+  @Test
+  public void shouldReturnEmptyList() {
+    final Instant firstTimeHours = parse("2016-01-19T00:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T00:00:00.00Z");
+
+    assertTrue(
+        instantsInRange(firstTimeHours, lastTimeHours, Schedule.parse("0 * * * *")).isEmpty());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void shouldGetExceptionIfLastInstantIsBeforeFirstInstant() {
-    final Instant firstTimeHours = Instant.parse("2016-01-19T10:00:00.00Z");
-    final Instant lastTimeHours = Instant.parse("2016-01-19T09:00:00.00Z");
-    instancesInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+    final Instant firstTimeHours = parse("2016-01-19T10:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T09:00:00.00Z");
+    instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void shouldGetExceptionIfLastInstantIsNotAlignedWithSchedule() {
-    final Instant firstTimeHours = Instant.parse("2016-01-19T08:00:00.00Z");
-    final Instant lastTimeHours = Instant.parse("2016-01-19T09:10:00.00Z");
-    instancesInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+    final Instant firstTimeHours = parse("2016-01-19T08:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T09:10:00.00Z");
+    instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void shouldGetExceptionIfFirstInstantIsNotAlignedWithSchedule() {
-    final Instant firstTimeHours = Instant.parse("2016-01-19T08:10:00.00Z");
-    final Instant lastTimeHours = Instant.parse("2016-01-19T09:00:00.00Z");
-    instancesInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+    final Instant firstTimeHours = parse("2016-01-19T08:10:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T09:00:00.00Z");
+    instantsInRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+  }
+
+  @Test
+  public void shouldGetCorrectNumberOfInstantsReversed() {
+    final Instant firstTimeHours = parse("2016-01-19T03:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T00:00:00.00Z");
+    final Instant firstTimeDays = parse("2016-01-13T00:00:00.00Z");
+    final Instant lastTimeDays = parse("2016-01-10T00:00:00.00Z");
+    final Instant firstTimeWeeks = parse("2016-01-18T00:00:00.00Z");
+    final Instant lastTimeWeeks = parse("2016-01-11T00:00:00.00Z");
+    final Instant firstTimeMonths = parse("2013-01-01T00:00:00.00Z");
+    final Instant lastTimeMonths = parse("2010-01-01T00:00:00.00Z");
+
+    assertThat(instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS),
+        contains(parse("2016-01-19T03:00:00.00Z"),
+            parse("2016-01-19T02:00:00.00Z"),
+            parse("2016-01-19T01:00:00.00Z")));
+
+    assertThat(instantsInReversedRange(firstTimeDays, lastTimeDays, Schedule.DAYS),
+        contains(parse("2016-01-13T00:00:00.00Z"),
+            parse("2016-01-12T00:00:00.00Z"),
+            parse("2016-01-11T00:00:00.00Z")));
+
+    assertThat(instantsInReversedRange(firstTimeWeeks, lastTimeWeeks, Schedule.WEEKS),
+        contains(parse("2016-01-18T00:00:00.00Z")));
+
+    assertThat(instantsInReversedRange(firstTimeMonths, lastTimeMonths, Schedule.YEARS),
+        contains(parse("2013-01-01T00:00:00.00Z"),
+            parse("2012-01-01T00:00:00.00Z"),
+            parse("2011-01-01T00:00:00.00Z")));
+  }
+
+  @Test
+  public void shouldGetCorrectNumberOfInstantsForCronReversed() {
+    final Instant firstTimeHours = parse("2016-01-19T03:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T00:00:00.00Z");
+
+    assertThat(instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.parse("0 * * * *")),
+        contains(parse("2016-01-19T03:00:00.00Z"),
+            parse("2016-01-19T02:00:00.00Z"),
+            parse("2016-01-19T01:00:00.00Z")));
+  }
+
+  @Test
+  public void shouldReturnEmptyListReversed() {
+    final Instant firstTimeHours = parse("2016-01-19T00:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T00:00:00.00Z");
+
+    assertTrue(
+        instantsInRange(firstTimeHours, lastTimeHours, Schedule.parse("0 * * * *")).isEmpty());
+  }
+
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldGetExceptionIfLastInstantIsBeforeFirstInstantReversed() {
+    final Instant firstTimeHours = parse("2016-01-19T09:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T10:00:00.00Z");
+    instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldGetExceptionIfLastInstantIsNotAlignedWithScheduleReversed() {
+    final Instant firstTimeHours = parse("2016-01-19T09:00:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T08:10:00.00Z");
+    instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldGetExceptionIfFirstInstantIsNotAlignedWithScheduleReversed() {
+    final Instant firstTimeHours = parse("2016-01-19T09:10:00.00Z");
+    final Instant lastTimeHours = parse("2016-01-19T08:00:00.00Z");
+    instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
@@ -231,13 +231,11 @@ class BackfillTriggerManager {
   }
 
   private Instant exclusiveEndTrigger(Backfill backfill) {
-    final Instant exclusiveLastTrigger;
     if (backfill.reverse()) {
-      exclusiveLastTrigger = previousInstant(backfill.start(), backfill.schedule());
+      return previousInstant(backfill.start(), backfill.schedule());
     } else {
-      exclusiveLastTrigger = backfill.end();
+      return backfill.end();
     }
-    return exclusiveLastTrigger;
   }
 
   private void storeBackfill(Backfill backfill) {
@@ -251,9 +249,11 @@ class BackfillTriggerManager {
   private static Instant getNextPartition(Backfill momentBackfill,
                                    Instant momentNextTrigger,
                                    boolean reversed) {
-    return reversed
-        ? previousInstant(momentNextTrigger, momentBackfill.schedule())
-        : nextInstant(momentNextTrigger, momentBackfill.schedule());
+    if (reversed) {
+      return previousInstant(momentNextTrigger, momentBackfill.schedule());
+    } else {
+      return nextInstant(momentNextTrigger, momentBackfill.schedule());
+    }
   }
 
   private static boolean capacityReached(Backfill momentBackfill, Instant initialNextTrigger,

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/BackfillTriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/BackfillTriggerManagerTest.java
@@ -607,7 +607,7 @@ public class BackfillTriggerManagerTest {
     backfills.put(BACKFILL_1.id(), BACKFILL_1.builder().halted(true).build());
 
     final boolean moveOn = backfillTriggerManager.triggerNextPartitionAndProgress(transaction,
-        BACKFILL_1.id(), workflow, BACKFILL_1.nextTrigger(), 10);
+        BACKFILL_1.id(), workflow, BACKFILL_1.nextTrigger(), 10, false);
     assertFalse(moveOn);
     verifyNoMoreInteractions(triggerListener);
   }


### PR DESCRIPTION
minimum effort to make this feature. everything being the same, but to
trigger backfill in reversed order, user only needs to put `start` after
`end`, where `start` is inclusive and `end` is exclusive as it is today.