### PR TITLE
consistently log the wfi key - ease log analysis

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowId.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowId.java
@@ -44,6 +44,7 @@ public abstract class WorkflowId {
   public abstract String id();
 
   public String toKey() {
+    // Used as ID in storage etc. Do not change.
     return componentId() + "#" + id();
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowInstance.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowInstance.java
@@ -46,6 +46,7 @@ public abstract class WorkflowInstance {
   public abstract String parameter();
 
   public String toKey() {
+    // Used as ID in storage etc. Do not change.
     return workflowId().toKey() + "#" + parameter();
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowInstance.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowInstance.java
@@ -65,4 +65,10 @@ public abstract class WorkflowInstance {
     final WorkflowId workflowId = WorkflowId.parseKey(key.substring(0, lastHashPos));
     return create(workflowId, key.substring(lastHashPos + 1));
   }
+
+  @Override
+  public String toString() {
+    // Ensure that the key gets printed when containing objects are logged
+    return toKey();
+  }
 }

--- a/styx-common/src/main/java/com/spotify/styx/state/RunState.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/RunState.java
@@ -397,8 +397,7 @@ public abstract class RunState {
   }
 
   private IllegalStateException illegalTransition(String event) {
-    final String key = workflowInstance().toKey();
-    return new IllegalStateException(key + " received " + event + " while in " + state());
+    return new IllegalStateException(workflowInstance() + " received " + event + " while in " + state());
   }
 
   public static RunState create(

--- a/styx-common/src/test/java/com/spotify/styx/model/WorkflowInstanceTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/WorkflowInstanceTest.java
@@ -27,9 +27,9 @@ import org.junit.Test;
 
 public class WorkflowInstanceTest {
 
-  public static final WorkflowId WORKFLOW_ID = WorkflowId.create("foo", "bar");
-  public static final String PARAMETER = "baz";
-  public static final WorkflowInstance WORKFLOW_INSTANCE = WorkflowInstance.create(WORKFLOW_ID, PARAMETER);
+  private static final WorkflowId WORKFLOW_ID = WorkflowId.create("foo", "bar");
+  private static final String PARAMETER = "baz";
+  private static final WorkflowInstance WORKFLOW_INSTANCE = WorkflowInstance.create(WORKFLOW_ID, PARAMETER);
 
   @Test
   public void create() {

--- a/styx-common/src/test/java/com/spotify/styx/model/WorkflowInstanceTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/WorkflowInstanceTest.java
@@ -31,6 +31,11 @@ public class WorkflowInstanceTest {
       .create(WorkflowId.create("foo", "bar"), "baz");
 
   @Test
+  public void toKey() {
+    assertThat(WORKFLOW_INSTANCE.toKey(), is("foo#bar#baz"));
+  }
+
+  @Test
   public void verifyToStringPrintsKey() {
     assertThat(WORKFLOW_INSTANCE.toString(), is(WORKFLOW_INSTANCE.toKey()));
   }

--- a/styx-common/src/test/java/com/spotify/styx/model/WorkflowInstanceTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/WorkflowInstanceTest.java
@@ -1,0 +1,37 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.model;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class WorkflowInstanceTest {
+
+  public static final WorkflowInstance WORKFLOW_INSTANCE = WorkflowInstance
+      .create(WorkflowId.create("foo", "bar"), "baz");
+
+  @Test
+  public void verifyToStringPrintsKey() {
+    assertThat(WORKFLOW_INSTANCE.toString(), is(WORKFLOW_INSTANCE.toKey()));
+  }
+}

--- a/styx-common/src/test/java/com/spotify/styx/model/WorkflowInstanceTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/WorkflowInstanceTest.java
@@ -27,16 +27,28 @@ import org.junit.Test;
 
 public class WorkflowInstanceTest {
 
-  public static final WorkflowInstance WORKFLOW_INSTANCE = WorkflowInstance
-      .create(WorkflowId.create("foo", "bar"), "baz");
+  public static final WorkflowId WORKFLOW_ID = WorkflowId.create("foo", "bar");
+  public static final String PARAMETER = "baz";
+  public static final WorkflowInstance WORKFLOW_INSTANCE = WorkflowInstance.create(WORKFLOW_ID, PARAMETER);
 
   @Test
-  public void toKey() {
-    assertThat(WORKFLOW_INSTANCE.toKey(), is("foo#bar#baz"));
+  public void create() {
+    assertThat(WORKFLOW_INSTANCE.workflowId(), is(WORKFLOW_ID));
+    assertThat(WORKFLOW_INSTANCE.parameter(), is(PARAMETER));
   }
 
   @Test
-  public void verifyToStringPrintsKey() {
+  public void toKey() {
+    assertThat(WORKFLOW_INSTANCE.toKey(), is(WORKFLOW_ID.toKey() + "#" + PARAMETER));
+  }
+
+  @Test
+  public void toStringShouldReturnKey() {
     assertThat(WORKFLOW_INSTANCE.toString(), is(WORKFLOW_INSTANCE.toKey()));
+  }
+
+  @Test
+  public void parseKey() {
+    assertThat(WorkflowInstance.parseKey(WORKFLOW_INSTANCE.toKey()), is(WORKFLOW_INSTANCE));
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -292,9 +292,9 @@ public class Scheduler {
     final RunState state = instanceState.runState();
 
     if (state.data().tries() == 0) {
-      LOG.info("Executing {}", workflowInstance.toKey());
+      LOG.info("Executing {}", workflowInstance);
     } else {
-      LOG.info("Executing {}, retry #{}", workflowInstance.toKey(), state.data().tries());
+      LOG.info("Executing {}, retry #{}", workflowInstance, state.data().tries());
     }
     stateManager.receiveIgnoreClosed(Event.dequeue(workflowInstance, resourceIds),
         instanceState.runState().counter());

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/TriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/TriggerManager.java
@@ -133,10 +133,10 @@ class TriggerManager implements Closeable {
               toParameter(workflow.configuration().schedule(), instantSpec.instant()));
 
           if (findCause(e, AlreadyInitializedException.class) != null) {
-            LOG.debug("{} already triggered", workflowInstance.toKey(), e);
+            LOG.debug("{} already triggered", workflowInstance, e);
             // move on to update next natural trigger
           } else {
-            LOG.debug("Failed to trigger {}", workflowInstance.toKey(), e);
+            LOG.debug("Failed to trigger {}", workflowInstance, e);
             return;
           }
         }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -423,9 +423,9 @@ class KubernetesDockerRunner implements DockerRunner {
     final String name = pod.getMetadata().getName();
     if (!debug.get()) {
       client.pods().withName(name).delete();
-      LOG.info("Deleted {} pod: {}, reason: '{}'", workflowInstance.toKey(), name, reason);
+      LOG.info("Deleted {} pod: {}, reason: '{}'", workflowInstance, name, reason);
     } else {
-      LOG.info("Keeping {} pod: {}, reason: '{}'", workflowInstance.toKey(), name, reason);
+      LOG.info("Keeping {} pod: {}, reason: '{}'", workflowInstance, name, reason);
     }
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -172,12 +172,9 @@ public class QueuedStateManager implements StateManager {
       });
     } catch (TransactionException e) {
       if (e.isAlreadyExists()) {
-        throw new AlreadyInitializedException(
-            "Workflow instance is already triggered: " + workflowInstance.toKey());
+        throw new AlreadyInitializedException("Workflow instance is already triggered: " + workflowInstance);
       } else if (e.isConflict()) {
-        LOG.debug(
-            "Transactional conflict, abort triggering Workflow instance: " + workflowInstance
-                .toKey());
+        LOG.debug("Transactional conflict, abort triggering Workflow instance: " + workflowInstance);
         throw new RuntimeException(e);
       } else {
         throw new RuntimeException(e);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -79,12 +79,12 @@ public class DockerRunnerHandler implements OutputHandler {
         }
 
         try {
-          LOG.info("running:{} image:{} args:{} termination_logging:{}", state.workflowInstance().toKey(),
+          LOG.info("running:{} image:{} args:{} termination_logging:{}", state.workflowInstance(),
               runSpec.imageName(), runSpec.args(), runSpec.terminationLogging());
           dockerRunner.start(state.workflowInstance(), runSpec);
         } catch (Throwable e) {
           try {
-            final String msg = "Failed the docker starting procedure for " + state.workflowInstance().toKey();
+            final String msg = "Failed the docker starting procedure for " + state.workflowInstance();
             if (isUserError(e)) {
               LOG.info("{}: {}", msg, e.getMessage());
             } else {
@@ -120,12 +120,10 @@ public class DockerRunnerHandler implements OutputHandler {
     final Optional<ExecutionDescription> executionDescriptionOpt = state.data().executionDescription();
 
     final ExecutionDescription executionDescription = executionDescriptionOpt.orElseThrow(
-        () -> new ResourceNotFoundException("Missing execution description for "
-                                            + state.workflowInstance().toKey()));
+        () -> new ResourceNotFoundException("Missing execution description for " + state.workflowInstance()));
 
     final String executionId = state.data().executionId().orElseThrow(
-        () -> new ResourceNotFoundException("Missing execution id for "
-                                            + state.workflowInstance().toKey()));
+        () -> new ResourceNotFoundException("Missing execution id for " + state.workflowInstance()));
 
     final String dockerImage = executionDescription.dockerImage();
     final List<String> dockerArgs = executionDescription.dockerArgs();

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -82,12 +82,11 @@ public class ExecutionDescriptionHandler implements OutputHandler {
                    workflowInstance);
           stateManager.receiveIgnoreClosed(Event.halt(workflowInstance));
         } catch (MissingRequiredPropertyException e) {
-          LOG.warn("Failed to prepare execution description for "
-                   + state.workflowInstance().toKey(), e);
+          LOG.warn("Failed to prepare execution description for " + state.workflowInstance(), e);
           stateManager.receiveIgnoreClosed(Event.halt(workflowInstance));
         } catch (IOException e) {
           try {
-            LOG.error("Failed to retrieve execution description for " + state.workflowInstance().toKey(), e);
+            LOG.error("Failed to retrieve execution description for " + state.workflowInstance(), e);
             stateManager.receive(Event.runError(state.workflowInstance(), e.getMessage()));
           } catch (IsClosedException isClosedException) {
             LOG.warn("Failed to send 'runError' event", isClosedException);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TransitionLogger.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TransitionLogger.java
@@ -41,10 +41,8 @@ public class TransitionLogger implements OutputHandler {
 
   @Override
   public void transitionInto(RunState state) {
-    final String instanceKey = state.workflowInstance().toKey();
-    LOG.info(
-        "{}{} transition -> {} {}",
-        this.prefix, instanceKey, state.state().name().toLowerCase(), stateInfo(state));
+    final String name = state.state().name().toLowerCase();
+    LOG.info("{}{} transition -> {} {}", prefix, state.workflowInstance(), name, stateInfo(state));
   }
 
   @VisibleForTesting


### PR DESCRIPTION
It would be useful to get all log messages for a WFI by searching for a single string, the wfi key, instead of having to search both for the key and the `WorkflowInstance{workflowId=...}` string. And the key is a lot easier to handle.