### PR TITLE
log workflow read exception

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -663,7 +663,7 @@ public class DatastoreStorage implements Closeable {
       return OBJECT_MAPPER
           .readValue(entity.getString(PROPERTY_WORKFLOW_JSON), Workflow.class);
     } catch (IOException e) {
-      LOG.error("Failed to read workflow for {}, {}", workflowId.componentId(), workflowId.id());
+      LOG.error("Failed to read workflow for {}, {}", workflowId.componentId(), workflowId.id(), e);
       throw e;
     }
   }


### PR DESCRIPTION
Let's log this exception as well. There's nothing else logging it upstream when hit by a user request.

@ulzha ptal