### PR TITLE
store workflow in transaction

### DIFF
--- a/styx-api-service/src/test/java/com/spotify/styx/api/workflow/WorkflowInitializerTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/workflow/WorkflowInitializerTest.java
@@ -20,18 +20,23 @@
 
 package com.spotify.styx.api.workflow;
 
+import static com.spotify.styx.util.TimeUtil.lastInstant;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.storage.StorageTransaction;
 import com.spotify.styx.storage.TransactionFunction;
 import com.spotify.styx.testdata.TestData;
+import com.spotify.styx.util.TriggerInstantSpec;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Optional;
@@ -44,6 +49,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class WorkflowInitializerTest {
 
+  public static final Instant NOW = Instant.parse("2015-12-31T23:59:10.000Z");
   private final Workflow HOURLY_WORKFLOW = Workflow.create("styx",
       TestData.HOURLY_WORKFLOW_CONFIGURATION);
   private final Workflow HOURLY_WORKFLOW_WITH_INVALID_OFFSET =
@@ -59,10 +65,33 @@ public class WorkflowInitializerTest {
 
   @Before
   public void setUp() throws IOException {
-    workflowInitializer = new WorkflowInitializer(storage,
-        () -> Instant.parse("2015-12-31T23:59:10.000Z"));
+    workflowInitializer = new WorkflowInitializer(storage, () -> NOW);
     when(storage.runInTransaction(any())).then(a ->
         a.getArgumentAt(0, TransactionFunction.class).apply(transaction));
+  }
+
+  @Test
+  public void shouldStoreNewWorkflowAndUpdateNextNaturalTrigger() throws IOException, WorkflowInitializationException {
+    when(transaction.workflow(HOURLY_WORKFLOW.id())).thenReturn(Optional.empty());
+    when(transaction.store(HOURLY_WORKFLOW)).thenReturn(HOURLY_WORKFLOW.id());
+    workflowInitializer.store(HOURLY_WORKFLOW);
+    verify(transaction).store(HOURLY_WORKFLOW);
+
+    final Instant nextTrigger = lastInstant(NOW, Schedule.HOURS);
+    final Instant nextWithOffset = HOURLY_WORKFLOW.configuration().addOffset(nextTrigger);
+    TriggerInstantSpec expectedTriggerInstantSpec = TriggerInstantSpec.create(nextTrigger, nextWithOffset);
+
+    verify(transaction).updateNextNaturalTrigger(HOURLY_WORKFLOW.id(), expectedTriggerInstantSpec);
+  }
+
+  @Test
+  public void shouldUpdateExistingWorkflowAndNotUpdateNextNaturalTrigger()
+      throws IOException, WorkflowInitializationException {
+    when(transaction.workflow(HOURLY_WORKFLOW.id())).thenReturn(Optional.of(HOURLY_WORKFLOW));
+    when(transaction.store(HOURLY_WORKFLOW)).thenReturn(HOURLY_WORKFLOW.id());
+    workflowInitializer.store(HOURLY_WORKFLOW);
+    verify(transaction).store(HOURLY_WORKFLOW);
+    verify(transaction, never()).updateNextNaturalTrigger(any(), any());
   }
 
   @Test


### PR DESCRIPTION
Avoid potential corruption, inconsistencies or partial updates due to races, failures, restarts, etc.