### PR TITLE
request no resources for keepalive container

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -309,6 +309,9 @@ class KubernetesDockerRunner implements DockerRunner {
         .addToRequests("cpu", new QuantityBuilder()
             .withAmount("0")
             .build())
+        .addToRequests("memory", new QuantityBuilder()
+            .withAmount("0")
+            .build())
         .endResources()
         .build();
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -60,6 +60,7 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.QuantityBuilder;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretVolumeSource;
@@ -304,6 +305,11 @@ class KubernetesDockerRunner implements DockerRunner {
         .withName(KEEPALIVE_CONTAINER_NAME)
         // Use the k8s pause container image. It sleeps forever until terminated.
         .withImage("k8s.gcr.io/pause:3.1")
+        .withNewResources()
+        .addToRequests("cpu", new QuantityBuilder()
+            .withAmount("0")
+            .build())
+        .endResources()
         .build();
   }
 


### PR DESCRIPTION
Without this, we get the default (non-zero in GKE) resource allocation.