### PR TITLE
Check for correct exception type when triggering already triggered instances 

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
@@ -279,7 +279,7 @@ public class SchedulerResource {
         // TODO: propagate error information using a more specific exception type
         return Response.forStatus(CONFLICT.withReasonPhrase(cause.getMessage()));
       } else {
-        return Response.forStatus(INTERNAL_SERVER_ERROR);
+        return Response.forStatus(INTERNAL_SERVER_ERROR.withReasonPhrase(cause.getMessage()));
       }
     }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
@@ -275,17 +275,17 @@ public class SchedulerResource {
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     } catch (ExecutionException e) {
-      final Throwable cause = e.getCause();
-      if (findCause(e, IllegalStateException.class) != null
-          || findCause(e, IllegalArgumentException.class) != null) {
+      Throwable cause;
+      if ((cause = findCause(e, IllegalStateException.class)) != null
+          || (cause = findCause(e, IllegalArgumentException.class)) != null) {
         // TODO: propagate error information using a more specific exception type
         return Response.forStatus(CONFLICT.withReasonPhrase(cause.getMessage()));
-      } else if (findCause(e, AlreadyInitializedException.class) != null) {
+      } else if ((cause = findCause(e, AlreadyInitializedException.class)) != null) {
         return Response.forStatus(CONFLICT.withReasonPhrase(
             "This workflow instance is already triggered. Did you want to `retry` running it instead? " + cause
                 .getMessage()));
       } else {
-        return Response.forStatus(INTERNAL_SERVER_ERROR.withReasonPhrase(cause.getMessage()));
+        return Response.forStatus(INTERNAL_SERVER_ERROR.withReasonPhrase(e.getCause().getMessage()));
       }
     }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
@@ -280,10 +280,9 @@ public class SchedulerResource {
           || (cause = findCause(e, IllegalArgumentException.class)) != null) {
         // TODO: propagate error information using a more specific exception type
         return Response.forStatus(CONFLICT.withReasonPhrase(cause.getMessage()));
-      } else if ((cause = findCause(e, AlreadyInitializedException.class)) != null) {
+      } else if (findCause(e, AlreadyInitializedException.class) != null) {
         return Response.forStatus(CONFLICT.withReasonPhrase(
-            "This workflow instance is already triggered. Did you want to `retry` running it instead? " + cause
-                .getMessage()));
+            "This workflow instance is already triggered. Did you want to `retry` running it instead?"));
       } else {
         return Response.forStatus(INTERNAL_SERVER_ERROR.withReasonPhrase(e.getCause().getMessage()));
       }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
@@ -24,6 +24,7 @@ import static com.spotify.apollo.Status.BAD_REQUEST;
 import static com.spotify.apollo.Status.CONFLICT;
 import static com.spotify.apollo.Status.INTERNAL_SERVER_ERROR;
 import static com.spotify.apollo.Status.OK;
+import static com.spotify.styx.util.ExceptionUtil.findCause;
 import static com.spotify.styx.util.ParameterUtil.parseAlignedInstant;
 
 import com.spotify.apollo.RequestContext;
@@ -275,11 +276,11 @@ public class SchedulerResource {
       throw new RuntimeException(e);
     } catch (ExecutionException e) {
       final Throwable cause = e.getCause();
-      if (cause instanceof IllegalStateException
-          || cause instanceof IllegalArgumentException) {
+      if (findCause(e, IllegalStateException.class) != null
+          || findCause(e, IllegalArgumentException.class) != null) {
         // TODO: propagate error information using a more specific exception type
         return Response.forStatus(CONFLICT.withReasonPhrase(cause.getMessage()));
-      } else if (cause instanceof AlreadyInitializedException) {
+      } else if (findCause(e, AlreadyInitializedException.class) != null) {
         return Response.forStatus(CONFLICT.withReasonPhrase(
             "This workflow instance is already triggered. Did you want to `retry` running it instead? " + cause
                 .getMessage()));

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/api/SchedulerResource.java
@@ -45,6 +45,7 @@ import com.spotify.styx.serialization.Json;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.Storage;
+import com.spotify.styx.util.AlreadyInitializedException;
 import com.spotify.styx.util.EventUtil;
 import com.spotify.styx.util.IsClosedException;
 import com.spotify.styx.util.RandomGenerator;
@@ -278,6 +279,10 @@ public class SchedulerResource {
           || cause instanceof IllegalArgumentException) {
         // TODO: propagate error information using a more specific exception type
         return Response.forStatus(CONFLICT.withReasonPhrase(cause.getMessage()));
+      } else if (cause instanceof AlreadyInitializedException) {
+        return Response.forStatus(CONFLICT.withReasonPhrase(
+            "This workflow instance is already triggered. Did you want to `retry` running it instead? " + cause
+                .getMessage()));
       } else {
         return Response.forStatus(INTERNAL_SERVER_ERROR.withReasonPhrase(cause.getMessage()));
       }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
@@ -551,8 +551,7 @@ public class SchedulerResourceTest {
   public void failTriggeringAlreadyActiveWorkflowInstance() throws Exception {
     final AlreadyInitializedException exception = new AlreadyInitializedException("already active!");
     failtriggeringOnException(DAILY_WORKFLOW, exception, Status.CONFLICT.withReasonPhrase(
-        "This workflow instance is already triggered. Did you want to `retry` running it instead? " + exception
-            .getMessage()));
+        "This workflow instance is already triggered. Did you want to `retry` running it instead?"));
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
@@ -59,6 +59,7 @@ import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.testdata.TestData;
+import com.spotify.styx.util.AlreadyInitializedException;
 import com.spotify.styx.util.TriggerUtil;
 import com.spotify.styx.util.WorkflowValidator;
 import com.spotify.styx.workflow.WorkflowInitializationException;
@@ -529,7 +530,7 @@ public class SchedulerResourceTest {
 
   @Test
   public void testTriggerAlreadyActiveWorkflowInstance() throws Exception {
-    final IllegalStateException cause = new IllegalStateException("already active!");
+    final AlreadyInitializedException cause = new AlreadyInitializedException("already active!");
 
     when(storage.workflow(DAILY_WORKFLOW.id())).thenReturn(Optional.of(DAILY_WORKFLOW));
     WorkflowInstance toTrigger = WorkflowInstance.create(DAILY_WORKFLOW.id(), "2015-12-31");
@@ -540,7 +541,9 @@ public class SchedulerResourceTest {
     Response<ByteString> response = requestAndWaitTriggerWorkflowInstance(toTrigger);
 
     assertThat(response.status(),
-               is(Status.CONFLICT.withReasonPhrase(cause.getMessage())));
+               is(Status.CONFLICT.withReasonPhrase(
+                   "This workflow instance is already triggered. Did you want to `retry` running it instead? " + cause
+                       .getMessage())));
   }
 
   @Test


### PR DESCRIPTION
When users call `styx trigger` on an already running partition, they only saw `API error: 500 Internal Server Error`, which was wrong and lacking more information. This corrects the return code to 409 instead, and adds the exception stack trace in cases of status code 500. 
