### PR TITLE
[wip] remove resource kind

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -22,7 +22,6 @@ package com.spotify.styx.storage;
 
 import com.google.cloud.datastore.Datastore;
 import com.spotify.styx.model.Backfill;
-import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.SequenceEvent;
 import com.spotify.styx.model.StyxConfig;
 import com.spotify.styx.model.Workflow;
@@ -40,6 +39,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
+import javaslang.Tuple2;
 import org.apache.hadoop.hbase.client.Connection;
 
 /**
@@ -199,21 +199,6 @@ public class AggregateStorage implements Storage {
   }
 
   @Override
-  public Optional<Resource> resource(String id) throws IOException {
-    return datastoreStorage.getResource(id);
-  }
-
-  @Override
-  public List<Resource> resources() throws IOException {
-    return datastoreStorage.getResources();
-  }
-
-  @Override
-  public void deleteResource(String id) throws IOException {
-    datastoreStorage.deleteResource(id);
-  }
-
-  @Override
   public void storeBackfill(Backfill backfill) throws IOException {
     datastoreStorage.storeBackfill(backfill);
   }
@@ -231,11 +216,6 @@ public class AggregateStorage implements Storage {
   @Override
   public long getLimitForCounter(String counterId) {
     return datastoreStorage.getLimitForCounter(counterId);
-  }
-
-  @Override
-  public void storeResource(Resource resource) throws IOException {
-    datastoreStorage.postResource(resource);
   }
 
   @Override
@@ -269,12 +249,23 @@ public class AggregateStorage implements Storage {
   }
 
   @Override
-  public void deleteLimitForCounter(String counterId) throws IOException {
-    datastoreStorage.deleteLimitForCounter(counterId);
+  public Optional<Tuple2<String, Long>> getCounterLimit(String id) throws IOException {
+    return datastoreStorage.getCounterLimit(id);
   }
 
   @Override
-  public void updateLimitForCounter(String counterId, long limit) throws IOException {
-    datastoreStorage.updateLimitForCounter(counterId, limit);
+  public List<Tuple2<String, Long>> getCounterLimits() throws IOException {
+    return datastoreStorage.getCounterLimits();
+  }
+
+
+  @Override
+  public void deleteCounterLimit(String counterId) throws IOException {
+    datastoreStorage.deleteCounterLimit(counterId);
+  }
+
+  @Override
+  public void updateCounterLimit(String counterId, long limit) throws IOException {
+    datastoreStorage.updateCounterLimit(counterId, limit);
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -258,7 +258,6 @@ public class AggregateStorage implements Storage {
     return datastoreStorage.getCounterLimits();
   }
 
-
   @Override
   public void deleteCounterLimit(String counterId) throws IOException {
     datastoreStorage.deleteCounterLimit(counterId);

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
@@ -21,7 +21,6 @@
 package com.spotify.styx.storage;
 
 import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
-import static com.spotify.styx.storage.DatastoreStorage.KIND_RESOURCE;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_ALL_TRIGGERED;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_COMPONENT;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_CONCURRENCY;
@@ -49,14 +48,12 @@ import static com.spotify.styx.util.ShardedCounter.PROPERTY_LIMIT;
 import static com.spotify.styx.util.ShardedCounter.PROPERTY_SHARD_INDEX;
 import static com.spotify.styx.util.ShardedCounter.PROPERTY_SHARD_VALUE;
 
-import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.StringValue;
 import com.google.cloud.datastore.Transaction;
 import com.spotify.styx.model.Backfill;
-import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
@@ -130,26 +127,14 @@ public class DatastoreStorageTransaction implements StorageTransaction {
   }
 
   @Override
-  public void updateLimitForCounter(String counterId, long limit) {
+  public void updateCounterLimit(String counterId, long limit) {
     final Key limitKey = tx.getDatastore().newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(counterId);
     tx.put(Entity.newBuilder(limitKey).set(PROPERTY_LIMIT, limit).build());
   }
 
   @Override
-  public void store(Resource resource) {
-    tx.put(resourceToEntity(tx.getDatastore(), resource));
-  }
-
-  @Override
   public void deleteCounterLimit(String counterId) {
     tx.delete(tx.getDatastore().newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(counterId));
-  }
-
-  private Entity resourceToEntity(Datastore datastore, Resource resource) {
-    final Key key = datastore.newKeyFactory().setKind(KIND_RESOURCE).newKey(resource.id());
-    return Entity.newBuilder(key)
-        .set(PROPERTY_CONCURRENCY, resource.concurrency())
-        .build();
   }
 
   @Override

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -20,8 +20,6 @@
 
 package com.spotify.styx.storage;
 
-import static java.util.stream.Collectors.toList;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -110,7 +108,7 @@ public class InMemStorage implements Storage {
   public List<Workflow> workflows(String componentId) throws IOException {
     return workflowStore.values().stream()
         .filter(w -> w.componentId().equals(componentId))
-        .collect(toList());
+        .collect(Collectors.toList());
   }
 
   @Override
@@ -207,7 +205,7 @@ public class InMemStorage implements Storage {
     return ImmutableList.copyOf(
         resourceStore.values().stream()
             .map(resource -> Tuple.of(resource.id(), resource.concurrency()))
-            .collect(toList()));
+            .collect(Collectors.toList()));
   }
 
   @Override
@@ -219,7 +217,7 @@ public class InMemStorage implements Storage {
           .filter(backfill -> backfill.halted() && backfill.allTriggered());
     }
 
-    return ImmutableList.copyOf(backfillStream.collect(toList())
+    return ImmutableList.copyOf(backfillStream.collect(Collectors.toList())
     );
   }
 
@@ -234,7 +232,7 @@ public class InMemStorage implements Storage {
           .filter(backfill -> backfill.halted() && backfill.allTriggered());
     }
 
-    return ImmutableList.copyOf(backfillStream.collect(toList()));
+    return ImmutableList.copyOf(backfillStream.collect(Collectors.toList()));
   }
 
   @Override
@@ -247,7 +245,7 @@ public class InMemStorage implements Storage {
           .filter(backfill -> backfill.halted() && backfill.allTriggered());
     }
 
-    return ImmutableList.copyOf(backfillStream.collect(toList()));
+    return ImmutableList.copyOf(backfillStream.collect(Collectors.toList()));
   }
 
   @Override
@@ -261,7 +259,7 @@ public class InMemStorage implements Storage {
           .filter(backfill -> backfill.halted() && backfill.allTriggered());
     }
 
-    return ImmutableList.copyOf(backfillStream.collect(toList()));
+    return ImmutableList.copyOf(backfillStream.collect(Collectors.toList()));
   }
 
   @Override
@@ -286,7 +284,7 @@ public class InMemStorage implements Storage {
 
   @Override
   public long getLimitForCounter(String counterId) {
-    throw new UnsupportedOperationException();
+    return resourceStore.get(counterId).concurrency();
   }
 
   @Override
@@ -297,12 +295,12 @@ public class InMemStorage implements Storage {
 
   @Override
   public void deleteCounterLimit(String counterId) {
-    throw new UnsupportedOperationException();
+    resourceStore.remove(counterId);
   }
 
   @Override
   public void updateCounterLimit(String counterId, long limit) throws IOException {
-    throw new UnsupportedOperationException();
+    resourceStore.put(counterId, Resource.create(counterId, limit));
   }
 
   @Override

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -20,6 +20,8 @@
 
 package com.spotify.styx.storage;
 
+import static java.util.stream.Collectors.toList;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -48,6 +50,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javaslang.Tuple;
+import javaslang.Tuple2;
 
 /**
  * A Storage implementation with state stored in memory. For testing.
@@ -106,7 +110,7 @@ public class InMemStorage implements Storage {
   public List<Workflow> workflows(String componentId) throws IOException {
     return workflowStore.values().stream()
         .filter(w -> w.componentId().equals(componentId))
-        .collect(Collectors.toList());
+        .collect(toList());
   }
 
   @Override
@@ -193,23 +197,17 @@ public class InMemStorage implements Storage {
   }
 
   @Override
-  public Optional<Resource> resource(String id) throws IOException {
-    return Optional.ofNullable(resourceStore.get(id));
+  public Optional<Tuple2<String, Long>> getCounterLimit(String id) throws IOException {
+    return Optional.ofNullable(resourceStore.get(id))
+        .map(resource -> Tuple.of(resource.id(), resource.concurrency()));
   }
 
   @Override
-  public void storeResource(Resource resource) throws IOException {
-    resourceStore.put(resource.id(), resource);
-  }
-
-  @Override
-  public List<Resource> resources() throws IOException {
-    return ImmutableList.copyOf(resourceStore.values());
-  }
-
-  @Override
-  public void deleteResource(String id) throws IOException {
-    resourceStore.remove(id);
+  public List<Tuple2<String, Long>> getCounterLimits() throws IOException {
+    return ImmutableList.copyOf(
+        resourceStore.values().stream()
+            .map(resource -> Tuple.of(resource.id(), resource.concurrency()))
+            .collect(toList()));
   }
 
   @Override
@@ -221,7 +219,7 @@ public class InMemStorage implements Storage {
           .filter(backfill -> backfill.halted() && backfill.allTriggered());
     }
 
-    return ImmutableList.copyOf(backfillStream.collect(Collectors.toList())
+    return ImmutableList.copyOf(backfillStream.collect(toList())
     );
   }
 
@@ -236,7 +234,7 @@ public class InMemStorage implements Storage {
           .filter(backfill -> backfill.halted() && backfill.allTriggered());
     }
 
-    return ImmutableList.copyOf(backfillStream.collect(Collectors.toList()));
+    return ImmutableList.copyOf(backfillStream.collect(toList()));
   }
 
   @Override
@@ -249,7 +247,7 @@ public class InMemStorage implements Storage {
           .filter(backfill -> backfill.halted() && backfill.allTriggered());
     }
 
-    return ImmutableList.copyOf(backfillStream.collect(Collectors.toList()));
+    return ImmutableList.copyOf(backfillStream.collect(toList()));
   }
 
   @Override
@@ -263,7 +261,7 @@ public class InMemStorage implements Storage {
           .filter(backfill -> backfill.halted() && backfill.allTriggered());
     }
 
-    return ImmutableList.copyOf(backfillStream.collect(Collectors.toList()));
+    return ImmutableList.copyOf(backfillStream.collect(toList()));
   }
 
   @Override
@@ -298,12 +296,12 @@ public class InMemStorage implements Storage {
   }
 
   @Override
-  public void deleteLimitForCounter(String counterId) {
+  public void deleteCounterLimit(String counterId) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void updateLimitForCounter(String counterId, long limit) throws IOException {
+  public void updateCounterLimit(String counterId, long limit) throws IOException {
     throw new UnsupportedOperationException();
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -21,7 +21,6 @@
 package com.spotify.styx.storage;
 
 import com.spotify.styx.model.Backfill;
-import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.SequenceEvent;
 import com.spotify.styx.model.StyxConfig;
 import com.spotify.styx.model.Workflow;
@@ -38,6 +37,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
+import javaslang.Tuple2;
 
 /**
  * The interface to the persistence layer.
@@ -257,14 +257,6 @@ public interface Storage extends Closeable {
    */
   WorkflowState workflowState(WorkflowId workflowId) throws IOException;
 
-  Optional<Resource> resource(String id) throws IOException;
-
-  void storeResource(Resource resource) throws IOException;
-
-  List<Resource> resources() throws IOException;
-
-  void deleteResource(String id) throws IOException;
-
   List<Backfill> backfills(boolean showAll) throws IOException;
 
   List<Backfill> backfillsForComponent(boolean showAll, String component) throws IOException;
@@ -290,7 +282,11 @@ public interface Storage extends Closeable {
   <T, E extends Exception> T runInTransaction(TransactionFunction<T, E> f)
       throws IOException, E;
 
-  void deleteLimitForCounter(String counterId) throws IOException;
+  Optional<Tuple2<String, Long>> getCounterLimit(String id) throws IOException;
 
-  void updateLimitForCounter(String counterId, long limit) throws IOException;
+  List<Tuple2<String, Long>> getCounterLimits() throws IOException;
+
+  void deleteCounterLimit(String counterId) throws IOException;
+
+  void updateCounterLimit(String counterId, long limit) throws IOException;
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/StorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/StorageTransaction.java
@@ -21,7 +21,6 @@
 package com.spotify.styx.storage;
 
 import com.spotify.styx.model.Backfill;
-import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
@@ -149,12 +148,7 @@ public interface StorageTransaction {
   /**
    * Updates the limit for the given counter
    */
-  void updateLimitForCounter(String counterId, long limit);
-
-  /**
-   * Stores a resource
-   */
-  void store(Resource resource);
+  void updateCounterLimit(String counterId, long limit);
 
   /**
    * Deletes the limit configured for the given counter

--- a/styx-common/src/main/java/com/spotify/styx/util/ShardedCounter.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ShardedCounter.java
@@ -206,7 +206,7 @@ public class ShardedCounter {
    * updateCounter operations on this counter.
    */
   public void updateLimit(StorageTransaction tx, String counterId, long limit) {
-    tx.updateLimitForCounter(counterId, limit);
+    tx.updateCounterLimit(counterId, limit);
   }
 
   /**
@@ -304,6 +304,6 @@ public class ShardedCounter {
    */
   public void deleteCounter(String counterId) throws IOException {
     storage.deleteShardsForCounter(counterId);
-    storage.deleteLimitForCounter(counterId);
+    storage.deleteCounterLimit(counterId);
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/monitoring/MeteredStorageProxyTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/monitoring/MeteredStorageProxyTest.java
@@ -60,19 +60,19 @@ public class MeteredStorageProxyTest {
 
   @Test
   public void instrumentStorageMethod() throws Exception {
-    proxy.resource("foobar");
+    proxy.getCounterLimit("foobar");
 
-    verify(storage).resource("foobar");
-    verify(stats).recordStorageOperation("resource", 123, "success");
+    verify(storage).getCounterLimit("foobar");
+    verify(stats).recordStorageOperation("getCounterLimit", 123, "success");
   }
 
   @Test
   public void surfaceExceptions() throws Exception {
-    doThrow(new RuntimeException("with message")).when(storage).resource("foobar");
+    doThrow(new RuntimeException("with message")).when(storage).getCounterLimit("foobar");
 
     expect.expect(RuntimeException.class);
     expect.expectMessage("with message");
 
-    proxy.resource("foobar");
+    proxy.getCounterLimit("foobar");
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/storage/AggregateStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/AggregateStorageTest.java
@@ -41,10 +41,10 @@ public class AggregateStorageTest {
 
   private static final String COMPONENT = "test-component";
 
-  @Mock BigtableStorage bigtable;
-  @Mock DatastoreStorage datastore;
-  @Mock WorkflowInstance workflowInstance;
-  @Mock RunState runState;
+  @Mock private BigtableStorage bigtable;
+  @Mock private DatastoreStorage datastore;
+  @Mock private WorkflowInstance workflowInstance;
+  @Mock private RunState runState;
 
   private AggregateStorage sut;
 
@@ -82,5 +82,29 @@ public class AggregateStorageTest {
   public void writeActiveState() throws Exception {
     sut.writeActiveState(workflowInstance, runState);
     verify(datastore).writeActiveState(workflowInstance, runState);
+  }
+
+  @Test
+  public void getCounterLimit() throws Exception {
+    sut.getCounterLimit("res1");
+    verify(datastore).getCounterLimit("res1");
+  }
+
+  @Test
+  public void getCounterLimits() throws Exception {
+    sut.getCounterLimits();
+    verify(datastore).getCounterLimits();
+  }
+
+  @Test
+  public void deleteCounterLimit() throws Exception {
+    sut.deleteCounterLimit("res1");
+    verify(datastore).deleteCounterLimit("res1");
+  }
+
+  @Test
+  public void updateCounterLimit() throws Exception {
+    sut.updateCounterLimit("res1", 1L);
+    verify(datastore).updateCounterLimit("res1", 1L);
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -86,6 +86,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.logging.Level;
+import javaslang.Tuple2;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -108,7 +109,6 @@ public class DatastoreStorageTest {
 
   static final Instant TIMESTAMP = Instant.parse("2017-01-01T00:00:00Z");
 
-
   static final RunState RUN_STATE = RunState.create(WORKFLOW_INSTANCE1, State.NEW,
       StateData.zero(), TIMESTAMP, 42L);
 
@@ -120,7 +120,6 @@ public class DatastoreStorageTest {
 
   static final RunState RUN_STATE3 = RunState.create(WORKFLOW_INSTANCE3, State.NEW,
       StateData.zero(), TIMESTAMP, 17L);
-
 
   static final RunState FULLY_POPULATED_RUNSTATE = RunState.create(WORKFLOW_INSTANCE, State.QUEUED,
       StateData.newBuilder()
@@ -158,6 +157,7 @@ public class DatastoreStorageTest {
   static final Workflow WORKFLOW = Workflow.create(WORKFLOW_ID.componentId(),
                                                            WORKFLOW_CONFIGURATION);
   private static final String COUNTER_ID1 = "counter-id1";
+  private static final String COUNTER_ID2 = "counter-id2";
 
   private static LocalDatastoreHelper helper;
   private DatastoreStorage storage;
@@ -768,6 +768,35 @@ public class DatastoreStorageTest {
     assertEquals(2, map.size());
     assertEquals(0, map.get(0).longValue());
     assertEquals(3, map.get(1).longValue());
+  }
+
+  @Test
+  public void shouldReturnCounterLimits() throws Exception {
+    storage.updateCounterLimit(COUNTER_ID1, 10);
+    storage.updateCounterLimit(COUNTER_ID2, 20);
+
+    assertEquals(2, storage.getCounterLimits().size());
+
+    final Optional<Tuple2<String, Long>> counterLimit1 = storage.getCounterLimit(COUNTER_ID1);
+    assertTrue(counterLimit1.isPresent());
+    assertEquals(Long.valueOf(10L), counterLimit1.get()._2);
+
+    final Optional<Tuple2<String, Long>> counterLimit2 = storage.getCounterLimit(COUNTER_ID2);
+    assertTrue(counterLimit2.isPresent());
+    assertEquals(Long.valueOf(20L), counterLimit2.get()._2);
+  }
+
+  @Test
+  public void shouldDeleteCounterLimit() throws Exception {
+    storage.updateCounterLimit(COUNTER_ID1, 10);
+    storage.updateCounterLimit(COUNTER_ID2, 20);
+
+    assertEquals(2, storage.getCounterLimits().size());
+
+    storage.deleteCounterLimit(COUNTER_ID1);
+    storage.deleteCounterLimit(COUNTER_ID2);
+
+    assertEquals(0, storage.getCounterLimits().size());
   }
 
   private static class FooException extends Exception {

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -787,6 +787,14 @@ public class DatastoreStorageTest {
   }
 
   @Test
+  public void shouldReturnEmptyIfNotFound() throws Exception {
+    storage.updateCounterLimit(COUNTER_ID1, 10);
+
+    final Optional<Tuple2<String, Long>> counterLimit2 = storage.getCounterLimit(COUNTER_ID2);
+    assertFalse(counterLimit2.isPresent());
+  }
+
+  @Test
   public void shouldDeleteCounterLimit() throws Exception {
     storage.updateCounterLimit(COUNTER_ID1, 10);
     storage.updateCounterLimit(COUNTER_ID2, 20);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -121,7 +121,9 @@ public class Scheduler {
     final Optional<Long> globalConcurrency;
     final StyxConfig config;
     try {
-      resources = storage.resources().stream().collect(toMap(Resource::id, identity()));
+      resources = storage.getCounterLimits().stream()
+          .map(counterLimit -> Resource.create(counterLimit._1, counterLimit._2))
+          .collect(toMap(Resource::id, identity()));
       config = storage.config();
       globalConcurrency = config.globalConcurrency();
     } catch (IOException e) {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/BackfillTriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/BackfillTriggerManagerTest.java
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.Lists;
 import com.spotify.futures.CompletableFutures;
 import com.spotify.styx.model.Backfill;
-import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.StyxConfig;
 import com.spotify.styx.model.Workflow;
@@ -70,6 +69,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import javaslang.Tuple2;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -106,7 +106,7 @@ public class BackfillTriggerManagerTest {
 
   private static final Time TIME =  () -> Instant.parse("2016-12-02T22:00:00Z");
 
-  private List<Resource> resourceLimits = Lists.newArrayList();
+  private List<Tuple2<String, Long>> counterLimits = Lists.newArrayList();
 
   @Mock TriggerListener triggerListener;
   @Mock Storage storage;
@@ -143,7 +143,7 @@ public class BackfillTriggerManagerTest {
 
     when(stateManager.getActiveStatesByTriggerId(anyString())).thenReturn(activeStates);
 
-    when(storage.resources()).thenReturn(resourceLimits);
+    when(storage.getCounterLimits()).thenReturn(counterLimits);
     when(config.globalConcurrency()).thenReturn(Optional.empty());
     when(storage.config()).thenReturn(config);
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -285,12 +285,7 @@ public class StyxSchedulerServiceFixture {
   }
 
   void givenResource(Resource resource) throws IOException {
-    storage.storeResource(resource);
-    storage.updateLimitForCounter(resource.id(), resource.concurrency());
-  }
-
-  void givenResourceIdsToDecorateWith(Set<String> resourceIds) throws IOException {
-    resourceIdsToDecorateWith = resourceIds;
+    storage.updateCounterLimit(resource.id(), resource.concurrency());
   }
 
   void workflowChanges(Workflow workflow) throws IOException {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
@@ -35,7 +35,6 @@ import com.google.api.services.container.v1beta1.model.Cluster;
 import com.google.api.services.container.v1beta1.model.MasterAuth;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.styx.StyxScheduler.KubernetesClientFactory;
-import com.spotify.styx.model.Resource;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.storage.StorageTransaction;
 import com.spotify.styx.storage.TransactionFunction;
@@ -153,7 +152,7 @@ public class StyxSchedulerTest {
     when(storage.runInTransaction(any())).thenAnswer(
         a -> a.getArgumentAt(0, TransactionFunction.class).apply(transaction));
 
-    styxScheduler.resetShards(storage, Resource.create("res1", 300));
+    styxScheduler.resetShards(storage, "res1");
 
     verify(transaction, times(128)).store(shardArgumentCaptor.capture());
     shardsWithValue(shardArgumentCaptor, 0L, 128);
@@ -165,7 +164,7 @@ public class StyxSchedulerTest {
     when(storage.runInTransaction(any())).thenThrow(exception);
 
     try {
-      styxScheduler.resetShards(storage, Resource.create("res1", 300));
+      styxScheduler.resetShards(storage, "res1");
       fail();
     } catch (Exception e) {
       assertThat(e.getCause(), is(exception));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -28,7 +28,6 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -36,7 +35,6 @@ import com.spotify.styx.docker.DockerRunner.RunSpec;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.ExecutionDescription;
-import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.SequenceEvent;
 import com.spotify.styx.model.Workflow;
@@ -108,16 +106,6 @@ public class SystemTest extends StyxSchedulerServiceFixture {
       .nextTrigger(Instant.parse("2015-01-01T00:00:00Z"))
       .schedule(Schedule.HOURS)
       .build();
-  private static final String RESOURCE_ID1 = "resource_1";
-  private static final String RESOURCE_ID2 = "resource_2";
-  private static final String RESOURCE_ID3 = "resource_3";
-  private static final String RESOURCE_ID4 = "resource_4";
-  private static final String RESOURCE_ID5 = "resource_5";
-  private static final Resource RESOURCE_1 = Resource.create(RESOURCE_ID1, 10);
-  private static final Resource RESOURCE_2 = Resource.create(RESOURCE_ID2, 128);
-  private static final Resource RESOURCE_3 = Resource.create(RESOURCE_ID3, 10000);
-  private static final Resource RESOURCE_4 = Resource.create(RESOURCE_ID4, 3);
-  private static final Resource RESOURCE_5 = Resource.create(RESOURCE_ID5, 1);
 
   private static RunSpec naturalRunSpec(String executionId, String imageName, List<String> args) {
     return RunSpec.builder()
@@ -667,25 +655,6 @@ public class SystemTest extends StyxSchedulerServiceFixture {
     awaitWorkflowInstanceCompletion(workflowInstance);
     tickScheduler();
     assertThat(getState(workflowInstance), is(Optional.empty()));
-  }
-  }
-
-  @RunWith(JUnitParamsRunner.class)
-  public static class CreatesCounterShardsForExistingResourcesTest extends SystemTest {
-  @Test
-  public void createsCounterShardsForExistingResources() throws Exception {
-    givenResource(RESOURCE_1);
-    givenResource(RESOURCE_2);
-    givenResource(RESOURCE_3);
-
-    styxStarts();
-
-    assertEquals(RESOURCE_1.concurrency(), storage.getLimitForCounter(RESOURCE_1.id()));
-    assertEquals(RESOURCE_2.concurrency(), storage.getLimitForCounter(RESOURCE_2.id()));
-    assertEquals(RESOURCE_3.concurrency(), storage.getLimitForCounter(RESOURCE_3.id()));
-    assertEquals(128, storage.shardsForCounter(RESOURCE_1.id()).size());
-    assertEquals(128, storage.shardsForCounter(RESOURCE_2.id()).size());
-    assertEquals(128, storage.shardsForCounter(RESOURCE_3.id()).size());
   }
   }
 }


### PR DESCRIPTION
The idea is to keep using `CounterLimit` and ditch `Resource` kind in Datastore.
In order to have minimum confusion, `Resource` usage has been removed from storage layer. So at storage side, we call it `CounterLimit`, while at API and scheduler side, we call it `Resource`.