### PR TITLE
do not delete pods if the WFI is still RUNNING

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -375,8 +375,9 @@ class KubernetesDockerRunner implements DockerRunner {
       case ERROR:
       case DONE:
         return false;
+      default:
+        return true;
     }
-    return true;
   }
 
   @VisibleForTesting

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -348,7 +348,7 @@ class KubernetesDockerRunner implements DockerRunner {
   }
 
   @VisibleForTesting
-  void cleanupWithRunState(WorkflowInstance workflowInstance, Pod pod) {
+  void cleanupWithRunState(WorkflowInstance workflowInstance, Pod pod, RunState runState) {
     // Precondition: The run states were fetched after the pods
     final Optional<ContainerStatus> containerStatus = getMainContainerStatus(pod);
     if (!containerStatus.isPresent()) {
@@ -356,11 +356,27 @@ class KubernetesDockerRunner implements DockerRunner {
       // Note: It is natural for pods to not have any container statuses for a while after creation.
       return;
     }
+    if (wantsPod(runState)) {
+      // Do not delete the pod if the workflow instance still wants it, e.g. it is still RUNNING.
+      return;
+    }
     if (isTerminated(containerStatus.get())) {
       deletePodIfNonDeletePeriodExpired(workflowInstance, pod);
     } else if (hasPullImageError(containerStatus.get())) {
       deletePod(workflowInstance, pod, "Pull image error");
     }
+  }
+
+  private boolean wantsPod(RunState runState) {
+    switch (runState.state()) {
+      // Be conservative and only let the pod go when we really know it is not needed anymore.
+      case TERMINATED:
+      case FAILED:
+      case ERROR:
+      case DONE:
+        return false;
+    }
+    return true;
   }
 
   @VisibleForTesting
@@ -538,7 +554,7 @@ class KubernetesDockerRunner implements DockerRunner {
       final RunState runState = activeStates.get(workflowInstance.get());
       if (runState != null && isPodRunState(pod, runState)) {
         emitPodEvents(Watcher.Action.MODIFIED, pod, runState);
-        cleanupWithRunState(workflowInstance.get(), pod);
+        cleanupWithRunState(workflowInstance.get(), pod, runState);
       } else {
         // The pod is stale as we fetched the active states _after_ listing all pods.
         cleanupWithoutRunState(workflowInstance.get(), pod);


### PR DESCRIPTION
We want to keep the pod around until the WFI has transitioned out of
RUNNING so we can get the exit code and not falsely label executions as
having failed just because the pod "expired" before the RunState managed
to transition (e.g. due to datastore contention and slowness).