### PR TITLE
revert addition of `commitSha` to `created`

### DIFF
--- a/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
@@ -83,7 +83,7 @@ public class StatusResourceTest extends VersionedApiTest {
     sinceVersion(Api.Version.V3);
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI, TRIGGER), 0L, 0L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI, "exec0", "img0", "commitSha0"), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI, "exec0", "img0"), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI), 2L, 2L));
 
     Response<ByteString> response =

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -313,7 +313,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     WorkflowInstance wfi = WorkflowInstance.create(WORKFLOW.id(), "2016-08-10");
     storage.writeEvent(create(Event.triggerExecution(wfi, NATURAL_TRIGGER), 0L, ms("07:00:00")));
-    storage.writeEvent(create(Event.created(wfi, "exec", "img", "commitSha"), 1L, ms("07:00:01")));
+    storage.writeEvent(create(Event.created(wfi, "exec", "img"), 1L, ms("07:00:01")));
     storage.writeEvent(create(Event.started(wfi), 2L, ms("07:00:02")));
 
     Response<ByteString> response =
@@ -342,7 +342,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     WorkflowInstance wfi = WorkflowInstance.create(WORKFLOW.id(), "2016-08-10");
     storage.writeEvent(create(Event.triggerExecution(wfi, NATURAL_TRIGGER), 0L, ms("07:00:00")));
-    storage.writeEvent(create(Event.created(wfi, "exec", "img", "commitSha"), 1L, ms("07:00:01")));
+    storage.writeEvent(create(Event.created(wfi, "exec", "img"), 1L, ms("07:00:01")));
     storage.writeEvent(create(Event.started(wfi), 2L, ms("07:00:02")));
 
     Response<ByteString> response =
@@ -371,7 +371,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     WorkflowInstance wfi = WorkflowInstance.create(WORKFLOW.id(), "2016-08-10");
     storage.writeEvent(create(Event.triggerExecution(wfi, NATURAL_TRIGGER), 0L, ms("07:00:00")));
-    storage.writeEvent(create(Event.created(wfi, "exec", "img", "commitSha"), 1L, ms("07:00:01")));
+    storage.writeEvent(create(Event.created(wfi, "exec", "img"), 1L, ms("07:00:01")));
     storage.writeEvent(create(Event.started(wfi), 2L, ms("07:00:02")));
 
     Response<ByteString> response =

--- a/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/EventVisitor.java
@@ -51,11 +51,11 @@ public interface EventVisitor<R> {
   R timeout(@Getter WorkflowInstance workflowInstance);
   R halt(@Getter WorkflowInstance workflowInstance);
 
+  // Note: Do not make changes to these deprecated event method signatures
   @Deprecated
   R timeTrigger(@Getter WorkflowInstance workflowInstance);
   @Deprecated
-  R created(@Getter WorkflowInstance workflowInstance, String executionId, String dockerImage,
-      @Nullable String commitSha);
+  R created(@Getter WorkflowInstance workflowInstance, String executionId, String dockerImage);
   @Deprecated
   R retry(@Getter WorkflowInstance workflowInstance);
 }

--- a/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/data/WFIExecutionBuilder.java
@@ -112,11 +112,10 @@ class WFIExecutionBuilder {
     }
 
     @Override
-    public Void created(WorkflowInstance workflowInstance, String executionId, String dockerImage, String commitSha) {
+    public Void created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
       currWorkflowInstance = workflowInstance;
       currExecutionId = executionId;
       currDockerImg = dockerImage;
-      currCommitSha = commitSha;
 
       executionStatusList.add(ExecStatus.create(eventTs, "SUBMITTED", Optional.empty()));
       return null;

--- a/styx-common/src/main/java/com/spotify/styx/serialization/PersistentEvent.java
+++ b/styx-common/src/main/java/com/spotify/styx/serialization/PersistentEvent.java
@@ -86,9 +86,8 @@ class PersistentEvent {
     }
 
     @Override
-    public PersistentEvent created(WorkflowInstance workflowInstance, String executionId,
-        String dockerImage, String commitSha) {
-      return new Created(workflowInstance.toKey(), executionId, Optional.of(dockerImage), Optional.of(commitSha));
+    public PersistentEvent created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
+      return new Created(workflowInstance.toKey(), executionId, Optional.of(dockerImage));
     }
 
     @Override
@@ -235,23 +234,20 @@ class PersistentEvent {
 
     public final String executionId;
     public final String dockerImage;
-    public final String commitSha;
 
     @JsonCreator
     public Created(
         @JsonProperty("workflow_instance") String workflowInstance,
         @JsonProperty("execution_id") String executionId,
-        @JsonProperty("docker_image") Optional<String> dockerImage,
-        @JsonProperty("commit_sha") Optional<String> commitSha ) {
+        @JsonProperty("docker_image") Optional<String> dockerImage) {
       super("created", workflowInstance);
       this.executionId = executionId;
       this.dockerImage = dockerImage.orElse("UNKNOWN");
-      this.commitSha = commitSha.orElse("UNKNOWN");
     }
 
     @Override
     public Event toEvent() {
-      return Event.created(WorkflowInstance.parseKey(workflowInstance), executionId, dockerImage, commitSha);
+      return Event.created(WorkflowInstance.parseKey(workflowInstance), executionId, dockerImage);
     }
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/state/RunState.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/RunState.java
@@ -158,7 +158,7 @@ public abstract class RunState {
     @Deprecated
     @Override
     public RunState created(WorkflowInstance workflowInstance, String executionId,
-        String dockerImage, String commitSha) {
+        String dockerImage) {
       switch (state()) {
         case PREPARE:
         case QUEUED:
@@ -167,7 +167,6 @@ public abstract class RunState {
               data().builder()
                   .executionId(executionId)
                   .executionDescription(ExecutionDescription.forImage(dockerImage))
-                  .commitSha(commitSha)
                   .tries(data().tries() + 1)
                   .build());
 

--- a/styx-common/src/main/java/com/spotify/styx/util/EventUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/EventUtil.java
@@ -69,8 +69,8 @@ public final class EventUtil {
     }
 
     @Override
-    public String created(WorkflowInstance workflowInstance, String executionId, String dockerImage, String commitSha) {
-      return String.format("Execution id: %s, Docker image: %s,  Commit sha: %s ", executionId, dockerImage, commitSha);
+    public String created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
+      return String.format("Execution id: %s, Docker image: %s", executionId, dockerImage);
     }
 
     @Override
@@ -163,7 +163,7 @@ public final class EventUtil {
 
     @Override
     public String created(WorkflowInstance workflowInstance, String executionId,
-        String dockerImage, String commitSha) {
+        String dockerImage) {
       return "created";
     }
 

--- a/styx-common/src/test/java/com/spotify/styx/WorkflowInstanceEventFactory.java
+++ b/styx-common/src/test/java/com/spotify/styx/WorkflowInstanceEventFactory.java
@@ -48,8 +48,8 @@ public class WorkflowInstanceEventFactory {
     return Event.info(workflowInstance, message);
   }
 
-  public Event created(String executionId, String dockerImage, String commitSha) {
-    return Event.created(workflowInstance, executionId, dockerImage, commitSha);
+  public Event created(String executionId, String dockerImage) {
+    return Event.created(workflowInstance, executionId, dockerImage);
   }
 
   public Event dequeue(Set<String> resourceIds) {

--- a/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
@@ -118,7 +118,7 @@ public class PersistentEventTest {
         is(Event.submitted(INSTANCE1, POD_NAME)));
     assertThat(
         deserializeEvent(json("created", "\"execution_id\":\"" + POD_NAME + "\",\"docker_image\":\"" + DOCKER_IMAGE
-            + "\",\"commit_sha\":\"" + COMMIT_SHA + "\"")),
+            + "\"")),
         is(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE)));
     assertThat(
         deserializeEvent(json("runError", "\"message\":\"ErrorMessage\"")),

--- a/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/PersistentEventTest.java
@@ -63,7 +63,7 @@ public class PersistentEventTest {
     assertRoundtrip(Event.timeTrigger(INSTANCE1));
     assertRoundtrip(Event.triggerExecution(INSTANCE1, UNKNOWN_TRIGGER));
     assertRoundtrip(Event.info(INSTANCE1, Message.info("InfoMessage")));
-    assertRoundtrip(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE, COMMIT_SHA));
+    assertRoundtrip(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE));
     assertRoundtrip(Event.dequeue(INSTANCE1, ImmutableSet.of("some-resource")));
     assertRoundtrip(Event.dequeue(INSTANCE1, ImmutableSet.of()));
     assertRoundtrip(Event.started(INSTANCE1));
@@ -119,7 +119,7 @@ public class PersistentEventTest {
     assertThat(
         deserializeEvent(json("created", "\"execution_id\":\"" + POD_NAME + "\",\"docker_image\":\"" + DOCKER_IMAGE
             + "\",\"commit_sha\":\"" + COMMIT_SHA + "\"")),
-        is(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE, COMMIT_SHA)));
+        is(Event.created(INSTANCE1, POD_NAME, DOCKER_IMAGE)));
     assertThat(
         deserializeEvent(json("runError", "\"message\":\"ErrorMessage\"")),
         is(Event.runError(INSTANCE1, "ErrorMessage")));
@@ -150,7 +150,7 @@ public class PersistentEventTest {
         is(Event.started(INSTANCE1))); // for backwards compatibility
     assertThat(
         deserializeEvent(json("created", "\"execution_id\":\"" + POD_NAME + "\"")),
-        is(Event.created(INSTANCE1, POD_NAME, "UNKNOWN", "UNKNOWN")));
+        is(Event.created(INSTANCE1, POD_NAME, "UNKNOWN")));
     assertThat(
         deserializeEvent(json("triggerExecution")),
         is(Event.triggerExecution(INSTANCE1, TRIGGER_UNKNOWN)));

--- a/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/state/RunStateTest.java
@@ -216,7 +216,7 @@ public class RunStateTest {
   public void testSetExecutionId() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(RUNNING));
@@ -227,7 +227,7 @@ public class RunStateTest {
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retryAfter(999));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_2, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_2, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(RUNNING));
@@ -267,7 +267,7 @@ public class RunStateTest {
   public void testSetsRetryDelay() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retryAfter(777));
 
@@ -275,7 +275,7 @@ public class RunStateTest {
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().retryDelayMillis(), hasValue(777L));
 
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retryAfter(999));
@@ -311,10 +311,10 @@ public class RunStateTest {
   public void testRetryFromRunError() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
 
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTED));
@@ -327,13 +327,13 @@ public class RunStateTest {
   public void testManyRetriesFromRunError() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().tries(), equalTo(3));
@@ -346,12 +346,12 @@ public class RunStateTest {
   public void testMissingDependenciesAddsToCost() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(RunState.MISSING_DEPS_EXIT_CODE));
     transitioner.receive(eventFactory.retryAfter(0));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(RunState.MISSING_DEPS_EXIT_CODE));
 
@@ -366,12 +366,12 @@ public class RunStateTest {
   public void testMissingDependenciesIncrementsTries() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(RunState.MISSING_DEPS_EXIT_CODE));
     transitioner.receive(eventFactory.retryAfter(0));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(RunState.MISSING_DEPS_EXIT_CODE));
 
@@ -386,12 +386,12 @@ public class RunStateTest {
   public void testErrorsAddsToCost() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retryAfter(0));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
 
@@ -405,7 +405,7 @@ public class RunStateTest {
   public void testFatalFromRunError() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.stop());
 
@@ -418,7 +418,7 @@ public class RunStateTest {
   public void testSuccessFromTerm() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(0));
     transitioner.receive(eventFactory.success());
@@ -434,11 +434,11 @@ public class RunStateTest {
   public void testRetryFromTerm() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().tries(), equalTo(2));
@@ -451,15 +451,15 @@ public class RunStateTest {
   public void testManyRetriesFromTerm() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(7));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().tries(), equalTo(3));
@@ -473,7 +473,7 @@ public class RunStateTest {
   public void testFatalFromTerm() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.stop());
@@ -488,11 +488,11 @@ public class RunStateTest {
   public void testRetryFromStartedThenRunError() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(SUBMITTED));
     assertThat(transitioner.get(WORKFLOW_INSTANCE).data().tries(), equalTo(2));
@@ -504,7 +504,7 @@ public class RunStateTest {
   public void testFatalFromStartedThenRunError() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.stop());
@@ -518,7 +518,7 @@ public class RunStateTest {
   public void testFailedFromTimeout() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.timeout());
 
@@ -532,13 +532,13 @@ public class RunStateTest {
   public void testRetriggerOfPartition() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.runError(TEST_ERROR_MESSAGE));
     transitioner.receive(eventFactory.stop());
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_2, DOCKER_IMAGE, COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_2, DOCKER_IMAGE));
     transitioner.receive(eventFactory.started());
 
     assertThat(transitioner.get(WORKFLOW_INSTANCE).state(), equalTo(RUNNING));
@@ -603,7 +603,7 @@ public class RunStateTest {
   public void testStoresExecutedDockerImage() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE + "1", COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE + "1"));
 
     assertThat(
         transitioner.get(WORKFLOW_INSTANCE).data().executionDescription().get().dockerImage(),
@@ -614,11 +614,11 @@ public class RunStateTest {
   public void testStoresLastExecutedDockerImage() throws Exception {
     transitioner.initialize(RunState.fresh(WORKFLOW_INSTANCE));
     transitioner.receive(eventFactory.triggerExecution(UNKNOWN_TRIGGER));
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE + "1", COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE + "1"));
     transitioner.receive(eventFactory.started());
     transitioner.receive(eventFactory.terminate(1));
     transitioner.receive(eventFactory.retry());
-    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE + "2", COMMIT_SHA));
+    transitioner.receive(eventFactory.created(TEST_EXECUTION_ID_1, DOCKER_IMAGE + "2"));
 
     assertThat(
         transitioner.get(WORKFLOW_INSTANCE).data().executionDescription().get().dockerImage(),

--- a/styx-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
@@ -81,7 +81,7 @@ public class BigTableStorageTest {
   public void shouldReturnExecutionDataForWorkflowInstance() throws Exception {
     setUp(0);
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI1, TRIGGER), 0L, 0L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId", "img", "commitsha"), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId", "img"), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI1), 2L, 2L));
 
     WorkflowInstanceExecutionData workflowInstanceExecutionData = storage.executionData(WFI1);
@@ -98,11 +98,11 @@ public class BigTableStorageTest {
   public void shouldReturnExecutionDataForWorkflow() throws Exception {
     setUp(0);
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI1, TRIGGER1), 0L, 0L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1", "commitsha1"), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1"), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI1), 2L, 2L));
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI2, TRIGGER2), 0L, 3L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2", "commitsha2"), 1L, 4L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2"), 1L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI2), 2L, 5L));
 
     List<WorkflowInstanceExecutionData> workflowInstanceExecutionData =
@@ -158,11 +158,11 @@ public class BigTableStorageTest {
   public void shouldReturnRangeOfExecutionDataForWorkflow() throws Exception {
     setUp(0);
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI1, TRIGGER1), 0L, 0L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1", "commitsha1"), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1"), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI1), 2L, 2L));
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI2, TRIGGER2), 0L, 3L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2", "commitsha2"), 1L, 4L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2"), 1L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI2), 2L, 5L));
 
     List<WorkflowInstanceExecutionData> workflowInstanceExecutionData =
@@ -190,11 +190,11 @@ public class BigTableStorageTest {
   public void shouldReturnExecutionDataForOneWorkflow() throws Exception {
     setUp(0);
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI1, TRIGGER1), 0L, 0L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1", "commitsha1"), 1L, 1L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI1, "execId1", "img1"), 1L, 1L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI1), 2L, 2L));
 
     storage.writeEvent(SequenceEvent.create(Event.triggerExecution(WFI2, TRIGGER2), 0L, 3L));
-    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2", "commitsha2"), 1L, 4L));
+    storage.writeEvent(SequenceEvent.create(Event.created(WFI2, "execId2", "img2"), 1L, 4L));
     storage.writeEvent(SequenceEvent.create(Event.started(WFI2), 2L, 5L));
 
     List<WorkflowInstanceExecutionData> workflowInstanceExecutionData =

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -727,8 +727,7 @@ class KubernetesDockerRunner implements DockerRunner {
     }
 
     @Override
-    public Boolean created(WorkflowInstance workflowInstance, String executionId,
-        String dockerImage, String commitSha) {
+    public Boolean created(WorkflowInstance workflowInstance, String executionId, String dockerImage) {
       return false;
     }
 


### PR DESCRIPTION
There are no existing `created` records with `commitSha` and the event is no longer emitted.