### PR TITLE
migrate workflow from having ancestor to flat structure 

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/model/StyxConfig.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/StyxConfig.java
@@ -48,6 +48,11 @@ public interface StyxConfig {
   boolean resourcesSyncEnabled();
 
   /**
+   * Get the flag for enabling migrate workflows at startup.
+   */
+  boolean migrateWorkflowsEnabled();
+
+  /**
    * Controls whether workflow instance execution gating should be performed. If set to false,
    * instances will be executed without checking for blockers.
    */

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -188,6 +188,12 @@ public class AggregateStorage implements Storage {
     return datastoreStorage.workflows(workflowIds);
   }
 
+  // TODO: remove after migration
+  @Override
+  public void migrateWorkflows() {
+    datastoreStorage.migrateWorkflows();
+  }
+
   @Override
   public void patchState(WorkflowId workflowId, WorkflowState state) throws IOException {
     datastoreStorage.patchState(workflowId, state);

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -411,7 +411,16 @@ public class DatastoreStorage implements Closeable {
     // FIXME: there might be a performance penalty but not too bad because this is only used by an API
     while (result.hasNext()) {
       final Entity entity = result.next();
-      if (!entity.getKey().getName().startsWith(componentId + "#")) {
+
+      final WorkflowId workflowId;
+      try {
+        workflowId = WorkflowId.parseKey(entity.getKey().getName());
+      } catch (IllegalArgumentException e) {
+        LOG.warn("Invalid workflow Id {}", entity.getKey().getName(), e);
+        continue;
+      }
+
+      if (!workflowId.componentId().equals(componentId)) {
         continue;
       }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -268,7 +268,7 @@ public class DatastoreStorage implements Closeable {
   Optional<Workflow> workflow(WorkflowId workflowId) throws IOException {
     final Optional<Entity> entityOptional = Optional.ofNullable(
         getOpt(datastore, workflowKey(datastore.newKeyFactory(), workflowId))
-            .orElse(getOpt(datastore,
+            .orElseGet(() -> getOpt(datastore,
                 legacyWorkflowKey(datastore.newKeyFactory(), workflowId)).orElse(null)));
     if (entityOptional.isPresent()) {
       return Optional.of(parseWorkflowJson(entityOptional.get(), workflowId));

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -452,6 +452,8 @@ public class DatastoreStorage implements Closeable {
     return workflows;
   }
 
+  // TODO: remove after migration
+  // this method is not well optimized and does redundant reading
   void migrateWorkflows() {
     final Map<WorkflowId, Workflow> map = workflows();
     map.values().forEach(workflow -> {

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
@@ -200,7 +200,7 @@ public class DatastoreStorageTransaction implements StorageTransaction {
     final Optional<Entity> entityOptional = Optional.ofNullable(
         DatastoreStorage.getOpt(tx,
             DatastoreStorage.workflowKey(tx.getDatastore().newKeyFactory(), workflowId))
-            .orElse(DatastoreStorage.getOpt(tx,
+            .orElseGet(() -> DatastoreStorage.getOpt(tx,
                 DatastoreStorage.legacyWorkflowKey(tx.getDatastore().newKeyFactory(), workflowId))
                 .orElse(null)));
     if (entityOptional.isPresent()) {

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
@@ -54,7 +54,6 @@ import static com.spotify.styx.util.ShardedCounter.PROPERTY_SHARD_VALUE;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.Entity;
-import com.google.cloud.datastore.Entity.Builder;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.StringValue;
 import com.google.cloud.datastore.Transaction;
@@ -179,23 +178,25 @@ public class DatastoreStorageTransaction implements StorageTransaction {
   @Override
   public WorkflowId storeWorkflowWithNextNaturalTrigger(Workflow workflow, TriggerInstantSpec triggerSpec)
       throws IOException {
-
-    final Key componentKey = DatastoreStorage.componentKey(tx.getDatastore().newKeyFactory(), workflow.componentId());
-    if (tx.get(componentKey) == null) {
-      tx.put(Entity.newBuilder(componentKey).build());
-    }
-
     final String json = OBJECT_MAPPER.writeValueAsString(workflow);
+
     final Key workflowKey = DatastoreStorage.workflowKey(tx.getDatastore().newKeyFactory(), workflow.id());
-    final Optional<Entity> workflowOpt = DatastoreStorage.getOpt(tx, workflowKey);
-    final Builder entity = DatastoreStorage.asBuilderOrNew(workflowOpt, workflowKey)
-        .set(PROPERTY_WORKFLOW_JSON, StringValue.newBuilder(json).setExcludeFromIndexes(true).build())
+    final Key legacyWorkflowKey = DatastoreStorage.legacyWorkflowKey(tx.getDatastore().newKeyFactory(), workflow.id());
+
+    final Optional<Entity> workflowOpt = getWorkflowOpt(tx, workflow.id(), workflowKey, legacyWorkflowKey);
+
+    final Entity workflowEntity = DatastoreStorage.asBuilderOrNew(workflowOpt, workflowKey)
+        .setKey(workflowKey)
+        .set(PROPERTY_WORKFLOW_JSON,
+            StringValue.newBuilder(json).setExcludeFromIndexes(true).build())
         .set(PROPERTY_NEXT_NATURAL_TRIGGER, instantToTimestamp(triggerSpec.instant()))
-        .set(PROPERTY_NEXT_NATURAL_OFFSET_TRIGGER, instantToTimestamp(triggerSpec.offsetInstant()));
-    tx.put(entity.build());
+        .set(PROPERTY_NEXT_NATURAL_OFFSET_TRIGGER, instantToTimestamp(triggerSpec.offsetInstant()))
+        .build();
+
+    tx.put(workflowEntity);
+    tx.delete(legacyWorkflowKey);
 
     return workflow.id();
-
   }
 
   @Override

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -135,6 +135,12 @@ public class InMemStorage implements Storage {
     throw new UnsupportedOperationException("Unsupported Operation!");
   }
 
+  // TODO: remove after migration
+  @Override
+  public void migrateWorkflows() {
+    // nop
+  }
+
   @Override
   public WorkflowInstanceExecutionData executionData(WorkflowInstance workflowInstance)
       throws IOException {

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -134,6 +134,9 @@ public interface Storage extends Closeable {
    */
   Map<WorkflowId,Workflow> workflows(Set<WorkflowId> workflowIds);
 
+  // TODO: remove after migration
+  void migrateWorkflows();
+
   /**
    * Stores information about an active {@link WorkflowInstance} to be tracked.
    * @param workflowInstance  The {@link WorkflowInstance} that entered an active state

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -101,7 +101,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -910,9 +909,15 @@ public class DatastoreStorageTest {
     Workflow workflow2 = workflow(WORKFLOW_ID2);
     Workflow workflow3 = workflow(WORKFLOW_ID3);
 
+    Key key1 = legacyWorkflowKey(datastore.newKeyFactory(), workflow1.id());
+    Key key2 = legacyWorkflowKey(datastore.newKeyFactory(), workflow2.id());
+    Key key3 = legacyWorkflowKey(datastore.newKeyFactory(), workflow3.id());
+
     storeWorkflowInLegacyWay(workflow1);
     storeWorkflowInLegacyWay(workflow2);
     storeWorkflowInLegacyWay(workflow3);
+
+    assertTrue(datastore.get(key1, key2, key3).hasNext());
 
     storage.migrateWorkflows();
 
@@ -926,12 +931,7 @@ public class DatastoreStorageTest {
     assertThat(storage.workflows(), hasEntry(WORKFLOW_ID2, workflow2));
     assertThat(storage.workflows(), hasEntry(WORKFLOW_ID3, workflow3));
 
-    Key key1 = legacyWorkflowKey(datastore.newKeyFactory(), workflow1.id());
-    Key key2 = legacyWorkflowKey(datastore.newKeyFactory(), workflow2.id());
-    Key key3 = legacyWorkflowKey(datastore.newKeyFactory(), workflow3.id());
-
-    final Iterator<Entity> entityIterator = datastore.get(key1, key2, key3);
-    assertFalse(entityIterator.hasNext());
+    assertFalse(datastore.get(key1, key2, key3).hasNext());
   }
 
   // TODO: remove after migration

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTransactionTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTransactionTest.java
@@ -230,7 +230,6 @@ public class DatastoreStorageTransactionTest {
     assertThat(result, hasEntry(workflow, spec));
   }
 
-
   @Test
   public void shouldStoreShards() throws IOException {
     DatastoreStorageTransaction tx = new DatastoreStorageTransaction(datastore.newTransaction());


### PR DESCRIPTION
Instead of using ancestor, make `component id` part of workflow key.