### PR TITLE
tracing of requests & internals

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -79,6 +79,7 @@ public class StyxApi implements AppInit {
 
   public static final Duration DEFAULT_RETRY_BASE_DELAY_BT = Duration.ofSeconds(1);
 
+  private final String serviceName;
   private final StorageFactory storageFactory;
   private final WorkflowConsumerFactory workflowConsumerFactory;
   private final StatsFactory statsFactory;
@@ -89,10 +90,16 @@ public class StyxApi implements AppInit {
 
   public static class Builder {
 
+    private String serviceName = "styx-api";
     private StorageFactory storageFactory = StyxApi::storage;
     private WorkflowConsumerFactory workflowConsumerFactory = (env, stats) -> (oldWorkflow, newWorkflow) -> { };
     private StatsFactory statsFactory = StyxApi::stats;
     private Time time = Instant::now;
+
+    public Builder setServiceName(String serviceName) {
+      this.serviceName = serviceName;
+      return this;
+    }
 
     public Builder setStorageFactory(StorageFactory storageFactory) {
       this.storageFactory = storageFactory;
@@ -128,6 +135,7 @@ public class StyxApi implements AppInit {
   }
 
   private StyxApi(Builder builder) {
+    this.serviceName = requireNonNull(builder.serviceName);
     this.storageFactory = requireNonNull(builder.storageFactory);
     this.workflowConsumerFactory = requireNonNull(builder.workflowConsumerFactory);
     this.statsFactory = requireNonNull(builder.statsFactory);
@@ -180,7 +188,7 @@ public class StyxApi implements AppInit {
 
     environment.routingEngine()
         .registerAutoRoute(Route.sync("GET", "/ping", rc -> "pong"))
-        .registerRoutes(Api.withCommonMiddleware(routes, clientBlacklistSupplier));
+        .registerRoutes(Api.withCommonMiddleware(routes, clientBlacklistSupplier, serviceName));
   }
 
   private static AggregateStorage storage(Environment environment) {

--- a/styx-common/pom.xml
+++ b/styx-common/pom.xml
@@ -95,6 +95,10 @@
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.opencensus</groupId>
+      <artifactId>opencensus-api</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.spotify</groupId>
@@ -130,6 +134,11 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path-assert</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opencensus</groupId>
+      <artifactId>opencensus-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -425,7 +425,7 @@ public class DatastoreStorage implements Closeable {
 
     // Strongly consistently read values for the above keys
     return Lists.partition(keys, MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH_READ).stream()
-        .map(batch -> CompletableFuture.supplyAsync(() -> this.readRunStateBatch(batch), forkJoinPool))
+        .map(batch -> CompletableFuture.supplyAsync(() -> this.readRunStateBatch(batch), executor))
         .collect(toList()).stream() // collect here to execute batch reads in parallel
         .flatMap(task -> task.join().stream())
         .collect(toMap(RunState::workflowInstance, Function.identity()));

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -22,7 +22,6 @@ package com.spotify.styx.storage;
 
 import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
 import static com.spotify.styx.storage.Storage.GLOBAL_RESOURCE_ID;
-import static com.spotify.styx.util.MDCUtil.withMDC;
 import static com.spotify.styx.util.ShardedCounter.KIND_COUNTER_LIMIT;
 import static com.spotify.styx.util.ShardedCounter.KIND_COUNTER_SHARD;
 import static com.spotify.styx.util.ShardedCounter.NUM_SHARDS;
@@ -75,11 +74,13 @@ import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.util.FnWithException;
+import com.spotify.styx.util.MDCUtil;
 import com.spotify.styx.util.ResourceNotFoundException;
 import com.spotify.styx.util.StreamUtil;
 import com.spotify.styx.util.TimeUtil;
 import com.spotify.styx.util.TriggerInstantSpec;
 import com.spotify.styx.util.TriggerUtil;
+import io.grpc.Context;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -95,6 +96,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -183,6 +186,7 @@ public class DatastoreStorage implements Closeable {
   private final Duration retryBaseDelay;
   private final Function<Transaction, DatastoreStorageTransaction> storageTransactionFactory;
   private final ForkJoinPool forkJoinPool;
+  private final Executor executor;
 
   DatastoreStorage(Datastore datastore, Duration retryBaseDelay) {
     this(datastore, retryBaseDelay, DatastoreStorageTransaction::new);
@@ -195,6 +199,7 @@ public class DatastoreStorage implements Closeable {
     this.retryBaseDelay = Objects.requireNonNull(retryBaseDelay);
     this.storageTransactionFactory = Objects.requireNonNull(storageTransactionFactory);
     this.forkJoinPool = new ForkJoinPool(REQUEST_CONCURRENCY);
+    this.executor = MDCUtil.withMDC(Context.currentContextExecutor(forkJoinPool));
   }
 
   @Override
@@ -349,7 +354,7 @@ public class DatastoreStorage implements Closeable {
     final Iterable<List<WorkflowId>> batches = Iterables.partition(workflowIds,
         MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH_READ);
     return StreamSupport.stream(batches.spliterator(), false)
-        .map(batch -> forkJoinPool.submit(withMDC(() -> this.getBatchOfWorkflows(batch))))
+        .map(batch -> CompletableFuture.supplyAsync(() -> this.getBatchOfWorkflows(batch), executor))
         // `collect and stream` is crucial to make tasks running in parallel, otherwise they will
         // be processed sequentially. Without `collect`, it will try to submit and wait for each task
         // while iterating through the stream. This is somewhat subtle, so think twice.
@@ -407,11 +412,11 @@ public class DatastoreStorage implements Closeable {
   Map<WorkflowInstance, RunState> readActiveStates() throws IOException {
     // Strongly read active state keys from index shards
     final List<Key> keys = activeWorkflowInstanceIndexShardKeys(datastore.newKeyFactory()).stream()
-        .map(key -> forkJoinPool.submit(withMDC(() ->
+        .map(key -> CompletableFuture.supplyAsync(() ->
             datastore.run(Query.newEntityQueryBuilder()
                 .setFilter(PropertyFilter.hasAncestor(key))
                 .setKind(KIND_ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARD_ENTRY)
-                .build()))))
+                .build()), executor))
         .collect(toList()).stream() // collect here to execute batch reads in parallel
         .flatMap(task -> StreamUtil.stream(task.join()))
         .map(entity -> entity.getKey().getName())
@@ -420,7 +425,7 @@ public class DatastoreStorage implements Closeable {
 
     // Strongly consistently read values for the above keys
     return Lists.partition(keys, MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH_READ).stream()
-        .map(batch -> forkJoinPool.submit(withMDC(() -> this.readRunStateBatch(batch))))
+        .map(batch -> CompletableFuture.supplyAsync(() -> this.readRunStateBatch(batch)))
         .collect(toList()).stream() // collect here to execute batch reads in parallel
         .flatMap(task -> task.join().stream())
         .collect(toMap(RunState::workflowInstance, Function.identity()));
@@ -429,13 +434,18 @@ public class DatastoreStorage implements Closeable {
   /**
    * Strongly consistently read a batch of {@link RunState}s.
    */
-  private List<RunState> readRunStateBatch(List<Key> keys) throws IOException {
+  private List<RunState> readRunStateBatch(List<Key> keys) {
     assert keys.size() <= MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH_READ;
     final List<RunState> runStates = new ArrayList<>();
     final Iterator<Entity> entities = datastore.get(keys);
     while (entities.hasNext()) {
       final Entity entity = entities.next();
-      final RunState runState = entityToRunState(entity, parseWorkflowInstance(entity));
+      final RunState runState;
+      try {
+        runState = entityToRunState(entity, parseWorkflowInstance(entity));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
       runStates.add(runState);
     }
     return runStates;

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -425,7 +425,7 @@ public class DatastoreStorage implements Closeable {
 
     // Strongly consistently read values for the above keys
     return Lists.partition(keys, MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH_READ).stream()
-        .map(batch -> CompletableFuture.supplyAsync(() -> this.readRunStateBatch(batch)))
+        .map(batch -> CompletableFuture.supplyAsync(() -> this.readRunStateBatch(batch), forkJoinPool))
         .collect(toList()).stream() // collect here to execute batch reads in parallel
         .flatMap(task -> task.join().stream())
         .collect(toMap(RunState::workflowInstance, Function.identity()));

--- a/styx-common/src/test/java/com/spotify/styx/api/MiddlewaresTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/api/MiddlewaresTest.java
@@ -701,6 +701,7 @@ public class MiddlewaresTest {
     }
   }
 
+  // Span has final methods and cannot be spied/mocked
   private static class MockSpan extends Span {
 
     boolean ended;
@@ -718,14 +719,17 @@ public class MiddlewaresTest {
 
     @Override
     public void addAnnotation(String description, Map<String, AttributeValue> attributes) {
+      // nop
     }
 
     @Override
     public void addAnnotation(Annotation annotation) {
+      // nop
     }
 
     @Override
     public void addLink(Link link) {
+      // nop
     }
 
     @Override

--- a/styx-common/src/test/java/com/spotify/styx/api/MiddlewaresTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/api/MiddlewaresTest.java
@@ -26,11 +26,13 @@ import static com.spotify.apollo.test.unit.StatusTypeMatchers.belongsToFamily;
 import static com.spotify.apollo.test.unit.StatusTypeMatchers.withCode;
 import static com.spotify.apollo.test.unit.StatusTypeMatchers.withReasonPhrase;
 import static com.spotify.styx.util.StringIsValidUuid.isValidUuid;
+import static io.opencensus.trace.AttributeValue.stringAttributeValue;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -53,11 +55,22 @@ import com.spotify.apollo.Status;
 import com.spotify.apollo.request.RequestContexts;
 import com.spotify.apollo.request.RequestMetadataImpl;
 import com.spotify.apollo.route.AsyncHandler;
+import io.opencensus.trace.Annotation;
+import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.EndSpanOptions;
+import io.opencensus.trace.Link;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.SpanBuilder;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.Tracer;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -89,6 +102,8 @@ public class MiddlewaresTest {
   @Mock public GoogleIdTokenVerifier idTokenVerifier;
   @Mock public GoogleIdToken idToken;
   @Mock public GoogleIdToken.Payload idTokenPayload;
+  @Mock Tracer tracer;
+  @Mock SpanBuilder spanBuilder;
 
   private static final TestStruct TEST_STRUCT = new AutoValue_MiddlewaresTest_TestStruct(
       "blah", new AutoValue_MiddlewaresTest_Inner("bloh", TestEnum.ENUM_VALUE));
@@ -536,6 +551,117 @@ public class MiddlewaresTest {
     assertThat(userHolder.get(), is(idToken));
   }
 
+  @Test
+  public void testTracingSync() throws Exception {
+    final RequestContext requestContext = mock(RequestContext.class);
+    final Request request = Request.forUri("/bar", "GET");
+    final MockSpan span = new MockSpan();
+
+    when(requestContext.request()).thenReturn(request);
+    when(tracer.spanBuilder("foo-service//bar")).thenReturn(spanBuilder);
+    when(spanBuilder.startSpan()).thenReturn(span);
+
+    awaitResponse(Middlewares.tracer(tracer, "foo-service")
+        .apply(rc -> completedFuture(Response.ok()))
+        .invoke(requestContext));
+
+    verify(tracer).spanBuilder("foo-service//bar");
+    verify(spanBuilder).startSpan();
+
+    assertThat(span.attributes.get("method"), is(stringAttributeValue("GET")));
+    assertThat(span.attributes.get("uri"), is(stringAttributeValue("/bar")));
+
+    assertThat(span.ended, is(true));
+    assertThat(span.status, is(nullValue()));
+  }
+
+  @Test
+  public void testTracingSyncError() {
+    final RequestContext requestContext = mock(RequestContext.class);
+    final Request request = Request.forUri("/bar", "GET");
+    final MockSpan span = new MockSpan();
+
+    when(requestContext.request()).thenReturn(request);
+    when(tracer.spanBuilder("foo-service//bar")).thenReturn(spanBuilder);
+    when(spanBuilder.startSpan()).thenReturn(span);
+
+    try {
+      awaitResponse(Middlewares.tracer(tracer, "foo-service")
+          .apply(rc -> {
+            throw new RuntimeException();
+          })
+          .invoke(requestContext));
+      fail();
+    } catch (Exception ignore) {
+    }
+
+    assertThat(span.ended, is(true));
+    assertThat(span.status, is(io.opencensus.trace.Status.UNKNOWN));
+  }
+
+  @Test
+  public void testTracingAsync() throws ExecutionException, InterruptedException {
+    final RequestContext requestContext = mock(RequestContext.class);
+    final Request request = Request.forUri("/bar", "GET");
+    final MockSpan span = new MockSpan();
+
+    when(requestContext.request()).thenReturn(request);
+
+    when(tracer.spanBuilder("foo-service//bar")).thenReturn(spanBuilder);
+    when(spanBuilder.startSpan()).thenReturn(span);
+
+    final CompletableFuture<Response<Object>> handlerFuture = new CompletableFuture<>();
+
+    final CompletableFuture<Response<Object>> responseFuture = Middlewares.tracer(tracer, "foo-service")
+        .apply(rc -> handlerFuture)
+        .invoke(requestContext)
+        .toCompletableFuture();
+
+    // Request handling is not complete, span should not be ended
+    assertThat(span.ended, is(false));
+
+    // Complete request handling future and wait for response
+    handlerFuture.complete(Response.ok());
+    responseFuture.get();
+
+    // Span should now be ended
+    assertThat(span.ended, is(true));
+    assertThat(span.status, is(nullValue()));
+  }
+
+  @Test
+  public void testTracingAsyncError() throws InterruptedException {
+    final RequestContext requestContext = mock(RequestContext.class);
+    final Request request = Request.forUri("/bar", "GET");
+    final MockSpan span = new MockSpan();
+
+    when(requestContext.request()).thenReturn(request);
+
+    when(tracer.spanBuilder("foo-service//bar")).thenReturn(spanBuilder);
+    when(spanBuilder.startSpan()).thenReturn(span);
+
+    final CompletableFuture<Response<Object>> handlerFuture = new CompletableFuture<>();
+
+    final CompletableFuture<Response<Object>> responseFuture = Middlewares.tracer(tracer, "foo-service")
+        .apply(rc -> handlerFuture)
+        .invoke(requestContext)
+        .toCompletableFuture();
+
+    // Request handling is not complete, span should not be ended
+    assertThat(span.ended, is(false));
+
+    // Fail request handling future and wait for response
+    handlerFuture.completeExceptionally(new RuntimeException());
+    try {
+      responseFuture.get();
+    } catch (ExecutionException ignore) {
+    }
+
+    // Span should now be ended
+    assertThat(span.ended, is(true));
+    assertThat(span.status, is(io.opencensus.trace.Status.UNKNOWN));
+  }
+
   public static <T> Response<T> awaitResponse(CompletionStage<Response<T>> completionStage)
       throws Exception {
     return completionStage.toCompletableFuture().get(5, SECONDS);
@@ -572,6 +698,44 @@ public class MiddlewaresTest {
     @JsonCreator
     public static TestEnum fromJson(String json) {
       return valueOf(json.toUpperCase());
+    }
+  }
+
+  private static class MockSpan extends Span {
+
+    boolean ended;
+    final Map<String, AttributeValue> attributes = new HashMap<>();
+    io.opencensus.trace.Status status;
+
+    MockSpan() {
+      super(SpanContext.INVALID, EnumSet.noneOf(Options.class));
+    }
+
+    @Override
+    public void putAttribute(String key, AttributeValue value) {
+      attributes.put(key, value);
+    }
+
+    @Override
+    public void addAnnotation(String description, Map<String, AttributeValue> attributes) {
+    }
+
+    @Override
+    public void addAnnotation(Annotation annotation) {
+    }
+
+    @Override
+    public void addLink(Link link) {
+    }
+
+    @Override
+    public void setStatus(io.opencensus.trace.Status status) {
+      this.status = status;
+    }
+
+    @Override
+    public void end(EndSpanOptions options) {
+      this.ended = true;
     }
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
@@ -42,6 +42,7 @@ import com.spotify.styx.util.Time;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
+import io.opencensus.trace.samplers.Samplers;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -99,7 +100,10 @@ class BackfillTriggerManager {
   }
 
   void tick() {
-    try (Scope ss = tracer.spanBuilder("Styx.BackfillTriggerManager.tick").startScopedSpan()) {
+    try (Scope ss = tracer.spanBuilder("Styx.BackfillTriggerManager.tick")
+        .setRecordEvents(true)
+        .setSampler(Samplers.alwaysSample())
+        .startScopedSpan()) {
       tick0();
     }
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
@@ -39,6 +39,9 @@ import com.spotify.styx.storage.Storage;
 import com.spotify.styx.storage.StorageTransaction;
 import com.spotify.styx.util.AlreadyInitializedException;
 import com.spotify.styx.util.Time;
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -62,6 +65,8 @@ class BackfillTriggerManager {
       LOWER_UNDERSCORE, BackfillTriggerManager.class.getSimpleName());
 
   private static Consumer<List<Backfill>> DEFAULT_SHUFFLER = Collections::shuffle;
+
+  private static final Tracer tracer = Tracing.getTracer();
 
   private final TriggerListener triggerListener;
   private final Storage storage;
@@ -94,6 +99,12 @@ class BackfillTriggerManager {
   }
 
   void tick() {
+    try (Scope ss = tracer.spanBuilder("Styx.BackfillTriggerManager.tick").startScopedSpan()) {
+      tick0();
+    }
+  }
+
+  void tick0() {
     final Instant t0 = time.get();
 
     final List<Backfill> backfills;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Cleaner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Cleaner.java
@@ -24,6 +24,7 @@ import com.spotify.styx.docker.DockerRunner;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
+import io.opencensus.trace.samplers.Samplers;
 import java.io.IOException;
 import java.util.Objects;
 import org.slf4j.Logger;
@@ -42,7 +43,10 @@ class Cleaner {
   }
 
   void tick() {
-    try (Scope ss = tracer.spanBuilder("Styx.Cleaner.tick").startScopedSpan()) {
+    try (Scope ss = tracer.spanBuilder("Styx.Cleaner.tick")
+        .setRecordEvents(true)
+        .setSampler(Samplers.alwaysSample())
+        .startScopedSpan()) {
       tick0();
     }
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Cleaner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Cleaner.java
@@ -21,6 +21,9 @@
 package com.spotify.styx;
 
 import com.spotify.styx.docker.DockerRunner;
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
 import java.io.IOException;
 import java.util.Objects;
 import org.slf4j.Logger;
@@ -30,6 +33,8 @@ class Cleaner {
 
   private static final Logger logger = LoggerFactory.getLogger(Cleaner.class);
 
+  private static final Tracer tracer = Tracing.getTracer();
+
   private final DockerRunner dockerRunner;
 
   Cleaner(DockerRunner dockerRunner) {
@@ -37,6 +42,12 @@ class Cleaner {
   }
 
   void tick() {
+    try (Scope ss = tracer.spanBuilder("Styx.Cleaner.tick").startScopedSpan()) {
+      tick0();
+    }
+  }
+
+  void tick0() {
     try {
       dockerRunner.cleanup();
     } catch (IOException e) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -53,6 +53,9 @@ import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.TimeoutConfig;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.Time;
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -91,6 +94,8 @@ public class Scheduler {
 
   private static final int SCHEDULING_BATCH_SIZE = 16;
 
+  private static final Tracer tracer = Tracing.getTracer();
+
   private final Time time;
   private final TimeoutConfig ttls;
   private final StateManager stateManager;
@@ -115,6 +120,12 @@ public class Scheduler {
   }
 
   void tick() {
+    try (Scope ss = tracer.spanBuilder("Styx.Scheduler.tick").startScopedSpan()) {
+      tick0();
+    }
+  }
+
+  void tick0() {
     final Instant t0 = time.get();
 
     final Map<String, Resource> resources;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -56,6 +56,7 @@ import com.spotify.styx.util.Time;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
+import io.opencensus.trace.samplers.Samplers;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -120,7 +121,10 @@ public class Scheduler {
   }
 
   void tick() {
-    try (Scope ss = tracer.spanBuilder("Styx.Scheduler.tick").startScopedSpan()) {
+    try (Scope ss = tracer.spanBuilder("Styx.Scheduler.tick")
+        .setRecordEvents(true)
+        .setSampler(Samplers.alwaysSample())
+        .startScopedSpan()) {
       tick0();
     }
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -104,6 +104,7 @@ import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
+import io.opencensus.trace.samplers.Samplers;
 import java.io.Closeable;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -559,7 +560,10 @@ public class StyxScheduler implements AppInit {
   }
 
   private static void updateRuntimeConfig(Supplier<StyxConfig> config, RateLimiter rateLimiter) {
-    try (Scope ss = tracer.spanBuilder("Styx.StyxScheduler.updateRuntimeConfig").startScopedSpan()) {
+    try (Scope ss = tracer.spanBuilder("Styx.StyxScheduler.updateRuntimeConfig")
+        .setRecordEvents(true)
+        .setSampler(Samplers.alwaysSample())
+        .startScopedSpan()) {
       updateRuntimeConfig0(config, rateLimiter);
     }
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/TriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/TriggerManager.java
@@ -43,6 +43,7 @@ import com.spotify.styx.util.TriggerInstantSpec;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
+import io.opencensus.trace.samplers.Samplers;
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Instant;
@@ -87,7 +88,10 @@ class TriggerManager implements Closeable {
   }
 
   void tick() {
-    try (Scope ss = tracer.spanBuilder("Styx.TriggerManager.tick").startScopedSpan()) {
+    try (Scope ss = tracer.spanBuilder("Styx.TriggerManager.tick")
+        .setRecordEvents(true)
+        .setSampler(Samplers.alwaysSample())
+        .startScopedSpan()) {
       tick0();
     }
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/TriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/TriggerManager.java
@@ -40,6 +40,9 @@ import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.AlreadyInitializedException;
 import com.spotify.styx.util.Time;
 import com.spotify.styx.util.TriggerInstantSpec;
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Instant;
@@ -64,6 +67,8 @@ class TriggerManager implements Closeable {
                                                          TriggerManager.class.getSimpleName());
   private static final int TRIGGER_CONCURRENCY = 32;
 
+  private static final Tracer tracer = Tracing.getTracer();
+
   private final TriggerListener triggerListener;
   private final Time time;
   private final Storage storage;
@@ -82,6 +87,12 @@ class TriggerManager implements Closeable {
   }
 
   void tick() {
+    try (Scope ss = tracer.spanBuilder("Styx.TriggerManager.tick").startScopedSpan()) {
+      tick0();
+    }
+  }
+
+  void tick0() {
     final Instant t0 = time.get();
 
     try {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -78,6 +78,9 @@ import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.norberg.automatter.AutoMatter;
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -98,6 +101,8 @@ import java.util.concurrent.TimeUnit;
  * A {@link DockerRunner} implementation that submits container executions to a Kubernetes cluster.
  */
 class KubernetesDockerRunner implements DockerRunner {
+
+  private static final Tracer tracer = Tracing.getTracer();
 
   static final String STYX_WORKFLOW_INSTANCE_ANNOTATION = "styx-workflow-instance";
   static final String DOCKER_TERMINATION_LOGGING_ANNOTATION = "styx-docker-termination-logging";
@@ -536,7 +541,9 @@ class KubernetesDockerRunner implements DockerRunner {
 
   private void pollPods() {
     try {
-      tryPollPods();
+      try (Scope ss = tracer.spanBuilder("Styx.KubernetesDockerRunner.pollPods").startScopedSpan()) {
+        tryPollPods();
+      }
     } catch (Throwable t) {
       LOG.warn("Error while polling pods", t);
     }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -81,6 +81,7 @@ import io.norberg.automatter.AutoMatter;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
+import io.opencensus.trace.samplers.Samplers;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -541,7 +542,10 @@ class KubernetesDockerRunner implements DockerRunner {
 
   private void pollPods() {
     try {
-      try (Scope ss = tracer.spanBuilder("Styx.KubernetesDockerRunner.pollPods").startScopedSpan()) {
+      try (Scope ss = tracer.spanBuilder("Styx.KubernetesDockerRunner.pollPods")
+          .setRecordEvents(true)
+          .setSampler(Samplers.alwaysSample())
+          .startScopedSpan()) {
         tryPollPods();
       }
     } catch (Throwable t) {

--- a/styx-standalone-service/src/main/java/com/spotify/styx/StyxService.java
+++ b/styx-standalone-service/src/main/java/com/spotify/styx/StyxService.java
@@ -33,6 +33,8 @@ import java.time.Instant;
 
 public class StyxService {
 
+  private static final String SERVICE_NAME = "styx-standalone";
+
   private StyxService() {
     throw new UnsupportedOperationException();
   }
@@ -47,9 +49,11 @@ public class StyxService {
       final StatsFactory statsFactory = (ignored) -> stats;
 
       final StyxScheduler scheduler = StyxScheduler.newBuilder()
+          .setServiceName(SERVICE_NAME)
           .setStatsFactory(statsFactory)
           .build();
       final StyxApi api = StyxApi.newBuilder()
+          .setServiceName(SERVICE_NAME)
           .setStatsFactory(statsFactory)
           .build();
 
@@ -57,6 +61,6 @@ public class StyxService {
       api.create(env);
     };
 
-    HttpService.boot(init, "styx-standalone", args);
+    HttpService.boot(init, SERVICE_NAME, args);
   }
 }


### PR DESCRIPTION
add tracing to styx api/scheduler requests and internals

A next step after this PR is to instrument the storage methods etc with spans to get more granular breakdown of what's going on in there.