### PR TITLE
Always capture exception causes

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -296,7 +296,7 @@ public class DatastoreStorage implements Closeable {
       try {
         workflow = OBJECT_MAPPER.readValue(entity.getString(PROPERTY_WORKFLOW_JSON), Workflow.class);
       } catch (IOException e) {
-        LOG.warn("Failed to read workflow {}.", entity.getKey());
+        LOG.warn("Failed to read workflow {}.", entity.getKey(), e);
         continue;
       }
 
@@ -333,7 +333,7 @@ public class DatastoreStorage implements Closeable {
       try {
         workflow = OBJECT_MAPPER.readValue(entity.getString(PROPERTY_WORKFLOW_JSON), Workflow.class);
       } catch (IOException e) {
-        LOG.warn("Failed to read workflow {}.", entity.getKey());
+        LOG.warn("Failed to read workflow {}.", entity.getKey(), e);
         continue;
       }
       map.put(workflow.id(), workflow);
@@ -365,7 +365,7 @@ public class DatastoreStorage implements Closeable {
       try {
         workflows.add(OBJECT_MAPPER.readValue(entity.getString(PROPERTY_WORKFLOW_JSON), Workflow.class));
       } catch (IOException e) {
-        LOG.warn("Failed to read workflow {}.", entity.getKey());
+        LOG.warn("Failed to read workflow {}.", entity.getKey(), e);
       }
     });
     return workflows;
@@ -388,7 +388,7 @@ public class DatastoreStorage implements Closeable {
         try {
           workflow = OBJECT_MAPPER.readValue(entity.getString(PROPERTY_WORKFLOW_JSON), Workflow.class);
         } catch (IOException e) {
-          LOG.warn("Failed to read workflow {}.", entity.getKey());
+          LOG.warn("Failed to read workflow {}.", entity.getKey(), e);
           continue;
         }
         workflows.add(workflow);
@@ -711,7 +711,7 @@ public class DatastoreStorage implements Closeable {
   static Key componentKey(KeyFactory keyFactory, String componentId) {
     return keyFactory.setKind(KIND_COMPONENT).newKey(componentId);
   }
-  
+
   static Key backfillKey(KeyFactory keyFactory, String backfillId) {
     return keyFactory.setKind(KIND_BACKFILL).newKey(backfillId);
   }

--- a/styx-common/src/main/java/com/spotify/styx/util/CachedSupplier.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/CachedSupplier.java
@@ -70,7 +70,7 @@ public class CachedSupplier<T> implements Supplier<T> {
         if (value == null) {
           throw Throwables.propagate(e);
         } else {
-          LOG.warn("Failed to update from delegate supplier, using old value");
+          LOG.warn("Failed to update from delegate supplier, using old value", e);
         }
       }
     }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
@@ -101,7 +101,7 @@ public class ServiceAccountKeyManager {
     } catch (GoogleJsonResponseException e) {
       // TODO: handle 403 correctly once google fixes their API
       if (e.getStatusCode() == 403 || e.getStatusCode() == 404) {
-        LOG.debug("Couldn't find key to delete {}", keyName);
+        LOG.debug("Couldn't find key to delete {}", keyName, e);
         return;
       }
       LOG.warn("[AUDIT] Failed to delete key {}", keyName, e);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -556,7 +556,7 @@ public class StyxScheduler implements AppInit {
       }
     } catch (Exception e) {
       LOG.warn("Failed to fetch the submission rate config from storage, "
-          + "skipping RateLimiter update");
+          + "skipping RateLimiter update", e);
     }
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/TriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/TriggerManager.java
@@ -90,7 +90,7 @@ class TriggerManager implements Closeable {
         return;
       }
     } catch (IOException e) {
-      LOG.warn("Couldn't fetch global enabled status, skipping this run.");
+      LOG.warn("Couldn't fetch global enabled status, skipping this run", e);
       return;
     }
 
@@ -100,7 +100,7 @@ class TriggerManager implements Closeable {
       canBeTriggeredWorkflows = storage.workflowsWithNextNaturalTrigger();
       enabledWorkflows = storage.enabled();
     } catch (IOException e) {
-      LOG.warn("Couldn't fetch workflows to trigger, skipping this run.");
+      LOG.warn("Couldn't fetch workflows to trigger, skipping this run", e);
       return;
     }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -428,7 +428,7 @@ class KubernetesDockerRunner implements DockerRunner {
     try {
       finishedAt = Instant.parse(t.getFinishedAt());
     } catch (DateTimeParseException e) {
-      LOG.warn("Failed to parse container state terminated finishedAt: '{}'", t.getFinishedAt());
+      LOG.warn("Failed to parse container state terminated finishedAt: '{}'", t.getFinishedAt(), e);
       return true;
     }
     final Instant deadline = time.get().minus(Duration.ofSeconds(podDeletionDelaySeconds));

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
@@ -253,9 +253,9 @@ class KubernetesGCPServiceAccountSecretManager {
         keyManager.deleteKey(annotations.get(STYX_WORKFLOW_SA_JSON_KEY_NAME_ANNOTATION));
         keyManager.deleteKey(annotations.get(STYX_WORKFLOW_SA_P12_KEY_NAME_ANNOTATION));
         deleteSecret(secret);
-      } catch (KubernetesClientException | IOException ignored) {
+      } catch (KubernetesClientException | IOException e) {
         LOG.warn("Failed to cleanup secret or keys for service account {}",
-            annotations.get(STYX_WORKFLOW_SA_ID_ANNOTATION));
+            annotations.get(STYX_WORKFLOW_SA_ID_ANNOTATION), e);
       }
     }
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -126,7 +126,7 @@ public class QueuedStateManager implements StateManager {
         try {
           storage.deleteActiveState(workflowInstance);
         } catch (IOException e) {
-          LOG.warn("Failed to remove dangling NEW state for: {}", workflowInstance);
+          LOG.warn("Failed to remove dangling NEW state for: {}", workflowInstance, e);
         }
         throw new RuntimeException(isClosedException);
       }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -78,8 +78,7 @@ public class ExecutionDescriptionHandler implements OutputHandler {
             LOG.warn("Could not send 'submit' event", isClosedException);
           }
         } catch (ResourceNotFoundException e) {
-          LOG.info("Workflow {} does not exist, halting {}", workflowInstance.workflowId(),
-                   workflowInstance);
+          LOG.info("Halting {}: {}", workflowInstance, e.getMessage());
           stateManager.receiveIgnoreClosed(Event.halt(workflowInstance));
         } catch (MissingRequiredPropertyException e) {
           LOG.warn("Failed to prepare execution description for " + state.workflowInstance(), e);


### PR DESCRIPTION
Went looking for any occurrences where an exception cause is swallowed (caught and then neither logged nor rethrown), a bit like this:

  $ git grep -A 5 "} catch" | grep -v ", e)" | grep -C 2 -iP "log\."