### PR TITLE
handle NodeLost

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
@@ -239,6 +239,10 @@ final class KubernetesPodEventTranslator {
     final PodStatus status = pod.getStatus();
     final String phase = status.getPhase();
 
+    if ("NodeLost".equals(pod.getStatus().getReason())) {
+      return Optional.of(Event.runError(workflowInstance, "Lost node running pod"));
+    }
+
     switch (phase) {
       case "Pending":
         // check if one or more docker contains failed to pull their image, a possible silent error

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -33,6 +33,7 @@ import com.spotify.styx.model.Event;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.RunState;
+import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.testdata.TestData;
 import io.fabric8.kubernetes.api.model.ContainerState;
 import io.fabric8.kubernetes.api.model.ContainerStateRunning;
@@ -129,6 +130,15 @@ public class KubernetesPodEventTranslatorTest {
     assertGeneratesEventsAndTransitions(
         RunState.State.SUBMITTED, pod,
         Event.runError(WFI, "Unexpected null terminated status"));
+  }
+  @Test
+  public void runErrorOnNodeLost() throws Exception {
+    setRunning(pod, true);
+    pod.getStatus().setReason("NodeLost");
+
+    assertGeneratesEventsAndTransitions(
+        State.RUNNING, pod,
+        Event.runError(WFI, "Lost node running pod"));
   }
 
   @Test


### PR DESCRIPTION
Emit runError on NodeLost instead of just waiting for the pod to disappear and then getting a "No pod associated with this instance" error.

Kubernetes sets this reason on pods that are being deleted because the node is unresponsive.

https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/util/node/controller_utils.go?utf8=%E2%9C%93#L55
https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/util/node/controller_utils.go?utf8=%E2%9C%93#L117