### PR TITLE
configurable scheduler & trigger tick interval + jitter scheduling

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/GuardedRunnable.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/GuardedRunnable.java
@@ -30,12 +30,14 @@ public class GuardedRunnable {
   }
 
   public static Runnable guard(Runnable delegate) {
-    return () -> {
-      try {
-        delegate.run();
-      } catch (Throwable t) {
-        LOG.warn("Guarded runnable threw", t);
-      }
-    };
+    return () -> runGuarded(delegate);
+  }
+
+  public static void runGuarded(Runnable delegate) {
+    try {
+      delegate.run();
+    } catch (Throwable t) {
+      LOG.warn("Guarded runnable threw", t);
+    }
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -145,7 +145,7 @@ public class StyxScheduler implements AppInit {
 
   public static final int DEFAULT_STYX_EVENT_PROCESSING_THREADS = 32;
   public static final Duration DEFAULT_SCHEDULER_TICK_INTERVAL = Duration.ofSeconds(2);
-  public static final Duration DEFAULT_TRIGGER_MANAGER_TICK_INTERVAL = Duration.ofSeconds(1);
+  public static final Duration DEFAULT_TRIGGER_TICK_INTERVAL = Duration.ofSeconds(1);
   public static final Duration CLEANER_TICK_INTERVAL = Duration.ofMinutes(30);
   public static final Duration RUNTIME_CONFIG_UPDATE_INTERVAL = Duration.ofSeconds(5);
   public static final Duration DEFAULT_RETRY_BASE_DELAY = Duration.ofMinutes(3);
@@ -373,7 +373,7 @@ public class StyxScheduler implements AppInit {
 
     final Duration triggerTickInterval = config.hasPath(STYX_TRIGGER_TICK_INTERVAL)
         ? config.getDuration(STYX_TRIGGER_TICK_INTERVAL)
-        : DEFAULT_TRIGGER_MANAGER_TICK_INTERVAL;
+        : DEFAULT_TRIGGER_TICK_INTERVAL;
 
     dockerRunner.restore();
     startTriggerManager(triggerManager, executor, schedulerTickInterval);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -376,9 +376,9 @@ public class StyxScheduler implements AppInit {
         : DEFAULT_TRIGGER_TICK_INTERVAL;
 
     dockerRunner.restore();
-    startTriggerManager(triggerManager, executor, schedulerTickInterval);
+    startTriggerManager(triggerManager, executor, triggerTickInterval);
     startBackfillTriggerManager(backfillTriggerManager, executor, triggerTickInterval);
-    startScheduler(scheduler, executor, triggerTickInterval);
+    startScheduler(scheduler, executor, schedulerTickInterval);
     startRuntimeConfigUpdate(styxConfig, executor, dequeueRateLimiter);
     startCleaner(cleaner, executor);
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -323,7 +323,7 @@ public class StyxSchedulerServiceFixture {
   /**
    * Fast forwards the time by executing all tasks in-between according to the executor's delay.
    */
-  void timePasses(int n, TimeUnit unit) {
+  void timePasses(long n, TimeUnit unit) {
     LOG.info("{} {} passes", n, unit);
     now = now.plusMillis(unit.toMillis(n));
     executor.tick(n, unit);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -530,7 +530,7 @@ public class SystemTest extends StyxSchedulerServiceFixture {
     // we must stagger the time progression here in order not to no trigger tons of retries
     timePasses(TerminationHandler.MISSING_DEPS_RETRY_DELAY_MINUTES - 1, MINUTES);
     timePasses(59, SECONDS);
-    timePasses(StyxScheduler.SCHEDULER_TICK_INTERVAL_SECONDS, SECONDS);
+    timePasses(StyxScheduler.DEFAULT_SCHEDULER_TICK_INTERVAL.getSeconds(), SECONDS);
 
     awaitNumberOfDockerRuns(2);
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -530,7 +530,7 @@ public class SystemTest extends StyxSchedulerServiceFixture {
     // we must stagger the time progression here in order not to no trigger tons of retries
     timePasses(TerminationHandler.MISSING_DEPS_RETRY_DELAY_MINUTES - 1, MINUTES);
     timePasses(59, SECONDS);
-    timePasses(StyxScheduler.DEFAULT_SCHEDULER_TICK_INTERVAL.getSeconds(), SECONDS);
+    timePasses(StyxScheduler.DEFAULT_SCHEDULER_TICK_INTERVAL.getSeconds() * 2, SECONDS);
 
     awaitNumberOfDockerRuns(2);
 


### PR DESCRIPTION
Current hard coded tick interval of ~1 hz is quite expensive for deployments with a lot of workflows due to causing a lot of datastore reads. This allows us to configure a more appropriate tick interval to lower datastore costs.

The default tick interval is unchanged.

Also add jitter to the tick scheduling to have less contention on datastore.