### PR TITLE
prefer maven central - avoid jitpack timeouts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,10 @@
 
   <repositories>
     <repository>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+    <repository>
       <id>jitpack.io</id>
       <url>https://jitpack.io</url>
     </repository>


### PR DESCRIPTION
Attempt to mitigate circleci timeouts due to trying to download non-jitpack artifacts from jitpack instead of maven central.

Avoid these annoying failures: https://circleci.com/gh/spotify/styx/3853