### PR TITLE
cli: print client error cause & add --debug flag

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -29,6 +29,7 @@ import static net.sourceforge.argparse4j.impl.Arguments.fileType;
 
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.spotify.apollo.Client;
 import com.spotify.apollo.core.Service;
@@ -100,6 +101,7 @@ public final class CliMain {
   private final Service cliService;
   private final CliOutput cliOutput;
   private final CliContext cliContext;
+  private final boolean debug;
   private StyxClient styxClient;
 
   private CliMain(
@@ -108,13 +110,15 @@ public final class CliMain {
       String apiHost,
       Service cliService,
       CliOutput cliOutput,
-      CliContext cliContext) {
+      CliContext cliContext,
+      boolean debug) {
     this.parser = Objects.requireNonNull(parser);
     this.namespace = Objects.requireNonNull(namespace);
     this.apiHost = Objects.requireNonNull(apiHost);
     this.cliService = Objects.requireNonNull(cliService);
     this.cliOutput = Objects.requireNonNull(cliOutput);
     this.cliContext = Objects.requireNonNull(cliContext);
+    this.debug = debug;
   }
 
   public static void main(String... args) {
@@ -169,7 +173,9 @@ public final class CliMain {
       cliOutput = cliContext.output(Output.PRETTY);
     }
 
-    new CliMain(parser, namespace, apiHost, cliService, cliOutput, cliContext).run();
+    final boolean debug = namespace.getBoolean(parser.debug.getDest());
+
+    new CliMain(parser, namespace, apiHost, cliService, cliOutput, cliContext, debug).run();
   }
 
   private void run() {
@@ -284,6 +290,9 @@ public final class CliMain {
       throw CliExitException.of(ExitStatus.ArgumentError);
     } catch (ExecutionException e) {
       final Throwable cause = e.getCause();
+      if (debug) {
+        cliOutput.printError(getStackTraceAsString(cause));
+      }
       if (cause instanceof ApiErrorException) {
         final ApiErrorException apiError = (ApiErrorException) cause;
         if (apiError.getCode() == UNAUTHORIZED.code()) {
@@ -305,7 +314,9 @@ public final class CliMain {
           throw CliExitException.of(ExitStatus.ApiError);
         }
       } else if (cause instanceof ClientErrorException) {
-        cliOutput.printError("Client error: " + cause.getMessage());
+        final Throwable rootCause = Throwables.getRootCause(cause.getCause());
+        cliOutput.printError("Client error: " + cause.getMessage() + ": "
+            + rootCause.getClass().getSimpleName() + ": " + rootCause.getMessage());
         throw CliExitException.of(ExitStatus.ClientError);
       } else {
         cliOutput.printError(getStackTraceAsString(cause));
@@ -748,6 +759,11 @@ public final class CliMain {
 
     final Argument plain = parser.addArgument("-p", "--plain")
         .help("plain output")
+        .setDefault(false)
+        .action(Arguments.storeTrue());
+
+    final Argument debug = parser.addArgument("--debug")
+        .help("debug output")
         .setDefault(false)
         .action(Arguments.storeTrue());
 

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -314,7 +314,7 @@ public final class CliMain {
           throw CliExitException.of(ExitStatus.ApiError);
         }
       } else if (cause instanceof ClientErrorException) {
-        final Throwable rootCause = Throwables.getRootCause(cause.getCause());
+        final Throwable rootCause = Throwables.getRootCause(cause);
         cliOutput.printError("Client error: " + cause.getMessage() + ": "
             + rootCause.getClass().getSimpleName() + ": " + rootCause.getMessage());
         throw CliExitException.of(ExitStatus.ClientError);

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.apollo.Client;
@@ -52,7 +51,6 @@ import com.spotify.styx.model.WorkflowState;
 import com.spotify.styx.model.data.EventInfo;
 import com.spotify.styx.util.EventUtil;
 import java.io.IOException;
-import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
@@ -440,12 +438,7 @@ class StyxApolloClient implements StyxClient {
     }
     return client.send(decorateRequest(request, authToken)).handle((response, e) -> {
       if (e != null) {
-        final Throwable rootCause = Throwables.getRootCause(e);
-        if (rootCause instanceof SocketTimeoutException) {
-          throw new ClientErrorException("Connection failed: " + rootCause.getMessage() + ": " + apiHost, e);
-        } else {
-          throw new ClientErrorException("Request failed: " + request, e);
-        }
+        throw new ClientErrorException("Request failed: " + request.method() + " " + request.uri(), e);
       } else {
         switch (response.status().family()) {
           case SUCCESSFUL:


### PR DESCRIPTION
Make the cli print the message of any encountered `ClientErrorException` and its root cause.

On unknown host, e.g. due to `STYX_CLI_HOST` typo:
```
Client error: Request failed: GET http://syx.spotify.net/api/v3/status/activeStates: UnknownHostException: syx.spotify.net: nodename nor servname provided, or not known
```

On connection failure due to e.g. network problem:
```
Client error: Request failed: GET http://styx.foo.net:4711/api/v3/status/activeStates: ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:4711
```

On http protocol error, e.g. talking to something unexpected:
```
Client error: Request failed: GET http://styx.foo.net:4711/api/v3/status/activeStates: ProtocolException: Unexpected status line: deadbeef
```

The `--debug` flag causes the full stack traces to be printed for any
error caught by the cli. E.g.:

```
com.spotify.styx.client.ClientErrorException: Request failed: GET http://styx.foo.net:4711/api/v3/status/activeStates: ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:4711
	at com.spotify.styx.client.StyxApolloClient.lambda$executeRequest$12(StyxApolloClient.java:452)
	at java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:822)
	at java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:797)
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474)
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977)
	at com.spotify.apollo.http.client.TransformingCallback.onFailure(TransformingCallback.java:58)
	at com.squareup.okhttp.Call$AsyncCall.execute(Call.java:185)
	at com.squareup.okhttp.internal.NamedRunnable.run(NamedRunnable.java:33)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Request Request{method=GET, url=http://localhost:4711/api/v3/status/activeStates, tag=null} failed
	at com.spotify.apollo.http.client.TransformingCallback.onFailure(TransformingCallback.java:57)
	... 5 more
Caused by: java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:4711
	at com.squareup.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:143)
	at com.squareup.okhttp.internal.io.RealConnection.connect(RealConnection.java:112)
	at com.squareup.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:184)
	at com.squareup.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
	at com.squareup.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
	at com.squareup.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
	at com.squareup.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
	at com.squareup.okhttp.Call.getResponse(Call.java:286)
	at com.squareup.okhttp.Call$ApplicationInterceptorChain.proceed(Call.java:243)
	at com.squareup.okhttp.Call.getResponseWithInterceptorChain(Call.java:205)
	at com.squareup.okhttp.Call.access$100(Call.java:35)
	at com.squareup.okhttp.Call$AsyncCall.execute(Call.java:171)
	... 4 more
```

An alternative to #502