### PR TITLE
state manager: log verified events

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -203,6 +203,7 @@ public class QueuedStateManager implements StateManager {
 
         // Verify counters for in-order event processing
         verifyCounter(event, expectedCounter, currentRunState.get());
+        LOG.info("Received event (verified) {}", event);
 
         final RunState nextRunState;
         try {


### PR DESCRIPTION
It would be useful to be able to scrape logs only for events that did not get discarded due to being stale etc.