### PR TITLE
revert container naming: use "styx-run"

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -416,7 +416,8 @@ class KubernetesDockerRunner implements DockerRunner {
             .findAny());
   }
 
-  private static boolean isMainContainer(String name, Pod pod) {
+  @VisibleForTesting
+  static boolean isMainContainer(String name, Pod pod) {
     return name.equals(MAIN_CONTAINER_NAME)
         // TODO: Containers used to be named same as the pod (execution id), remove this after deploying
         || name.equals(pod.getMetadata().getName());

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
@@ -25,6 +25,7 @@ import static com.spotify.styx.docker.KubernetesDockerRunner.COMPONENT_ID;
 import static com.spotify.styx.docker.KubernetesDockerRunner.DOCKER_IMAGE;
 import static com.spotify.styx.docker.KubernetesDockerRunner.DOCKER_TERMINATION_LOGGING_ANNOTATION;
 import static com.spotify.styx.docker.KubernetesDockerRunner.EXECUTION_ID;
+import static com.spotify.styx.docker.KubernetesDockerRunner.MAIN_CONTAINER_NAME;
 import static com.spotify.styx.docker.KubernetesDockerRunner.PARAMETER;
 import static com.spotify.styx.docker.KubernetesDockerRunner.SERVICE_ACCOUNT;
 import static com.spotify.styx.docker.KubernetesDockerRunner.STYX_WORKFLOW_INSTANCE_ANNOTATION;
@@ -71,7 +72,7 @@ public class KubernetesDockerRunnerPodResourceTest {
 
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(containers.size(), is(2));
-    assertThat(containers.get(0).getName(), is("eid"));
+    assertThat(containers.get(0).getName(), is(MAIN_CONTAINER_NAME));
 
     Container container = containers.get(0);
     assertThat(container.getImage(), is("busybox:latest"));
@@ -85,7 +86,7 @@ public class KubernetesDockerRunnerPodResourceTest {
 
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(containers.size(), is(2));
-    assertThat(containers.get(0).getName(), is("eid"));
+    assertThat(containers.get(0).getName(), is(MAIN_CONTAINER_NAME));
 
     Container container = containers.get(0);
     assertThat(container.getImage(), is("busybox:v7"));
@@ -99,7 +100,7 @@ public class KubernetesDockerRunnerPodResourceTest {
 
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(containers.size(), is(2));
-    assertThat(containers.get(0).getName(), is("eid"));
+    assertThat(containers.get(0).getName(), is(MAIN_CONTAINER_NAME));
 
     Container container = containers.get(0);
     assertThat(container.getArgs(), contains("echo", "foo", "bar"));
@@ -173,7 +174,7 @@ public class KubernetesDockerRunnerPodResourceTest {
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(volumes.size(), is(0));
     assertThat(containers.size(), is(2));
-    assertThat(containers.get(0).getName(), is("eid"));
+    assertThat(containers.get(0).getName(), is(MAIN_CONTAINER_NAME));
 
     Container container = containers.get(0);
     List<VolumeMount> volumeMounts = container.getVolumeMounts();
@@ -199,7 +200,7 @@ public class KubernetesDockerRunnerPodResourceTest {
     List<Container> containers = pod.getSpec().getContainers();
     assertThat(volumes.size(), is(1));
     assertThat(containers.size(), is(2));
-    assertThat(containers.get(0).getName(), is("eid"));
+    assertThat(containers.get(0).getName(), is(MAIN_CONTAINER_NAME));
 
     Volume volume = volumes.get(0);
     assertThat(volume.getName(), is("my-secret"));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.docker;
 
 import static com.spotify.styx.docker.KubernetesDockerRunner.KEEPALIVE_CONTAINER_NAME;
+import static com.spotify.styx.docker.KubernetesDockerRunner.MAIN_CONTAINER_NAME;
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.podStatusNoContainer;
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.setRunning;
 import static com.spotify.styx.docker.KubernetesPodEventTranslatorTest.setTerminated;
@@ -236,14 +237,14 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
-  public void shouldCreateMainContainerNamedByExecutionIdAndKeepaliveContainer() throws IOException {
+  public void shouldCreateMainContainerAndKeepaliveContainer() throws IOException {
     kdr.start(WORKFLOW_INSTANCE, RUN_SPEC);
     verify(pods).create(podCaptor.capture());
     Pod submittedPod = podCaptor.getValue();
     assertThat(submittedPod.getSpec().getContainers().size(), is(2));
     final Container mainContainer = submittedPod.getSpec().getContainers().get(0);
     final Container keepaliveContainer = submittedPod.getSpec().getContainers().get(1);
-    assertThat(mainContainer.getName(), is(RUN_SPEC.executionId()));
+    assertThat(mainContainer.getName(), is(MAIN_CONTAINER_NAME));
     assertThat(keepaliveContainer.getName(), is(KEEPALIVE_CONTAINER_NAME));
     assertThat(keepaliveContainer.getVolumeMounts(), is(empty()));
   }
@@ -550,7 +551,6 @@ public class KubernetesDockerRunnerTest {
                is(KubernetesDockerRunner.STYX_WORKFLOW_SA_SECRET_NAME));
     assertThat(pod.getSpec().getContainers().size(), is(2));
     final Container mainContainer = pod.getSpec().getContainers().get(0);
-    assertThat(mainContainer.getName(), is(RUN_SPEC_WITH_SA.executionId()));
     assertThat(mainContainer.getEnv().stream()
             .anyMatch(e -> e.getName().equals(KubernetesDockerRunner.STYX_WORKFLOW_SA_ENV_VARIABLE)),
         is(true));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -837,6 +837,15 @@ public class KubernetesDockerRunnerTest {
         0);
   }
 
+  @Test
+  public void shouldRecognizeMainContainer() {
+    assertThat(KubernetesDockerRunner.isMainContainer(MAIN_CONTAINER_NAME, createdPod), is(true));
+    assertThat(KubernetesDockerRunner.isMainContainer(KEEPALIVE_CONTAINER_NAME, createdPod), is(false));
+    assertThat(KubernetesDockerRunner.isMainContainer("foobar", createdPod), is(false));
+    // TODO: delete after deploying container name change
+    assertThat(KubernetesDockerRunner.isMainContainer(POD_NAME, createdPod), is(true));
+  }
+
   private void verifyPodNeverDeleted(PodResource<Pod, DoneablePod> pod) {
     verify(k8sClient.pods(), never()).delete(any(Pod.class));
     verify(k8sClient.pods(), never()).delete(any(Pod[].class));


### PR DESCRIPTION
Unique container naming causes logs to end up in separate stackdriver logs and breaks log exporting.