### PR TITLE
Commit sha for executions

### DIFF
--- a/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
@@ -83,7 +83,7 @@ public class StatusResourceTest extends VersionedApiTest {
     sinceVersion(Api.Version.V3);
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI, TRIGGER), 0L, 0L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI, "exec0", "img0"), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI, "exec0", "img0", "commitSha0"), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI), 2L, 2L));
 
     Response<ByteString> response =

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -313,7 +313,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     WorkflowInstance wfi = WorkflowInstance.create(WORKFLOW.id(), "2016-08-10");
     storage.writeEvent(create(Event.triggerExecution(wfi, NATURAL_TRIGGER), 0L, ms("07:00:00")));
-    storage.writeEvent(create(Event.created(wfi, "exec", "img"), 1L, ms("07:00:01")));
+    storage.writeEvent(create(Event.created(wfi, "exec", "img", "commitSha"), 1L, ms("07:00:01")));
     storage.writeEvent(create(Event.started(wfi), 2L, ms("07:00:02")));
 
     Response<ByteString> response =
@@ -342,7 +342,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     WorkflowInstance wfi = WorkflowInstance.create(WORKFLOW.id(), "2016-08-10");
     storage.writeEvent(create(Event.triggerExecution(wfi, NATURAL_TRIGGER), 0L, ms("07:00:00")));
-    storage.writeEvent(create(Event.created(wfi, "exec", "img"), 1L, ms("07:00:01")));
+    storage.writeEvent(create(Event.created(wfi, "exec", "img", "commitSha"), 1L, ms("07:00:01")));
     storage.writeEvent(create(Event.started(wfi), 2L, ms("07:00:02")));
 
     Response<ByteString> response =
@@ -371,7 +371,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     WorkflowInstance wfi = WorkflowInstance.create(WORKFLOW.id(), "2016-08-10");
     storage.writeEvent(create(Event.triggerExecution(wfi, NATURAL_TRIGGER), 0L, ms("07:00:00")));
-    storage.writeEvent(create(Event.created(wfi, "exec", "img"), 1L, ms("07:00:01")));
+    storage.writeEvent(create(Event.created(wfi, "exec", "img", "commitSha"), 1L, ms("07:00:01")));
     storage.writeEvent(create(Event.started(wfi), 2L, ms("07:00:02")));
 
     Response<ByteString> response =

--- a/styx-common/src/main/java/com/spotify/styx/model/Backfill.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/Backfill.java
@@ -51,6 +51,8 @@ public interface Backfill {
 
   boolean reverse();
 
+  boolean complete();
+
   BackfillBuilder builder();
 
   static BackfillBuilder newBuilder() {

--- a/styx-common/src/main/java/com/spotify/styx/model/Backfill.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/Backfill.java
@@ -51,8 +51,6 @@ public interface Backfill {
 
   boolean reverse();
 
-  boolean complete();
-
   BackfillBuilder builder();
 
   static BackfillBuilder newBuilder() {

--- a/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
@@ -54,7 +54,7 @@ public interface EventVisitor<R> {
   @Deprecated
   R timeTrigger(@Getter WorkflowInstance workflowInstance);
   @Deprecated
-  R created(@Getter WorkflowInstance workflowInstance, String executionId, String dockerImage);
+  R created(@Getter WorkflowInstance workflowInstance, String executionId, String dockerImage, String commitSha);
   @Deprecated
   R retry(@Getter WorkflowInstance workflowInstance);
 }

--- a/styx-common/src/main/java/com/spotify/styx/model/data/Execution.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/Execution.java
@@ -39,13 +39,17 @@ public abstract class Execution {
   public abstract Optional<String> dockerImage();
 
   @JsonProperty
+  public abstract Optional<String> commitSha();
+
+  @JsonProperty
   public abstract List<ExecStatus> statuses();
 
   @JsonCreator
   public static Execution create(
       @JsonProperty("execution_id") Optional<String> executionId,
       @JsonProperty("docker_image") Optional<String> dockerImage,
+      @JsonProperty("commit_sha") Optional<String> commitSha,
       @JsonProperty("statuses") List<ExecStatus> statuses) {
-    return new AutoValue_Execution(executionId, dockerImage, statuses);
+    return new AutoValue_Execution(executionId, dockerImage, commitSha, statuses);
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -44,6 +44,7 @@ class WFIExecutionBuilder {
   @Nullable private String currExecutionId;
   @Nullable private String currTriggerId = "UNKNOWN";
   @Nullable private String currDockerImg;
+  @Nullable private String currCommitSha;
 
   private boolean completed;
 
@@ -56,12 +57,14 @@ class WFIExecutionBuilder {
     final Execution execution = Execution.create(
         Optional.ofNullable(currExecutionId),
         Optional.ofNullable(currDockerImg),
+        Optional.ofNullable(currCommitSha),
         executionStatusList);
     executionList.add(execution);
 
     executionStatusList = new ArrayList<>();
     currExecutionId = null;
     currDockerImg = null;
+    currCommitSha = null;
   }
 
   private void closeTrigger() {
@@ -109,10 +112,11 @@ class WFIExecutionBuilder {
     }
 
     @Override
-    public Void created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
+    public Void created(WorkflowInstance workflowInstance, String executionId, String dockerImage, String commitSha) {
       currWorkflowInstance = workflowInstance;
       currExecutionId = executionId;
       currDockerImg = dockerImage;
+      currCommitSha = commitSha;
 
       executionStatusList.add(ExecStatus.create(eventTs, "SUBMITTED", Optional.empty()));
       return null;
@@ -123,6 +127,7 @@ class WFIExecutionBuilder {
         String executionId) {
       currWorkflowInstance = workflowInstance;
       currDockerImg = executionDescription.dockerImage();
+      currCommitSha = executionDescription.commitSha().get();
       currExecutionId = executionId;
 
       return null;

--- a/styx-common/src/main/java/com/spotify/styx/serialization/PersistentEvent.java
+++ b/styx-common/src/main/java/com/spotify/styx/serialization/PersistentEvent.java
@@ -86,8 +86,9 @@ class PersistentEvent {
     }
 
     @Override
-    public PersistentEvent created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
-      return new Created(workflowInstance.toKey(), executionId, Optional.of(dockerImage));
+    public PersistentEvent created(WorkflowInstance workflowInstance, String executionId,
+        String dockerImage, String commitSha) {
+      return new Created(workflowInstance.toKey(), executionId, Optional.of(dockerImage), Optional.of(commitSha));
     }
 
     @Override
@@ -234,20 +235,23 @@ class PersistentEvent {
 
     public final String executionId;
     public final String dockerImage;
+    public final String commitSha;
 
     @JsonCreator
     public Created(
         @JsonProperty("workflow_instance") String workflowInstance,
         @JsonProperty("execution_id") String executionId,
-        @JsonProperty("docker_image") Optional<String> dockerImage) {
+        @JsonProperty("docker_image") Optional<String> dockerImage,
+        @JsonProperty("commit_sha") Optional<String> commitSha ) {
       super("created", workflowInstance);
       this.executionId = executionId;
       this.dockerImage = dockerImage.orElse("UNKNOWN");
+      this.commitSha = commitSha.orElse("UNKNOWN");
     }
 
     @Override
     public Event toEvent() {
-      return Event.created(WorkflowInstance.parseKey(workflowInstance), executionId, dockerImage);
+      return Event.created(WorkflowInstance.parseKey(workflowInstance), executionId, dockerImage, commitSha);
     }
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/state/RunState.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/RunState.java
@@ -157,7 +157,8 @@ public abstract class RunState {
 
     @Deprecated
     @Override
-    public RunState created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
+    public RunState created(WorkflowInstance workflowInstance, String executionId,
+        String dockerImage, String commitSha) {
       switch (state()) {
         case PREPARE:
         case QUEUED:
@@ -166,6 +167,7 @@ public abstract class RunState {
               data().builder()
                   .executionId(executionId)
                   .executionDescription(ExecutionDescription.forImage(dockerImage))
+                  .commitSha(commitSha)
                   .tries(data().tries() + 1)
                   .build());
 

--- a/styx-common/src/main/java/com/spotify/styx/state/StateData.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/StateData.java
@@ -46,6 +46,7 @@ public interface StateData {
   Optional<Trigger> trigger();
   Optional<String> triggerId(); //for backwards compatibility
   Optional<String> executionId();
+  Optional<String> commitSha();
   Optional<ExecutionDescription> executionDescription();
   Optional<Set<String>> resourceIds(); // resources referenced in the workflow configuration at the time of dequeue
 

--- a/styx-common/src/main/java/com/spotify/styx/util/EventUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/EventUtil.java
@@ -69,8 +69,8 @@ public final class EventUtil {
     }
 
     @Override
-    public String created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
-      return String.format("Execution id: %s, Docker image: %s", executionId, dockerImage);
+    public String created(WorkflowInstance workflowInstance, String executionId, String dockerImage, String commitSha) {
+      return String.format("Execution id: %s, Docker image: %s,  Commit sha: %s ", executionId, dockerImage, commitSha);
     }
 
     @Override
@@ -162,7 +162,8 @@ public final class EventUtil {
     }
 
     @Override
-    public String created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
+    public String created(WorkflowInstance workflowInstance, String executionId,
+        String dockerImage, String commitSha) {
       return "created";
     }
 

--- a/styx-common/src/test/java/com/spotify/styx/WorkflowInstanceEventFactory.java
+++ b/styx-common/src/test/java/com/spotify/styx/WorkflowInstanceEventFactory.java
@@ -48,8 +48,8 @@ public class WorkflowInstanceEventFactory {
     return Event.info(workflowInstance, message);
   }
 
-  public Event created(String executionId, String dockerImage) {
-    return Event.created(workflowInstance, executionId, dockerImage);
+  public Event created(String executionId, String dockerImage, String commitSha) {
+    return Event.created(workflowInstance, executionId, dockerImage, commitSha);
   }
 
   public Event dequeue(Set<String> resourceIds) {

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WFIExecutionBuilderTest.java
@@ -51,9 +51,10 @@ public class WFIExecutionBuilderTest {
       UNKNOWN_TRIGGER1 = com.spotify.styx.state.Trigger.unknown("trig1");
   private static final Set<String> RESOURCE_IDS = ImmutableSet.of("foo-resource", "bar-resource");
 
-  private ExecutionDescription desc(String dockerImage) {
+  private ExecutionDescription desc(String dockerImage, String commitSha) {
     return ExecutionDescription.builder()
         .dockerImage(dockerImage)
+        .commitSha(commitSha)
         .build();
   }
 
@@ -77,6 +78,7 @@ public class WFIExecutionBuilderTest {
                     true,
                     Arrays.asList(
                         Execution.create(
+                            Optional.empty(),
                             Optional.empty(),
                             Optional.empty(),
                             Arrays.asList(
@@ -113,6 +115,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.empty(),
                             Optional.empty(),
+                            Optional.empty(),
                             Arrays.asList(
                                 ExecStatus.create(time("07:56"), "FAILED", Optional.of("Error message"))
                             )
@@ -131,14 +134,14 @@ public class WFIExecutionBuilderTest {
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
         SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("07:55")),
-        SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
+        SequenceEvent.create(E.submit(desc("img1", "sha1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57")),
         SequenceEvent.create(E.terminate(RunState.MISSING_DEPS_EXIT_CODE), c++, ts("07:58")),
         SequenceEvent.create(E.retryAfter(10), c++, ts("07:59")),
 
         SequenceEvent.create(E.retry(), c++, ts("08:56")),
-        SequenceEvent.create(E.submit(desc("img2"), "exec-id-01"), c++, ts("08:55")),
+        SequenceEvent.create(E.submit(desc("img2", "sha2"), "exec-id-01"), c++, ts("08:55")),
         SequenceEvent.create(E.submitted("exec-id-01"), c++, ts("08:56")),
         SequenceEvent.create(E.started(), c++, ts("08:57")),
         SequenceEvent.create(E.terminate(0), c++, ts("08:58")),
@@ -146,14 +149,14 @@ public class WFIExecutionBuilderTest {
 
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER1), c++, ts("09:55")),
         SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("09:55")),
-        SequenceEvent.create(E.submit(desc("img3"), "exec-id-10"), c++, ts("09:55")),
+        SequenceEvent.create(E.submit(desc("img3", "sha3"), "exec-id-10"), c++, ts("09:55")),
         SequenceEvent.create(E.submitted("exec-id-10"), c++, ts("09:56")),
         SequenceEvent.create(E.started(), c++, ts("09:57")),
         SequenceEvent.create(E.terminate(1), c++, ts("09:58")),
         SequenceEvent.create(E.retryAfter(10), c++, ts("09:59")),
 
         SequenceEvent.create(E.retry(), c++, ts("10:56")),
-        SequenceEvent.create(E.submit(desc("img4"), "exec-id-11"), c++, ts("10:55")),
+        SequenceEvent.create(E.submit(desc("img4", "sha4"), "exec-id-11"), c++, ts("10:55")),
         SequenceEvent.create(E.submitted("exec-id-11"), c++, ts("10:56")),
         SequenceEvent.create(E.started(), c++, ts("10:57"))
     );
@@ -173,6 +176,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.of("exec-id-00"),
                             Optional.of("img1"),
+                            Optional.of("sha1"),
                             Arrays.asList(
                                 ExecStatus.create(time("07:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("07:57"), "STARTED", Optional.empty()),
@@ -182,6 +186,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.of("exec-id-01"),
                             Optional.of("img2"),
+                            Optional.of("sha2"),
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("08:57"), "STARTED", Optional.empty()),
@@ -198,6 +203,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.of("exec-id-10"),
                             Optional.of("img3"),
+                            Optional.of("sha3"),
                             Arrays.asList(
                                 ExecStatus.create(time("09:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("09:57"), "STARTED", Optional.empty()),
@@ -207,6 +213,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.of("exec-id-11"),
                             Optional.of("img4"),
+                            Optional.of("sha4"),
                             Arrays.asList(
                                 ExecStatus.create(time("10:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("10:57"), "STARTED", Optional.empty())
@@ -226,7 +233,7 @@ public class WFIExecutionBuilderTest {
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
         SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("07:55")),
-        SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
+        SequenceEvent.create(E.submit(desc("img1", "sha1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57")),
         SequenceEvent.create(E.terminate(Optional.empty()), c++, ts("07:58"))
@@ -247,6 +254,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.of("exec-id-00"),
                             Optional.of("img1"),
+                            Optional.of("sha1"),
                             Arrays.asList(
                                 ExecStatus.create(time("07:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("07:57"), "STARTED", Optional.empty()),
@@ -267,14 +275,14 @@ public class WFIExecutionBuilderTest {
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
         SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("07:55")),
-        SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
+        SequenceEvent.create(E.submit(desc("img1", "sha1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57")),
         SequenceEvent.create(E.timeout(), c++, ts("07:58")),
         SequenceEvent.create(E.retryAfter(10), c++, ts("07:59")),
 
         SequenceEvent.create(E.retry(), c++, ts("08:56")),
-        SequenceEvent.create(E.submit(desc("img2"), "exec-id-01"), c++, ts("08:55")),
+        SequenceEvent.create(E.submit(desc("img2", "sha2"), "exec-id-01"), c++, ts("08:55")),
         SequenceEvent.create(E.submitted("exec-id-01"), c++, ts("08:56")),
         SequenceEvent.create(E.started(), c++, ts("08:57"))
     );
@@ -294,6 +302,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.of("exec-id-00"),
                             Optional.of("img1"),
+                            Optional.of("sha1"),
                             Arrays.asList(
                                 ExecStatus.create(time("07:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("07:57"), "STARTED", Optional.empty()),
@@ -303,6 +312,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.of("exec-id-01"),
                             Optional.of("img2"),
+                            Optional.of("sha2"),
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("08:57"), "STARTED", Optional.empty())
@@ -322,7 +332,7 @@ public class WFIExecutionBuilderTest {
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.timeout(), c++, ts("07:54")),
         SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("07:55")),
-        SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
+        SequenceEvent.create(E.submit(desc("img1", "sha1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.started(), c++, ts("07:57"))
     );
@@ -341,6 +351,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.of("exec-id-00"),
                             Optional.of("img1"),
+                            Optional.of("sha1"),
                             Arrays.asList(
                                 ExecStatus.create(time("07:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("07:57"), "STARTED", Optional.empty())
@@ -360,12 +371,12 @@ public class WFIExecutionBuilderTest {
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
         SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("07:55")),
-        SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
+        SequenceEvent.create(E.submit(desc("img1", "sha1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.runError("First failure"), c++, ts("07:58")),
         SequenceEvent.create(E.retryAfter(10), c++, ts("07:59")),
 
         SequenceEvent.create(E.retry(), c++, ts("08:56")),
-        SequenceEvent.create(E.submit(desc("img2"), "exec-id-01"), c++, ts("08:55")),
+        SequenceEvent.create(E.submit(desc("img2", "sha2"), "exec-id-01"), c++, ts("08:55")),
         SequenceEvent.create(E.submitted("exec-id-01"), c++, ts("08:56")),
         SequenceEvent.create(E.started(), c++, ts("08:57")),
         SequenceEvent.create(E.runError("Second failure"), c++, ts("08:59"))
@@ -386,6 +397,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.of("exec-id-00"),
                             Optional.of("img1"),
+                            Optional.of("sha1"),
                             Arrays.asList(
                                 ExecStatus.create(time("07:58"), "FAILED", Optional.of("First failure"))
                             )
@@ -393,6 +405,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.of("exec-id-01"),
                             Optional.of("img2"),
+                            Optional.of("sha2"),
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("08:57"), "STARTED", Optional.empty()),
@@ -413,13 +426,13 @@ public class WFIExecutionBuilderTest {
     List<SequenceEvent> events = Arrays.asList(
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER0), c++, ts("07:55")),
         SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("07:55")),
-        SequenceEvent.create(E.submit(desc("img1"), "exec-id-00"), c++, ts("07:55")),
+        SequenceEvent.create(E.submit(desc("img1", "sha1"), "exec-id-00"), c++, ts("07:55")),
         SequenceEvent.create(E.submitted("exec-id-00"), c++, ts("07:56")),
         SequenceEvent.create(E.halt(), c++, ts("07:57")),
 
         SequenceEvent.create(E.triggerExecution(UNKNOWN_TRIGGER1), c++, ts("08:56")),
         SequenceEvent.create(E.dequeue(RESOURCE_IDS), c++, ts("08:56")),
-        SequenceEvent.create(E.submit(desc("img2"), "exec-id-10"), c++, ts("08:55")),
+        SequenceEvent.create(E.submit(desc("img2", "sha2"), "exec-id-10"), c++, ts("08:55")),
         SequenceEvent.create(E.submitted("exec-id-10"), c++, ts("08:56")),
         SequenceEvent.create(E.started(), c++, ts("08:57"))
     );
@@ -439,6 +452,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.of("exec-id-00"),
                             Optional.of("img1"),
+                            Optional.of("sha1"),
                             Arrays.asList(
                                 ExecStatus.create(time("07:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("07:57"), "HALTED", Optional.empty())
@@ -454,6 +468,7 @@ public class WFIExecutionBuilderTest {
                         Execution.create(
                             Optional.of("exec-id-10"),
                             Optional.of("img2"),
+                            Optional.of("sha2"),
                             Arrays.asList(
                                 ExecStatus.create(time("08:56"), "SUBMITTED", Optional.empty()),
                                 ExecStatus.create(time("08:57"), "STARTED", Optional.empty())

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
@@ -43,7 +43,7 @@ public class WorkflowInstanceExecutionDataTest {
 
   @Test
   public void shouldDeserializeExecution() throws Exception {
-    String json = executionJson("exec-id", "busybox:1.0", "commitSha", "09", "SUCCESS", Optional.empty());
+    String json = executionJson("exec-id", "busybox:1.0", "commit-sha", "09", "SUCCESS", Optional.empty());
 
     Execution execution = OBJECT_MAPPER.readValue(json, Execution.class);
     Execution expected = Execution.create(
@@ -80,8 +80,8 @@ public class WorkflowInstanceExecutionDataTest {
 
   @Test
   public void shouldDeserializeTrigger() throws Exception {
-    String jsonExec0 = executionJson("exec-id-0", "busybox:1.0","commitSha1","09", "FAILED", Optional.of("Exit code 1"));
-    String jsonExec1 = executionJson("exec-id-1", "busybox:1.1","commitSha2", "10", "SUCCESS", Optional.empty());
+    String jsonExec0 = executionJson("exec-id-0", "busybox:1.0","commit-sha0","09", "FAILED", Optional.of("Exit code 1"));
+    String jsonExec1 = executionJson("exec-id-1", "busybox:1.1","commit-sha1", "10", "SUCCESS", Optional.empty());
 
     String json =
         "{"
@@ -125,8 +125,8 @@ public class WorkflowInstanceExecutionDataTest {
 
   @Test
   public void shouldDeserializeExecutionData() throws Exception {
-    String jsonExec00 = executionJson("exec-id-00", "busybox:1.0","commitSha0", "07", "FAILED", Optional.of("Exit code 1"));
-    String jsonExec01 = executionJson("exec-id-01", "busybox:1.1","commitSha1", "08", "SUCCESS", Optional.empty());
+    String jsonExec00 = executionJson("exec-id-00", "busybox:1.0","commit-sha0", "07", "FAILED", Optional.of("Exit code 1"));
+    String jsonExec01 = executionJson("exec-id-01", "busybox:1.1","commit-sha1", "08", "SUCCESS", Optional.empty());
 
     String jsonTrigger0 =
         "{"
@@ -137,8 +137,8 @@ public class WorkflowInstanceExecutionDataTest {
         + jsonExec00 + "," + jsonExec01
         + "]}";
 
-    String jsonExec10 = executionJson("exec-id-10", "busybox:1.2","commitSha10", "09", "FAILED", Optional.of("Exit code 1"));
-    String jsonExec11 = executionJson("exec-id-11", "busybox:1.3","commitSha11", "10", "SUCCESS", Optional.empty());
+    String jsonExec10 = executionJson("exec-id-10", "busybox:1.2","commit-sha2", "09", "FAILED", Optional.of("Exit code 1"));
+    String jsonExec11 = executionJson("exec-id-11", "busybox:1.3","commit-sha3", "10", "SUCCESS", Optional.empty());
 
     String jsonTrigger1 =
         "{"
@@ -202,7 +202,7 @@ public class WorkflowInstanceExecutionDataTest {
                     Execution.create(
                         Optional.of("exec-id-10"),
                         Optional.of("busybox:1.2"),
-                        Optional.of("commit-sha12"),
+                        Optional.of("commit-sha2"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
                             ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
@@ -212,7 +212,7 @@ public class WorkflowInstanceExecutionDataTest {
                     Execution.create(
                         Optional.of("exec-id-11"),
                         Optional.of("busybox:1.3"),
-                        Optional.of("commit-sha13"),
+                        Optional.of("commit-sha3"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED", Optional.empty()),
                             ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING", Optional.empty()),

--- a/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/model/data/WorkflowInstanceExecutionDataTest.java
@@ -43,12 +43,13 @@ public class WorkflowInstanceExecutionDataTest {
 
   @Test
   public void shouldDeserializeExecution() throws Exception {
-    String json = executionJson("exec-id", "busybox:1.0", "09", "SUCCESS", Optional.empty());
+    String json = executionJson("exec-id", "busybox:1.0", "commitSha", "09", "SUCCESS", Optional.empty());
 
     Execution execution = OBJECT_MAPPER.readValue(json, Execution.class);
     Execution expected = Execution.create(
         Optional.of("exec-id"),
         Optional.of("busybox:1.0"),
+        Optional.of("commit-sha"),
         Arrays.asList(
             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
             ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
@@ -69,6 +70,7 @@ public class WorkflowInstanceExecutionDataTest {
     Execution expected = Execution.create(
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         Arrays.asList(
             ExecStatus.create(Instant.parse("2016-08-03T16:56:03.607Z"), "HALTED", Optional.empty())
         )
@@ -78,8 +80,8 @@ public class WorkflowInstanceExecutionDataTest {
 
   @Test
   public void shouldDeserializeTrigger() throws Exception {
-    String jsonExec0 = executionJson("exec-id-0", "busybox:1.0", "09", "FAILED", Optional.of("Exit code 1"));
-    String jsonExec1 = executionJson("exec-id-1", "busybox:1.1", "10", "SUCCESS", Optional.empty());
+    String jsonExec0 = executionJson("exec-id-0", "busybox:1.0","commitSha1","09", "FAILED", Optional.of("Exit code 1"));
+    String jsonExec1 = executionJson("exec-id-1", "busybox:1.1","commitSha2", "10", "SUCCESS", Optional.empty());
 
     String json =
         "{"
@@ -99,6 +101,7 @@ public class WorkflowInstanceExecutionDataTest {
             Execution.create(
                 Optional.of("exec-id-0"),
                 Optional.of("busybox:1.0"),
+                Optional.of("commit-sha0"),
                 Arrays.asList(
                     ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
                     ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
@@ -108,6 +111,7 @@ public class WorkflowInstanceExecutionDataTest {
             Execution.create(
                 Optional.of("exec-id-1"),
                 Optional.of("busybox:1.1"),
+                Optional.of("commit-sha1"),
                 Arrays.asList(
                     ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED", Optional.empty()),
                     ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING", Optional.empty()),
@@ -121,8 +125,8 @@ public class WorkflowInstanceExecutionDataTest {
 
   @Test
   public void shouldDeserializeExecutionData() throws Exception {
-    String jsonExec00 = executionJson("exec-id-00", "busybox:1.0", "07", "FAILED", Optional.of("Exit code 1"));
-    String jsonExec01 = executionJson("exec-id-01", "busybox:1.1", "08", "SUCCESS", Optional.empty());
+    String jsonExec00 = executionJson("exec-id-00", "busybox:1.0","commitSha0", "07", "FAILED", Optional.of("Exit code 1"));
+    String jsonExec01 = executionJson("exec-id-01", "busybox:1.1","commitSha1", "08", "SUCCESS", Optional.empty());
 
     String jsonTrigger0 =
         "{"
@@ -133,8 +137,8 @@ public class WorkflowInstanceExecutionDataTest {
         + jsonExec00 + "," + jsonExec01
         + "]}";
 
-    String jsonExec10 = executionJson("exec-id-10", "busybox:1.2", "09", "FAILED", Optional.of("Exit code 1"));
-    String jsonExec11 = executionJson("exec-id-11", "busybox:1.3", "10", "SUCCESS", Optional.empty());
+    String jsonExec10 = executionJson("exec-id-10", "busybox:1.2","commitSha10", "09", "FAILED", Optional.of("Exit code 1"));
+    String jsonExec11 = executionJson("exec-id-11", "busybox:1.3","commitSha11", "10", "SUCCESS", Optional.empty());
 
     String jsonTrigger1 =
         "{"
@@ -171,6 +175,7 @@ public class WorkflowInstanceExecutionDataTest {
                     Execution.create(
                         Optional.of("exec-id-00"),
                         Optional.of("busybox:1.0"),
+                        Optional.of("commit-sha0"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T07:56:03.607Z"), "STARTED", Optional.empty()),
                             ExecStatus.create(Instant.parse("2016-08-03T07:57:03.607Z"), "RUNNING", Optional.empty()),
@@ -180,6 +185,7 @@ public class WorkflowInstanceExecutionDataTest {
                     Execution.create(
                         Optional.of("exec-id-01"),
                         Optional.of("busybox:1.1"),
+                        Optional.of("commit-sha1"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T08:56:03.607Z"), "STARTED", Optional.empty()),
                             ExecStatus.create(Instant.parse("2016-08-03T08:57:03.607Z"), "RUNNING", Optional.empty()),
@@ -196,6 +202,7 @@ public class WorkflowInstanceExecutionDataTest {
                     Execution.create(
                         Optional.of("exec-id-10"),
                         Optional.of("busybox:1.2"),
+                        Optional.of("commit-sha12"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T09:56:03.607Z"), "STARTED", Optional.empty()),
                             ExecStatus.create(Instant.parse("2016-08-03T09:57:03.607Z"), "RUNNING", Optional.empty()),
@@ -205,6 +212,7 @@ public class WorkflowInstanceExecutionDataTest {
                     Execution.create(
                         Optional.of("exec-id-11"),
                         Optional.of("busybox:1.3"),
+                        Optional.of("commit-sha13"),
                         Arrays.asList(
                             ExecStatus.create(Instant.parse("2016-08-03T10:56:03.607Z"), "STARTED", Optional.empty()),
                             ExecStatus.create(Instant.parse("2016-08-03T10:57:03.607Z"), "RUNNING", Optional.empty()),
@@ -224,7 +232,7 @@ public class WorkflowInstanceExecutionDataTest {
     return message.map(s -> baseJson + ", \"message\":\"" + s + "\"}").orElse(baseJson + "}");
   }
 
-  private String executionJson(String id, String image, String hour, String endStatus, Optional<String> endMessage) {
+  private String executionJson(String id, String image, String sha, String hour, String endStatus, Optional<String> endMessage) {
     String jsonStatus1 = statusJson(hour + ":56", "STARTED", Optional.empty());
     String jsonStatus2 = statusJson(hour + ":57", "RUNNING", Optional.empty());
     String jsonStatus3 = statusJson(hour + ":58", endStatus, endMessage);
@@ -233,6 +241,7 @@ public class WorkflowInstanceExecutionDataTest {
         "{"
         + "\"execution_id\":\"" + id + "\","
         + "\"docker_image\":\"" + image + "\","
+        + "\"commit_sha\":\"" + sha + "\","
         + "\"statuses\":["
         + jsonStatus1 + "," + jsonStatus2 + "," + jsonStatus3
         + "]}";

--- a/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
@@ -117,7 +117,7 @@ public class PersistentEventTest {
         deserializeEvent(json("submitted", "\"execution_id\":\"" + POD_NAME + "\"")),
         is(Event.submitted(INSTANCE1, POD_NAME)));
     assertThat(
-        deserializeEvent(json("created", "\"execution_id\":\"" + POD_NAME + "\",\"docker_image\":\"" + DOCKER_IMAGE + "\""
+        deserializeEvent(json("created", "\"execution_id\":\"" + POD_NAME + "\",\"docker_image\":\"" + DOCKER_IMAGE
             + "\",\"commit_sha\":\"" + COMMIT_SHA + "\"")),
         is(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE, COMMIT_SHA)));
     assertThat(
@@ -150,7 +150,7 @@ public class PersistentEventTest {
         is(Event.started(INSTANCE1))); // for backwards compatibility
     assertThat(
         deserializeEvent(json("created", "\"execution_id\":\"" + POD_NAME + "\"")),
-        is(Event.created(INSTANCE1, POD_NAME, "UNKNOWN", COMMIT_SHA)));
+        is(Event.created(INSTANCE1, POD_NAME, "UNKNOWN", "UNKNOWN")));
     assertThat(
         deserializeEvent(json("triggerExecution")),
         is(Event.triggerExecution(INSTANCE1, TRIGGER_UNKNOWN)));

--- a/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
@@ -63,7 +63,7 @@ public class PersistentEventTest {
     assertRoundtrip(Event.timeTrigger(INSTANCE1));
     assertRoundtrip(Event.triggerExecution(INSTANCE1, UNKNOWN_TRIGGER));
     assertRoundtrip(Event.info(INSTANCE1, Message.info("InfoMessage")));
-    assertRoundtrip(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE));
+    assertRoundtrip(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE, COMMIT_SHA));
     assertRoundtrip(Event.dequeue(INSTANCE1, ImmutableSet.of("some-resource")));
     assertRoundtrip(Event.dequeue(INSTANCE1, ImmutableSet.of()));
     assertRoundtrip(Event.started(INSTANCE1));
@@ -117,8 +117,9 @@ public class PersistentEventTest {
         deserializeEvent(json("submitted", "\"execution_id\":\"" + POD_NAME + "\"")),
         is(Event.submitted(INSTANCE1, POD_NAME)));
     assertThat(
-        deserializeEvent(json("created", "\"execution_id\":\"" + POD_NAME + "\",\"docker_image\":\"" + DOCKER_IMAGE + "\"")),
-        is(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE)));
+        deserializeEvent(json("created", "\"execution_id\":\"" + POD_NAME + "\",\"docker_image\":\"" + DOCKER_IMAGE + "\""
+            + "\",\"commit_sha\":\"" + COMMIT_SHA + "\"")),
+        is(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE, COMMIT_SHA)));
     assertThat(
         deserializeEvent(json("runError", "\"message\":\"ErrorMessage\"")),
         is(Event.runError(INSTANCE1, "ErrorMessage")));
@@ -149,7 +150,7 @@ public class PersistentEventTest {
         is(Event.started(INSTANCE1))); // for backwards compatibility
     assertThat(
         deserializeEvent(json("created", "\"execution_id\":\"" + POD_NAME + "\"")),
-        is(Event.created(INSTANCE1, POD_NAME, "UNKNOWN")));
+        is(Event.created(INSTANCE1, POD_NAME, "UNKNOWN", COMMIT_SHA)));
     assertThat(
         deserializeEvent(json("triggerExecution")),
         is(Event.triggerExecution(INSTANCE1, TRIGGER_UNKNOWN)));

--- a/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
@@ -76,6 +76,8 @@ public class RunStateTest {
       .dockerArgs("--date", "{}", "--bar")
       .build();
 
+  private static final String COMMIT_SHA = "sha_1";
+
   private static final Trigger UNKNOWN_TRIGGER = Trigger.unknown("trig");
   private static final Trigger NATURAL_TRIGGER1 = Trigger.natural();
 
@@ -214,7 +216,7 @@ public class RunStateTest {
   public void testSetExecutionId() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(RUNNING));
@@ -225,7 +227,7 @@ public class RunStateTest {
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retryAfter(999));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_2, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_2, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(RUNNING));
@@ -265,7 +267,7 @@ public class RunStateTest {
   public void testSetsRetryDelay() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retryAfter(777));
 
@@ -273,7 +275,7 @@ public class RunStateTest {
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().retryDelayMillis(), hasValue(777L));
 
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retryAfter(999));
@@ -309,10 +311,10 @@ public class RunStateTest {
   public void testRetryFromRunError() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
 
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTED));
@@ -325,13 +327,13 @@ public class RunStateTest {
   public void testManyRetriesFromRunError() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().tries(), equalTo(3));
@@ -344,12 +346,12 @@ public class RunStateTest {
   public void testMissingDependenciesAddsToCost() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(RunState.MISSING_DEPS_EXIT_CODE));
     transitioner.receive(eventFactory.retryAfter(0));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(RunState.MISSING_DEPS_EXIT_CODE));
 
@@ -364,12 +366,12 @@ public class RunStateTest {
   public void testMissingDependenciesIncrementsTries() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(RunState.MISSING_DEPS_EXIT_CODE));
     transitioner.receive(eventFactory.retryAfter(0));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(RunState.MISSING_DEPS_EXIT_CODE));
 
@@ -384,12 +386,12 @@ public class RunStateTest {
   public void testErrorsAddsToCost() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retryAfter(0));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
 
@@ -403,7 +405,7 @@ public class RunStateTest {
   public void testFatalFromRunError() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.stop());
 
@@ -416,7 +418,7 @@ public class RunStateTest {
   public void testSuccessFromTerm() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(0));
     transitioner.receive(eventFactory.success());
@@ -432,11 +434,11 @@ public class RunStateTest {
   public void testRetryFromTerm() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().tries(), equalTo(2));
@@ -449,15 +451,15 @@ public class RunStateTest {
   public void testManyRetriesFromTerm() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(7));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().tries(), equalTo(3));
@@ -471,7 +473,7 @@ public class RunStateTest {
   public void testFatalFromTerm() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.stop());
@@ -486,11 +488,11 @@ public class RunStateTest {
   public void testRetryFromStartedThenRunError() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().tries(), equalTo(2));
@@ -502,7 +504,7 @@ public class RunStateTest {
   public void testFatalFromStartedThenRunError() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.stop());
@@ -516,7 +518,7 @@ public class RunStateTest {
   public void testFailedFromTimeout() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.timeout());
 
@@ -530,13 +532,13 @@ public class RunStateTest {
   public void testRetriggerOfPartition() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.stop());
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_2, DOCKER_IMAGE));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_2, DOCKER_IMAGE, COMMIT_SHA));
     transitioner.receive(eventFactory.started());
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(RUNNING));
@@ -601,7 +603,7 @@ public class RunStateTest {
   public void testStoresExecutedDockerImage() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE + "1"));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE + "1", COMMIT_SHA));
 
     assertThat(
         transitioner.get(WORKFLOW_INSTANCE).data().executionDescription().get().dockerImage(),
@@ -612,11 +614,11 @@ public class RunStateTest {
   public void testStoresLastExecutedDockerImage() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE + "1"));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE + "1", COMMIT_SHA));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE + "2"));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE + "2", COMMIT_SHA));
 
     assertThat(
         transitioner.get(WORKFLOW_INSTANCE).data().executionDescription().get().dockerImage(),

--- a/styx-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
@@ -81,7 +81,7 @@ public class BigTableStorageTest {
   public void shouldReturnExecutionDataForWorkflowInstance() throws Exception {
     setUp(0);
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI1, TRIGGER), 0L, 0L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId", "img"), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId", "img", "commitsha"), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI1), 2L, 2L));
 
     WorkflowInstanceExecutionData workflowInstanceExecutionData = storage.executionData(WFI1);
@@ -98,11 +98,11 @@ public class BigTableStorageTest {
   public void shouldReturnExecutionDataForWorkflow() throws Exception {
     setUp(0);
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI1, TRIGGER1), 0L, 0L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1"), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1", "commitsha1"), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI1), 2L, 2L));
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI2, TRIGGER2), 0L, 3L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2"), 1L, 4L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2", "commitsha2"), 1L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI2), 2L, 5L));
 
     List<WorkflowInstanceExecutionData> workflowInstanceExecutionData =
@@ -158,11 +158,11 @@ public class BigTableStorageTest {
   public void shouldReturnRangeOfExecutionDataForWorkflow() throws Exception {
     setUp(0);
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI1, TRIGGER1), 0L, 0L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1"), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1", "commitsha1"), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI1), 2L, 2L));
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI2, TRIGGER2), 0L, 3L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2"), 1L, 4L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2", "commitsha2"), 1L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI2), 2L, 5L));
 
     List<WorkflowInstanceExecutionData> workflowInstanceExecutionData =
@@ -190,11 +190,11 @@ public class BigTableStorageTest {
   public void shouldReturnExecutionDataForOneWorkflow() throws Exception {
     setUp(0);
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI1, TRIGGER1), 0L, 0L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1"), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1", "commitsha1"), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI1), 2L, 2L));
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI2, TRIGGER2), 0L, 3L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2"), 1L, 4L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2", "commitsha2"), 1L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI2), 2L, 5L));
 
     List<WorkflowInstanceExecutionData> workflowInstanceExecutionData =

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -727,7 +727,8 @@ class KubernetesDockerRunner implements DockerRunner {
     }
 
     @Override
-    public Boolean created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
+    public Boolean created(WorkflowInstance workflowInstance, String executionId,
+        String dockerImage, String commitSha) {
       return false;
     }
 


### PR DESCRIPTION
When getting workflow instances through the API, expose commit sha of execution, if available.