### PR TITLE
Backfill status performance improvement

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -164,9 +164,12 @@ public class StyxApi implements AppInit {
         new WorkflowValidator(new DockerImageValidator()),
         new WorkflowInitializer(storage, time),
         workflowConsumer);
+
     final BackfillResource backfillResource = new BackfillResource(schedulerServiceBaseUrl,
         storage,
         new WorkflowValidator(new DockerImageValidator()));
+    environment.closer().register(backfillResource);
+
     final ShardedCounter shardedCounter = new ShardedCounter(storage, new ShardedCounterSnapshotFactory(storage));
     final ResourceResource resourceResource = new ResourceResource(storage, shardedCounter);
     final StatusResource statusResource = new StatusResource(storage);

--- a/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
@@ -386,7 +386,7 @@ public final class BackfillResource implements Closeable {
     final List<RunStateData> processedStates;
     final List<RunStateData> waitingStates;
 
-   final Map<WorkflowInstance, RunState> activeWorkflowInstances;
+    final Map<WorkflowInstance, RunState> activeWorkflowInstances;
     try {
       activeWorkflowInstances = storage.readActiveStatesByTriggerId(backfill.id());
     } catch (IOException e) {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
@@ -388,6 +388,8 @@ public final class BackfillResource implements Closeable {
 
     final Map<WorkflowInstance, RunState> activeWorkflowInstances;
     try {
+      // this is weakly consistent and is tolerable in this case because no critical action
+      // depends on this
       activeWorkflowInstances = storage.readActiveStatesByTriggerId(backfill.id());
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -152,13 +152,10 @@ public class BackfillResourceTest extends VersionedApiTest {
   @Override
   protected void init(Environment environment) {
     storage = new AggregateStorage(bigtable, localDatastore.getOptions().getService(),
-        Duration.ZERO);
+                                   Duration.ZERO);
 
-    final BackfillResource backfillResource =
-        new BackfillResource(SCHEDULER_BASE, storage, workflowValidator);
     environment.routingEngine()
-        .registerRoutes(backfillResource.routes());
-    environment.closer().register(backfillResource);
+        .registerRoutes(new BackfillResource(SCHEDULER_BASE, storage, workflowValidator).routes());
   }
 
   @BeforeClass
@@ -245,7 +242,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeBackfill(BACKFILL_4.builder().allTriggered(true).build());
 
     final String uri = path(String.format("?showAll=true&component=%s",
-        BACKFILL_4.workflowId().componentId()));
+                                          BACKFILL_4.workflowId().componentId()));
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("GET", uri));
 
@@ -260,7 +257,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeBackfill(BACKFILL_4);
 
     final String uri = path(String.format("?component=%s",
-        BACKFILL_1.workflowId().componentId()));
+                                          BACKFILL_1.workflowId().componentId()));
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("GET", uri));
 
@@ -276,7 +273,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeBackfill(BACKFILL_4);
 
     final String uri = path(String.format("?workflow=%s",
-        BACKFILL_1.workflowId().id()));
+                                          BACKFILL_1.workflowId().id()));
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("GET", uri));
 
@@ -293,8 +290,8 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.storeBackfill(BACKFILL_4);
 
     final String uri = path(String.format("?component=%s&workflow=%s",
-        BACKFILL_1.workflowId().componentId(),
-        BACKFILL_1.workflowId().id()));
+                                          BACKFILL_1.workflowId().componentId(),
+                                          BACKFILL_1.workflowId().id()));
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("GET", uri));
 
@@ -326,7 +323,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     assertThat(response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
     assertJson(response, "backfills", hasSize(2));
   }
-  @Test
+   @Test
   public void shouldListMultipleBackfills() throws Exception {
     sinceVersion(Api.Version.V3);
 
@@ -477,7 +474,7 @@ public class BackfillResourceTest extends VersionedApiTest {
         awaitResponse(serviceHelper.request("POST", path(""), ByteString.encodeUtf8(json)));
 
     assertThat(response.status().reasonPhrase(),
-        response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+               response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
     Backfill postedBackfill = Json.OBJECT_MAPPER.readValue(
         response.payload().get().toByteArray(), Backfill.class);
     assertThat(postedBackfill.id().matches("backfill-[\\d-]+"), is(true));
@@ -539,7 +536,7 @@ public class BackfillResourceTest extends VersionedApiTest {
         awaitResponse(serviceHelper.request("POST", path(""), ByteString.encodeUtf8(json)));
 
     assertThat(response.status().reasonPhrase(),
-        response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+               response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
     Backfill postedBackfill = Json.OBJECT_MAPPER.readValue(
         response.payload().get().toByteArray(), Backfill.class);
     assertThat(postedBackfill.id().matches("backfill-[\\d-]+"), is(true));
@@ -568,7 +565,7 @@ public class BackfillResourceTest extends VersionedApiTest {
         awaitResponse(serviceHelper.request("POST", path(""), ByteString.encodeUtf8(json)));
 
     assertThat(response.status().reasonPhrase(),
-        response, hasStatus(belongsToFamily(StatusType.Family.CLIENT_ERROR)));
+               response, hasStatus(belongsToFamily(StatusType.Family.CLIENT_ERROR)));
   }
 
   @Test
@@ -592,7 +589,7 @@ public class BackfillResourceTest extends VersionedApiTest {
         awaitResponse(serviceHelper.request("POST", path(""), Json.serialize(backfillInput)));
 
     assertThat(response.status().reasonPhrase(),
-        response, hasStatus(belongsToFamily(StatusType.Family.CLIENT_ERROR)));
+               response, hasStatus(belongsToFamily(StatusType.Family.CLIENT_ERROR)));
   }
 
   @Test
@@ -613,7 +610,7 @@ public class BackfillResourceTest extends VersionedApiTest {
             ByteString.encodeUtf8(json)));
 
     assertThat(response.status().reasonPhrase(),
-        response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+               response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
     assertJson(response, "id", equalTo(BACKFILL_1.id()));
     assertJson(response, "concurrency", equalTo(4));
     assertJson(response, "description", is("foobar"));
@@ -742,7 +739,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("DELETE", path("/" + BACKFILL_1.id())));
     assertThat(response.status().reasonPhrase(),
-        response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
+               response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
 
     assertThat(storage.backfill(BACKFILL_1.id()).get().halted(), equalTo(true));
     verify(serviceHelper.stubClient(), times(1)).send(any());
@@ -753,13 +750,13 @@ public class BackfillResourceTest extends VersionedApiTest {
     sinceVersion(Api.Version.V3);
 
     serviceHelper.stubClient().respond(Responses.sequence(ImmutableList.of(ResponseWithDelay
-            .forResponse(Response
-                .forStatus(
-                    Status.INTERNAL_SERVER_ERROR)),
-        ResponseWithDelay
-            .forResponse(Response
-                .forStatus(
-                    Status.ACCEPTED)))))
+                                                                               .forResponse(Response
+                                                                                                .forStatus(
+                                                                                                    Status.INTERNAL_SERVER_ERROR)),
+                                                                           ResponseWithDelay
+                                                                               .forResponse(Response
+                                                                                                .forStatus(
+                                                                                                    Status.ACCEPTED)))))
         .to(SCHEDULER_BASE + "/api/v0/events");
 
     WorkflowInstance wfi1 = WorkflowInstance.create(BACKFILL_1.workflowId(), "2017-01-01T01");
@@ -786,7 +783,7 @@ public class BackfillResourceTest extends VersionedApiTest {
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("DELETE", path("/" + BACKFILL_1.id())));
     assertThat(response.status().reasonPhrase(),
-        response, hasStatus(belongsToFamily(StatusType.Family.SERVER_ERROR)));
+               response, hasStatus(belongsToFamily(StatusType.Family.SERVER_ERROR)));
 
     assertThat(storage.backfill(BACKFILL_1.id()).get().halted(), equalTo(true));
     verify(serviceHelper.stubClient(), times(2)).send(any());
@@ -801,10 +798,10 @@ public class BackfillResourceTest extends VersionedApiTest {
 
     Response<ByteString> response =
         awaitResponse(serviceHelper.request("PUT", path("/wrong-id"),
-            ByteString.encodeUtf8(json)));
+                                            ByteString.encodeUtf8(json)));
 
     assertThat(response.status().reasonPhrase(),
-        response, hasStatus(belongsToFamily(StatusType.Family.CLIENT_ERROR)));
+               response, hasStatus(belongsToFamily(StatusType.Family.CLIENT_ERROR)));
   }
 
   @Test
@@ -812,10 +809,10 @@ public class BackfillResourceTest extends VersionedApiTest {
     sinceVersion(Api.Version.V3);
 
     final String json = "{\"start\":\"2017-01-01T00:00:00Z\"," +
-                        "\"end\":\"2017-02-01T00:00:00Z\"," +
-                        "\"component\":\"component\"," +
-                        "\"workflow\":\"workflow2\","+
-                        "\"concurrency\":1}";
+        "\"end\":\"2017-02-01T00:00:00Z\"," +
+        "\"component\":\"component\"," +
+        "\"workflow\":\"workflow2\","+
+        "\"concurrency\":1}";
 
     when(workflowValidator.validateWorkflow(any())).thenReturn(ImmutableList.of("bad", "f00d"));
 
@@ -831,10 +828,10 @@ public class BackfillResourceTest extends VersionedApiTest {
     sinceVersion(Api.Version.V3);
 
     final String json = "{\"start\":\"2017-01-01T00:00:00Z\"," +
-                        "\"end\":\"2017-02-01T00:00:00Z\"," +
-                        "\"component\":\"other_component\"," +
-                        "\"workflow\":\"other_workflow\","+
-                        "\"concurrency\":1}";
+        "\"end\":\"2017-02-01T00:00:00Z\"," +
+        "\"component\":\"other_component\"," +
+        "\"workflow\":\"other_workflow\","+
+        "\"concurrency\":1}";
 
     final Response<ByteString> response = awaitResponse(
         serviceHelper.request("POST", path(""), ByteString.encodeUtf8(json)));

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -154,8 +154,11 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage = new AggregateStorage(bigtable, localDatastore.getOptions().getService(),
         Duration.ZERO);
 
+    final BackfillResource backfillResource =
+        new BackfillResource(SCHEDULER_BASE, storage, workflowValidator);
     environment.routingEngine()
-        .registerRoutes(new BackfillResource(SCHEDULER_BASE, storage, workflowValidator).routes());
+        .registerRoutes(backfillResource.routes());
+    environment.closer().register(backfillResource);
   }
 
   @BeforeClass

--- a/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
@@ -27,7 +27,6 @@ import com.spotify.styx.state.RunState;
 import com.spotify.styx.storage.Storage;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Map;
 import java.util.Optional;
 import java.util.SortedSet;
 
@@ -40,7 +39,6 @@ public final class ReplayEvents {
   // TODO: fix NPath complexity
   public static Optional<RunState> getBackfillRunState(
       WorkflowInstance workflowInstance,
-      Map<WorkflowInstance, RunState> activeWorkflowInstances,
       Storage storage,
       String backfillId) {
     final SettableTime time = new SettableTime();
@@ -59,10 +57,7 @@ public final class ReplayEvents {
 
     RunState restoredState = RunState.fresh(workflowInstance, time);
 
-    final long lastConsumedEvent =
-        Optional.ofNullable(activeWorkflowInstances.get(workflowInstance))
-            .map(RunState::counter)
-            .orElse(sequenceEvents.last().counter());
+    final long lastConsumedEvent = sequenceEvents.last().counter();
 
     for (SequenceEvent sequenceEvent : sequenceEvents) {
       // The active state event counters are read before the events themselves and styx is 

--- a/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
@@ -32,16 +32,12 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableMap;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.SequenceEvent;
 import com.spotify.styx.state.RunState;
-import com.spotify.styx.state.RunState.State;
-import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.Storage;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.Optional;
 import java.util.SortedSet;
 import junitparams.JUnitParamsRunner;
@@ -73,7 +69,6 @@ public class ReplayEventsTest {
 
     RunState restoredRunState = ReplayEvents.getBackfillRunState(
         WORKFLOW_INSTANCE,
-        ImmutableMap.of(WORKFLOW_INSTANCE, RunState.create(WORKFLOW_INSTANCE, State.RUNNING, StateData.zero(), Instant.now(), 6L)),
         storage, "bf-1").get();
 
     assertThat(restoredRunState.state(), is(RUNNING));
@@ -98,7 +93,7 @@ public class ReplayEventsTest {
     when(storage.readEvents(WORKFLOW_INSTANCE)).thenReturn(events);
 
     RunState restoredRunState =
-        ReplayEvents.getBackfillRunState(WORKFLOW_INSTANCE, ImmutableMap.of(), storage, "bf-1").get();
+        ReplayEvents.getBackfillRunState(WORKFLOW_INSTANCE, storage, "bf-1").get();
 
     assertThat(restoredRunState.state(), is(DONE));
     assertThat(restoredRunState.data().lastExit(), isPresent());
@@ -115,7 +110,6 @@ public class ReplayEventsTest {
 
     Optional<RunState> restoredRunState = ReplayEvents.getBackfillRunState(
         WORKFLOW_INSTANCE,
-        ImmutableMap.of(WORKFLOW_INSTANCE, RunState.create(WORKFLOW_INSTANCE, State.PREPARE, StateData.zero(), Instant.now(), 2L)),
         storage, "erroneous-id");
 
     assertThat(restoredRunState, is(Optional.empty()));

--- a/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
@@ -107,14 +107,14 @@ public class ReplayEventsTest {
 
   @Test
   public void throwExceptionWhenFailedToReadEvents() throws Exception {
-    IOException exception = new IOException("forced failure");
+    IOException exception = new IOException();
     when(storage.readEvents(WORKFLOW_INSTANCE)).thenThrow(exception);
 
     try {
       ReplayEvents.getBackfillRunState(WORKFLOW_INSTANCE, storage, "bf-1");
       fail();
     } catch (RuntimeException e) {
-      assertThat(e.getCause().getMessage(), is("forced failure"));
+      assertThat(e.getCause(), is(exception));
     }
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
@@ -28,6 +28,7 @@ import static com.spotify.styx.testdata.TestData.RESOURCE_IDS;
 import static com.spotify.styx.testdata.TestData.WORKFLOW_INSTANCE;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -111,6 +112,7 @@ public class ReplayEventsTest {
 
     try {
       ReplayEvents.getBackfillRunState(WORKFLOW_INSTANCE, storage, "bf-1");
+      fail();
     } catch (RuntimeException e) {
       assertThat(e.getCause().getMessage(), is("forced failure"));
     }

--- a/styx-test/pom.xml
+++ b/styx-test/pom.xml
@@ -38,9 +38,5 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
     </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/styx-test/pom.xml
+++ b/styx-test/pom.xml
@@ -38,5 +38,9 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
* read active states by backfill trigger id
* skip replaying of running workflow instances
* parallel stream -> fork join pool