### PR TITLE
use a keepalive sidecar container

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -302,9 +302,7 @@ class KubernetesDockerRunner implements DockerRunner {
   private static Container keepaliveContainer() {
     return new ContainerBuilder()
         .withName(KEEPALIVE_CONTAINER_NAME)
-        .withImage("busybox")
-        // Sleep forever and exit immediately on SIGTERM or SIGINT
-        .withArgs("/bin/sh", "-c", "trap : INT TERM; mkfifo pipe && read < pipe")
+        .withImage("kubernetes/pause")
         .build();
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -303,7 +303,8 @@ class KubernetesDockerRunner implements DockerRunner {
     return new ContainerBuilder()
         .withName(KEEPALIVE_CONTAINER_NAME)
         .withImage("busybox")
-        .withArgs("/bin/sh", "-c", "trap : TERM INT; while :; do sleep 1000; done")
+        // Sleep forever and exit immediately on SIGTERM or SIGINT
+        .withArgs("/bin/sh", "-c", "trap : INT TERM; mkfifo pipe && read < pipe")
         .build();
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -302,7 +302,9 @@ class KubernetesDockerRunner implements DockerRunner {
   private static Container keepaliveContainer() {
     return new ContainerBuilder()
         .withName(KEEPALIVE_CONTAINER_NAME)
-        .withImage("kubernetes/pause")
+        // Use the GKE pause container image. It sleeps forever until terminated.
+        .withImage("gcr.io/google-containers/pause"
+            + "@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea")
         .build();
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -302,9 +302,8 @@ class KubernetesDockerRunner implements DockerRunner {
   private static Container keepaliveContainer() {
     return new ContainerBuilder()
         .withName(KEEPALIVE_CONTAINER_NAME)
-        // Use the GKE pause container image. It sleeps forever until terminated.
-        .withImage("gcr.io/google-containers/pause"
-            + "@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea")
+        // Use the k8s pause container image. It sleeps forever until terminated.
+        .withImage("k8s.gcr.io/pause:3.1")
         .build();
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -338,7 +338,7 @@ class KubernetesDockerRunner implements DockerRunner {
   @VisibleForTesting
   void cleanupWithRunState(WorkflowInstance workflowInstance, String executionId) {
     cleanup(workflowInstance, executionId, pod ->
-        getMainContainer(pod).ifPresent(containerStatus -> {
+        getMainContainerStatus(pod).ifPresent(containerStatus -> {
           if (hasPullImageError(containerStatus)) {
             deletePod(workflowInstance, executionId);
           } else {
@@ -352,7 +352,7 @@ class KubernetesDockerRunner implements DockerRunner {
   @VisibleForTesting
   void cleanupWithoutRunState(WorkflowInstance workflowInstance, String executionId) {
     cleanup(workflowInstance, executionId, pod ->
-        getMainContainer(pod).ifPresent(containerStatus -> {
+        getMainContainerStatus(pod).ifPresent(containerStatus -> {
           if (containerStatus.getState().getTerminated() != null) {
             deletePodIfNonDeletePeriodExpired(workflowInstance, executionId, containerStatus);
           } else {
@@ -385,7 +385,7 @@ class KubernetesDockerRunner implements DockerRunner {
     });
   }
 
-  static Optional<ContainerStatus> getMainContainer(Pod pod) {
+  static Optional<ContainerStatus> getMainContainerStatus(Pod pod) {
     return readPodWorkflowInstance(pod)
         .flatMap(wfi -> pod.getStatus().getContainerStatuses().stream()
             .filter(status -> mainContainerName(pod.getMetadata().getName()).equals(status.getName()))

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -50,6 +50,7 @@ import com.spotify.styx.util.EventUtil;
 import com.spotify.styx.util.IsClosedException;
 import com.spotify.styx.util.Time;
 import com.spotify.styx.util.TriggerUtil;
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -120,6 +121,7 @@ class KubernetesDockerRunner implements DockerRunner {
       .setDaemon(true)
       .setNameFormat("k8s-scheduler-thread-%d")
       .build();
+  static final String KEEPALIVE_CONTAINER_NAME = "keepalive";
 
   private final ScheduledExecutorService executor;
 
@@ -225,9 +227,10 @@ class KubernetesDockerRunner implements DockerRunner {
         ? runSpec.imageName()
         : runSpec.imageName() + ":latest";
 
+    final String executionId = runSpec.executionId();
     final PodBuilder podBuilder = new PodBuilder()
         .withNewMetadata()
-        .withName(runSpec.executionId())
+        .withName(executionId)
         .addToAnnotations(STYX_WORKFLOW_INSTANCE_ANNOTATION, workflowInstance.toKey())
         .addToAnnotations(DOCKER_TERMINATION_LOGGING_ANNOTATION,
                           String.valueOf(runSpec.terminationLogging()))
@@ -241,7 +244,7 @@ class KubernetesDockerRunner implements DockerRunner {
     runSpec.memLimit().ifPresent(s -> resourceRequirements.addToLimits("memory", new Quantity(s)));
 
     final ContainerBuilder containerBuilder = new ContainerBuilder()
-        .withName(runSpec.executionId())
+        .withName(mainContainerName(executionId))
         .withImage(imageWithTag)
         .withArgs(runSpec.args())
         .withEnv(buildEnv(workflowInstance, runSpec))
@@ -286,9 +289,22 @@ class KubernetesDockerRunner implements DockerRunner {
     });
 
     specBuilder.addToContainers(containerBuilder.build());
+    specBuilder.addToContainers(keepaliveContainer());
     podBuilder.withSpec(specBuilder.build());
 
     return podBuilder.build();
+  }
+
+  private static String mainContainerName(String executionId) {
+    return executionId;
+  }
+
+  private static Container keepaliveContainer() {
+    return new ContainerBuilder()
+        .withName(KEEPALIVE_CONTAINER_NAME)
+        .withImage("busybox")
+        .withArgs("/bin/sh", "-c", "trap : TERM INT; while :; do sleep 1000; done")
+        .build();
   }
 
   @VisibleForTesting
@@ -322,7 +338,7 @@ class KubernetesDockerRunner implements DockerRunner {
   @VisibleForTesting
   void cleanupWithRunState(WorkflowInstance workflowInstance, String executionId) {
     cleanup(workflowInstance, executionId, pod ->
-        getStyxContainer(pod).ifPresent(containerStatus -> {
+        getMainContainer(pod).ifPresent(containerStatus -> {
           if (hasPullImageError(containerStatus)) {
             deletePod(workflowInstance, executionId);
           } else {
@@ -336,7 +352,7 @@ class KubernetesDockerRunner implements DockerRunner {
   @VisibleForTesting
   void cleanupWithoutRunState(WorkflowInstance workflowInstance, String executionId) {
     cleanup(workflowInstance, executionId, pod ->
-        getStyxContainer(pod).ifPresent(containerStatus -> {
+        getMainContainer(pod).ifPresent(containerStatus -> {
           if (containerStatus.getState().getTerminated() != null) {
             deletePodIfNonDeletePeriodExpired(workflowInstance, executionId, containerStatus);
           } else {
@@ -369,9 +385,11 @@ class KubernetesDockerRunner implements DockerRunner {
     });
   }
 
-  static Optional<ContainerStatus> getStyxContainer(Pod pod) {
+  static Optional<ContainerStatus> getMainContainer(Pod pod) {
     return readPodWorkflowInstance(pod)
-        .flatMap(wfi -> pod.getStatus().getContainerStatuses().stream().findFirst());
+        .flatMap(wfi -> pod.getStatus().getContainerStatuses().stream()
+            .filter(status -> mainContainerName(pod.getMetadata().getName()).equals(status.getName()))
+            .findAny());
   }
 
   private boolean isNonDeletePeriodExpired(ContainerStatus containerStatus) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -243,7 +243,7 @@ class KubernetesDockerRunner implements DockerRunner {
     runSpec.memRequest().ifPresent(s -> resourceRequirements.addToRequests("memory", new Quantity(s)));
     runSpec.memLimit().ifPresent(s -> resourceRequirements.addToLimits("memory", new Quantity(s)));
 
-    final ContainerBuilder containerBuilder = new ContainerBuilder()
+    final ContainerBuilder mainContainerBuilder = new ContainerBuilder()
         .withName(mainContainerName(executionId))
         .withImage(imageWithTag)
         .withArgs(runSpec.args())
@@ -265,8 +265,8 @@ class KubernetesDockerRunner implements DockerRunner {
           .withName(saVolume.getName())
           .withReadOnly(true)
           .build();
-      containerBuilder.addToVolumeMounts(saMount);
-      containerBuilder.addToEnv(envVar(STYX_WORKFLOW_SA_ENV_VARIABLE,
+      mainContainerBuilder.addToVolumeMounts(saMount);
+      mainContainerBuilder.addToEnv(envVar(STYX_WORKFLOW_SA_ENV_VARIABLE,
                                        saMount.getMountPath() + STYX_WORKFLOW_SA_JSON_KEY));
     });
 
@@ -285,10 +285,10 @@ class KubernetesDockerRunner implements DockerRunner {
           .withName(secretVolume.getName())
           .withReadOnly(true)
           .build();
-      containerBuilder.addToVolumeMounts(secretMount);
+      mainContainerBuilder.addToVolumeMounts(secretMount);
     });
 
-    specBuilder.addToContainers(containerBuilder.build());
+    specBuilder.addToContainers(mainContainerBuilder.build());
     specBuilder.addToContainers(keepaliveContainer());
     podBuilder.withSpec(specBuilder.build());
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
@@ -22,7 +22,7 @@ package com.spotify.styx.docker;
 
 import static com.spotify.styx.docker.DockerRunner.LOG;
 import static com.spotify.styx.docker.KubernetesDockerRunner.DOCKER_TERMINATION_LOGGING_ANNOTATION;
-import static com.spotify.styx.docker.KubernetesDockerRunner.getStyxContainer;
+import static com.spotify.styx.docker.KubernetesDockerRunner.getMainContainer;
 import static java.util.Collections.emptyList;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -34,6 +34,7 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.serialization.Json;
 import com.spotify.styx.state.RunState;
+import io.fabric8.kubernetes.api.model.ContainerState;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -167,24 +168,27 @@ final class KubernetesPodEventTranslator {
 
     boolean exited = false;
     boolean started = false;
-    Optional<Integer> exitCode = Optional.empty();
 
+    final Optional<ContainerStatus> container = getMainContainer(pod);
     switch (phase) {
       case "Running":
-        // check that the styx container is ready
-        started = getStyxContainer(pod)
-            .map(ContainerStatus::getReady)
-            .orElse(false);
+        // Check if the main container has exited
+        exited = container.map(ContainerStatus::getState)
+                          .map(ContainerState::getTerminated)
+                          .isPresent();
+        if (exited) {
+          break;
+        }
+
+        // check that the main container is ready
+        // TODO: is checking for "ready" meaningful without a readiness probe configured?
+        started = container.map(ContainerStatus::getReady)
+                           .orElse(false);
         break;
 
       case "Succeeded":
       case "Failed":
         exited = true;
-        exitCode = getStyxContainer(pod)
-            .flatMap(cs -> getExitCodeIfValid(
-                workflowInstance.toKey(),
-                pod,
-                cs, stats));
         break;
 
       default:
@@ -213,6 +217,8 @@ final class KubernetesPodEventTranslator {
           // intentional fall-through
 
         case RUNNING:
+          final Optional<Integer> exitCode = container.flatMap(cs ->
+              getExitCodeIfValid(workflowInstance.toKey(), pod, cs, stats));
           generatedEvents.add(Event.terminate(workflowInstance, exitCode));
           break;
 
@@ -232,13 +238,13 @@ final class KubernetesPodEventTranslator {
     switch (phase) {
       case "Pending":
         // check if one or more docker contains failed to pull their image, a possible silent error
-        return getStyxContainer(pod)
+        return getMainContainer(pod)
             .filter(KubernetesPodEventTranslator::hasPullImageError)
             .map(x -> Event.runError(workflowInstance, "One or more containers failed to pull their image"));
 
       case "Succeeded":
       case "Failed":
-        final Optional<ContainerStatus> containerStatusOpt = getStyxContainer(pod);
+        final Optional<ContainerStatus> containerStatusOpt = getMainContainer(pod);
         if (!containerStatusOpt.isPresent()) {
           return Optional.of(Event.runError(workflowInstance, "Could not find our container in pod"));
         }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -81,9 +81,12 @@ public class KubernetesDockerRunnerPodPollerTest {
   PodList podList;
   @Mock PodResource<Pod, DoneablePod> namedPod1;
   @Mock PodResource<Pod, DoneablePod> namedPod2;
-  @Mock PodStatus podStatus;
-  @Mock ContainerStatus containerStatus;
-  @Mock ContainerState containerState;
+  @Mock PodStatus podStatus1;
+  @Mock PodStatus podStatus2;
+  @Mock ContainerStatus containerStatus1;
+  @Mock ContainerStatus containerStatus2;
+  @Mock ContainerState containerState1;
+  @Mock ContainerState containerState2;
   @Mock ContainerStateTerminated containerStateTerminated;
   @Mock
   StateManager stateManager;
@@ -176,21 +179,22 @@ public class KubernetesDockerRunnerPodPollerTest {
     when(namedPod2.get()).thenReturn(createdPod2);
     when(stateManager.getActiveState(any())).thenReturn(Optional.empty());
 
-    setStatusAndState(createdPod1, RUN_SPEC.executionId());
-    setStatusAndState(createdPod2, RUN_SPEC_2.executionId());
+    createdPod1.setStatus(podStatus1);
+    when(podStatus1.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus1));
+    when(containerStatus1.getName()).thenReturn(RUN_SPEC.executionId());
+    when(containerStatus1.getState()).thenReturn(containerState1);
+    when(containerState1.getTerminated()).thenReturn(containerStateTerminated);
+
+    createdPod2.setStatus(podStatus2);
+    when(podStatus2.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus2));
+    when(containerStatus2.getName()).thenReturn(RUN_SPEC_2.executionId());
+    when(containerStatus2.getState()).thenReturn(containerState2);
+    when(containerState2.getTerminated()).thenReturn(containerStateTerminated);
 
     kdr.pollPods();
 
     verify(namedPod1).delete();
     verify(namedPod2).delete();
-  }
-
-  private void setStatusAndState(Pod createdPod, String containerName) {
-    createdPod.setStatus(podStatus);
-    when(podStatus.getContainerStatuses()).thenReturn(ImmutableList.of(containerStatus));
-    when(containerStatus.getName()).thenReturn(containerName);
-    when(containerStatus.getState()).thenReturn(containerState);
-    when(containerState.getTerminated()).thenReturn(containerStateTerminated);
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
@@ -70,7 +70,8 @@ public class KubernetesDockerRunnerPodResourceTest {
         DockerRunner.RunSpec.simple("eid", "busybox"), EMPTY_SECRET_SPEC);
 
     List<Container> containers = pod.getSpec().getContainers();
-    assertThat(containers.size(), is(1));
+    assertThat(containers.size(), is(2));
+    assertThat(containers.get(0).getName(), is("eid"));
 
     Container container = containers.get(0);
     assertThat(container.getImage(), is("busybox:latest"));
@@ -83,7 +84,8 @@ public class KubernetesDockerRunnerPodResourceTest {
         DockerRunner.RunSpec.simple("eid", "busybox:v7"), EMPTY_SECRET_SPEC);
 
     List<Container> containers = pod.getSpec().getContainers();
-    assertThat(containers.size(), is(1));
+    assertThat(containers.size(), is(2));
+    assertThat(containers.get(0).getName(), is("eid"));
 
     Container container = containers.get(0);
     assertThat(container.getImage(), is("busybox:v7"));
@@ -96,7 +98,8 @@ public class KubernetesDockerRunnerPodResourceTest {
         DockerRunner.RunSpec.simple("eid", "busybox", "echo", "foo", "bar"), EMPTY_SECRET_SPEC);
 
     List<Container> containers = pod.getSpec().getContainers();
-    assertThat(containers.size(), is(1));
+    assertThat(containers.size(), is(2));
+    assertThat(containers.get(0).getName(), is("eid"));
 
     Container container = containers.get(0);
     assertThat(container.getArgs(), contains("echo", "foo", "bar"));
@@ -169,7 +172,8 @@ public class KubernetesDockerRunnerPodResourceTest {
     List<Volume> volumes = pod.getSpec().getVolumes();
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(volumes.size(), is(0));
-    assertThat(containers.size(), is(1));
+    assertThat(containers.size(), is(2));
+    assertThat(containers.get(0).getName(), is("eid"));
 
     Container container = containers.get(0);
     List<VolumeMount> volumeMounts = container.getVolumeMounts();
@@ -194,7 +198,8 @@ public class KubernetesDockerRunnerPodResourceTest {
     List<Volume> volumes = pod.getSpec().getVolumes();
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(volumes.size(), is(1));
-    assertThat(containers.size(), is(1));
+    assertThat(containers.size(), is(2));
+    assertThat(containers.get(0).getName(), is("eid"));
 
     Volume volume = volumes.get(0);
     assertThat(volume.getName(), is("my-secret"));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -24,6 +24,7 @@ import static com.spotify.styx.docker.KubernetesDockerRunner.KEEPALIVE_CONTAINER
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.podStatusNoContainer;
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.setRunning;
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.setTerminated;
+import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.setWaiting;
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.terminated;
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.terminatedContainerState;
 import static org.hamcrest.Matchers.empty;
@@ -326,7 +327,7 @@ public class KubernetesDockerRunnerTest {
     when(namedPod.get()).thenReturn(createdPod);
 
     // inject mock status in real instance
-    KubernetesPodEventTranslatorTest.setWaiting(createdPod, "Pending", "ErrImagePull");
+    setWaiting(createdPod, "Pending", "ErrImagePull");
 
     kdr.cleanupWithRunState(WORKFLOW_INSTANCE, name);
     verify(namedPod).delete();
@@ -638,7 +639,7 @@ public class KubernetesDockerRunnerTest {
 
   @Test
   public void shouldFailOnErrImagePull() throws Exception {
-    KubernetesPodEventTranslatorTest.setWaiting(createdPod, "Pending", "ErrImagePull");
+    setWaiting(createdPod, "Pending", "ErrImagePull");
     podWatcher.eventReceived(Watcher.Action.MODIFIED, createdPod);
 
     verify(stateManager).receive(
@@ -648,7 +649,7 @@ public class KubernetesDockerRunnerTest {
 
   @Test
   public void shouldSendStatsOnErrImagePull() throws Exception {
-    KubernetesPodEventTranslatorTest.setWaiting(createdPod, "Pending", "ErrImagePull");
+    setWaiting(createdPod, "Pending", "ErrImagePull");
     podWatcher.eventReceived(Watcher.Action.MODIFIED, createdPod);
 
     verify(stats, times(1)).recordPullImageError();
@@ -694,7 +695,7 @@ public class KubernetesDockerRunnerTest {
 
   @Test
   public void shouldFailOnUnexpectedTerminatedStatus() throws Exception {
-    KubernetesPodEventTranslatorTest.setWaiting(createdPod, "Failed", "");
+    setWaiting(createdPod, "Failed", "");
     podWatcher.eventReceived(Watcher.Action.MODIFIED, createdPod);
 
     verify(stateManager).receive(

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -305,11 +305,11 @@ public class KubernetesPodEventTranslatorTest {
   }
 
   static PodStatus running(boolean ready, String containerName) {
-    return podStatus("Running", ready, containerName,
-        new ContainerState(
-            new ContainerStateRunning("2016-05-30T09:46:48Z"),
-            null,
-            null));
+    return podStatus("Running", ready, containerName, runningContainerState());
+  }
+
+  private static ContainerState runningContainerState() {
+    return new ContainerState(new ContainerStateRunning("2016-05-30T09:46:48Z"), null, null);
   }
 
   static void setTerminated(Pod pod, String phase, Integer exitCode, String message) {
@@ -317,11 +317,11 @@ public class KubernetesPodEventTranslatorTest {
   }
 
   static PodStatus terminated(String phase, Integer exitCode, String message, String containerName) {
-    return podStatus(phase, true, containerName,
-        new ContainerState(
-            null,
-            new ContainerStateTerminated("", exitCode, "", message, "", 0, ""),
-            null));
+    return podStatus(phase, true, containerName, terminatedContainerState(exitCode, message));
+  }
+
+  static ContainerState terminatedContainerState(Integer exitCode, String message) {
+    return new ContainerState(null, new ContainerStateTerminated("", exitCode, "", message, "", 0, ""), null);
   }
 
   static void setWaiting(Pod pod, String phase, String reason) {
@@ -329,11 +329,11 @@ public class KubernetesPodEventTranslatorTest {
   }
 
   static PodStatus waiting(String phase, String reason, String containerName) {
-    return podStatus(phase, true, containerName,
-        new ContainerState(
-            null,
-            null,
-            new ContainerStateWaiting("", reason)));
+    return podStatus(phase, true, containerName, waitingContainerState(reason));
+  }
+
+  private static ContainerState waitingContainerState(String reason) {
+    return new ContainerState(null, null, new ContainerStateWaiting("", reason));
   }
 
   static PodStatus podStatus(String phase, boolean ready, String containerName, ContainerState containerState) {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx.docker;
 
+import static com.spotify.styx.docker.KubernetesDockerRunner.KEEPALIVE_CONTAINER_NAME;
 import static com.spotify.styx.docker.KubernetesPodEventTranslator.translate;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.contains;
@@ -38,6 +39,7 @@ import io.fabric8.kubernetes.api.model.ContainerStateRunning;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.ContainerStatusBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodStatus;
 import io.fabric8.kubernetes.client.Watcher;
@@ -59,7 +61,7 @@ public class KubernetesPodEventTranslatorTest {
 
   @Test
   public void terminateOnSuccessfulTermination() throws Exception {
-    pod.setStatus(terminated("Succeeded", 20, null));
+    setTerminated(pod, "Succeeded", 20, null);
 
     assertGeneratesEventsAndTransitions(
         RunState.State.RUNNING, pod,
@@ -68,7 +70,7 @@ public class KubernetesPodEventTranslatorTest {
 
   @Test
   public void startedAndTerminatedOnFromSubmitted() throws Exception {
-    pod.setStatus(terminated("Succeeded", 0, null));
+    setTerminated(pod, "Succeeded", 0, null);
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -78,7 +80,7 @@ public class KubernetesPodEventTranslatorTest {
 
   @Test
   public void shouldNotGenerateStartedWhenContainerIsNotReady() throws Exception {
-    pod.setStatus(running(/* ready= */ false));
+    setRunning(pod, /* ready= */ false);
 
     assertGeneratesNoEvents(
         RunState.State.SUBMITTED, pod);
@@ -86,7 +88,7 @@ public class KubernetesPodEventTranslatorTest {
 
   @Test
   public void shouldGenerateStartedWhenContainerIsReady() throws Exception {
-    pod.setStatus(running(/* ready= */ true));
+    setRunning(pod, /* ready= */ true);
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -95,7 +97,7 @@ public class KubernetesPodEventTranslatorTest {
 
   @Test
   public void runErrorOnErrImagePull() throws Exception {
-    pod.setStatus(waiting("Pending", "ErrImagePull"));
+    setWaiting(pod, "Pending", "ErrImagePull");
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -122,7 +124,7 @@ public class KubernetesPodEventTranslatorTest {
 
   @Test
   public void runErrorOnUnexpectedTerminatedStatus() throws Exception {
-    pod.setStatus(waiting("Failed", ""));
+    setWaiting(pod, "Failed", "");
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -132,7 +134,7 @@ public class KubernetesPodEventTranslatorTest {
   @Test
   public void errorExitCodeOnTerminationLoggingButNoMessage() throws Exception {
     Pod pod = podWithTerminationLogging();
-    pod.setStatus(terminated("Succeeded", 0, null));
+    setTerminated(pod, "Succeeded", 0, null);
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -143,7 +145,7 @@ public class KubernetesPodEventTranslatorTest {
   @Test
   public void errorExitCodeOnTerminationLoggingButInvalidJson() throws Exception {
     Pod pod = podWithTerminationLogging();
-    pod.setStatus(terminated("Succeeded", 0, "SUCCESS"));
+    setTerminated(pod, "Succeeded", 0, "SUCCESS");
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -154,7 +156,7 @@ public class KubernetesPodEventTranslatorTest {
   @Test
   public void errorExitCodeOnTerminationLoggingButPartialJson() throws Exception {
     Pod pod = podWithTerminationLogging();
-    pod.setStatus(terminated("Succeeded", 0, "{\"workflow_id\":\"dummy\"}"));
+    setTerminated(pod, "Succeeded", 0, "{\"workflow_id\":\"dummy\"}");
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -165,7 +167,7 @@ public class KubernetesPodEventTranslatorTest {
   @Test
   public void errorExitCodeOnTerminationLoggingButK8sFallback() throws Exception {
     Pod pod = podWithTerminationLogging();
-    pod.setStatus(terminated("Failed", 17, "{\"workflow_id\":\"dummy\"}"));
+    setTerminated(pod, "Failed", 17, "{\"workflow_id\":\"dummy\"}");
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -176,7 +178,7 @@ public class KubernetesPodEventTranslatorTest {
   @Test
   public void errorContainerExitCodeAndUnparsableTerminationLog() throws Exception {
     Pod pod = podWithTerminationLogging();
-    pod.setStatus(terminated("Failed", 17, "{\"workf"));
+    setTerminated(pod, "Failed", 17, "{\"workf");
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -187,7 +189,7 @@ public class KubernetesPodEventTranslatorTest {
   @Test
   public void zeroContainerExitCodeAndInvalidTerminationLog() throws Exception {
     Pod pod = podWithTerminationLogging();
-    pod.setStatus(terminated("Failed", 0, "{\"workflow_id\":\"dummy\"}"));
+    setTerminated(pod, "Failed", 0, "{\"workflow_id\":\"dummy\"}");
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -198,7 +200,7 @@ public class KubernetesPodEventTranslatorTest {
   @Test
   public void zeroContainerExitCodeAndUnparsableTerminationLog() throws Exception {
     Pod pod = podWithTerminationLogging();
-    pod.setStatus(terminated("Failed", 0, "{\"workflo"));
+    setTerminated(pod, "Failed", 0, "{\"workflo");
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -209,7 +211,7 @@ public class KubernetesPodEventTranslatorTest {
   @Test
   public void exitCodeFromMessageOnTerminationLoggingAndZeroExitCode() throws Exception {
     Pod pod = podWithTerminationLogging();
-    pod.setStatus(terminated("Succeeded", 0, String.format(MESSAGE_FORMAT, 1)));
+    setTerminated(pod, "Succeeded", 0, String.format(MESSAGE_FORMAT, 1));
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -220,7 +222,7 @@ public class KubernetesPodEventTranslatorTest {
   @Test
   public void noExitCodeFromEitherMessageOnTerminationLoggingNorDocker() throws Exception {
     Pod pod = podWithTerminationLogging();
-    pod.setStatus(terminated("Succeeded", null, null));
+    setTerminated(pod, "Succeeded", null, null);
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -231,7 +233,7 @@ public class KubernetesPodEventTranslatorTest {
   @Test
   public void exitCodeFromMessageOnTerminationLoggingAndNonzeroExitCode() throws Exception {
     Pod pod = podWithTerminationLogging();
-    pod.setStatus(terminated("Failed", 2, String.format(MESSAGE_FORMAT, 3)));
+    setTerminated(pod, "Failed", 2, String.format(MESSAGE_FORMAT, 3));
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -242,7 +244,7 @@ public class KubernetesPodEventTranslatorTest {
   @Test
   public void zeroExitCodeFromTerminationLogAndNonZeroContainerExitCode() throws Exception {
     Pod pod = podWithTerminationLogging();
-    pod.setStatus(terminated("Failed", 2, String.format(MESSAGE_FORMAT, 0)));
+    setTerminated(pod, "Failed", 2, String.format(MESSAGE_FORMAT, 0));
 
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
@@ -266,7 +268,7 @@ public class KubernetesPodEventTranslatorTest {
 
   @Test
   public void shouldIgnoreDeletedEvents() throws Exception {
-    pod.setStatus(terminated("Succeeded", 0, null));
+    setTerminated(pod, "Succeeded", 0, null);
     RunState state = RunState.create(WFI, RunState.State.TERMINATED);
 
     List<Event> events = translate(WFI, state, Watcher.Action.DELETED, pod, Stats.NOOP);
@@ -298,32 +300,51 @@ public class KubernetesPodEventTranslatorTest {
     assertThat(events, empty());
   }
 
-  static PodStatus running(boolean ready) {
-    return podStatus("Running", ready, new ContainerState(
-        new ContainerStateRunning("2016-05-30T09:46:48Z"),
-        null,
-        null));
+  static void setRunning(Pod pod, boolean ready) {
+    pod.setStatus(running(ready, pod.getMetadata().getName()));
   }
 
-  static PodStatus terminated(String phase, Integer exitCode, String message) {
-    return podStatus(phase, true, new ContainerState(
-        null,
-        new ContainerStateTerminated("", exitCode, "", message, "", 0, ""),
-        null));
+  static PodStatus running(boolean ready, String containerName) {
+    return podStatus("Running", ready, containerName,
+        new ContainerState(
+            new ContainerStateRunning("2016-05-30T09:46:48Z"),
+            null,
+            null));
   }
 
-  static PodStatus waiting(String phase, String reason) {
-    return podStatus(phase, true, new ContainerState(
-        null,
-        null,
-        new ContainerStateWaiting("", reason)));
+  static void setTerminated(Pod pod, String phase, Integer exitCode, String message) {
+    pod.setStatus(terminated(phase, exitCode, message, pod.getMetadata().getName()));
   }
 
-  static PodStatus podStatus(String phase, boolean ready, ContainerState containerState) {
+  static PodStatus terminated(String phase, Integer exitCode, String message, String containerName) {
+    return podStatus(phase, true, containerName,
+        new ContainerState(
+            null,
+            new ContainerStateTerminated("", exitCode, "", message, "", 0, ""),
+            null));
+  }
+
+  static void setWaiting(Pod pod, String phase, String reason) {
+    pod.setStatus(waiting(phase, reason, pod.getMetadata().getName()));
+  }
+
+  static PodStatus waiting(String phase, String reason, String containerName) {
+    return podStatus(phase, true, containerName,
+        new ContainerState(
+            null,
+            null,
+            new ContainerStateWaiting("", reason)));
+  }
+
+  static PodStatus podStatus(String phase, boolean ready, String containerName, ContainerState containerState) {
     PodStatus podStatus = podStatusNoContainer(phase);
     podStatus.getContainerStatuses()
         .add(new ContainerStatus("foo", "", "", containerState,
-                                 "bar", ready, 0, containerState));
+                                 containerName, ready, 0, containerState));
+    podStatus.getContainerStatuses()
+        .add(new ContainerStatusBuilder().withName(KEEPALIVE_CONTAINER_NAME)
+            .withNewState().withNewRunning().endRunning().endState()
+            .build());
     return podStatus;
   }
 


### PR DESCRIPTION
Start a sidecar container that runs forever in order to keep the pod alive after the main container exits. Styx can then reap the pod whenever it wishes, without missing the exit code and termination log
due to aggressive k8s pod GC.