### PR TITLE
remove old execution id migration code

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -123,11 +123,9 @@ public class DockerRunnerHandler implements OutputHandler {
         () -> new ResourceNotFoundException("Missing execution description for "
                                             + state.workflowInstance().toKey()));
 
-    // For backwards compatibility, create an execution ID here for RunStates that do not have one as
-    // they transitioned through a SUBMITTING state that did not create execution IDs. This execution ID
-    // will be added to the RunState through the submitted event.
-    final String executionId = state.data().executionId()
-        .orElseGet(ExecutionDescriptionHandler::createExecutionId);
+    final String executionId = state.data().executionId().orElseThrow(
+        () -> new ResourceNotFoundException("Missing execution id for "
+                                            + state.workflowInstance().toKey()));
 
     final String dockerImage = executionDescription.dockerImage();
     final List<String> dockerArgs = executionDescription.dockerArgs();

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -134,7 +134,7 @@ public class ExecutionDescriptionHandler implements OutputHandler {
         .build();
   }
 
-  static String createExecutionId() {
+  private static String createExecutionId() {
     return STYX_RUN + "-" + UUID.randomUUID().toString();
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
@@ -104,7 +104,10 @@ public class DockerRunnerHandlerTest {
     Workflow workflow = Workflow.create("id", configuration());
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
     RunState runState = RunState.create(workflowInstance, RunState.State.SUBMITTING,
-        StateData.newBuilder().executionDescription(EXECUTION_DESCRIPTION).build());
+        StateData.newBuilder()
+            .executionId(TEST_EXECUTION_ID)
+            .executionDescription(EXECUTION_DESCRIPTION)
+            .build());
 
     dockerRunnerHandler.transitionInto(runState);
 
@@ -179,7 +182,22 @@ public class DockerRunnerHandlerTest {
   public void shouldHaltIfMissingExecutionDescription() {
     Workflow workflow = Workflow.create("id", configuration());
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
-    RunState runState = RunState.create(workflowInstance, RunState.State.SUBMITTING);
+    RunState runState = RunState.create(workflowInstance, State.SUBMITTING, StateData.newBuilder()
+        .executionId(TEST_EXECUTION_ID)
+        .build());
+
+    dockerRunnerHandler.transitionInto(runState);
+
+    verify(stateManager).receiveIgnoreClosed(Event.halt(workflowInstance));
+  }
+
+  @Test
+  public void shouldHaltIfMissingExecutionId() {
+    Workflow workflow = Workflow.create("id", configuration());
+    WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
+    RunState runState = RunState.create(workflowInstance, State.SUBMITTING, StateData.newBuilder()
+        .executionDescription(EXECUTION_DESCRIPTION)
+        .build());
 
     dockerRunnerHandler.transitionInto(runState);
 


### PR DESCRIPTION
All currently active WFIs have execution id assigned in PREPARE by the `ExecutionDescriptionHandler`.