### PR TITLE
k8s: optimize watcher

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/GrpcContextUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/GrpcContextUtil.java
@@ -1,0 +1,94 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.util;
+
+import io.grpc.Context;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.TimeUnit;
+
+public class GrpcContextUtil {
+
+  private GrpcContextUtil() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * A variant of {@link Context#currentContextExecutor(Executor)} for {@link ExecutorService}s.
+   */
+  public static ExecutorService currentContextExecutorService(ExecutorService executorService) {
+    return new CurrentContextExecutorService(executorService);
+  }
+
+  private static class CurrentContextExecutorService extends AbstractExecutorService {
+
+    private final ExecutorService executorService;
+
+    CurrentContextExecutorService(ExecutorService executorService) {
+      this.executorService = Objects.requireNonNull(executorService, "executorService");
+    }
+
+    @Override
+    public void shutdown() {
+      executorService.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return executorService.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return executorService.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return executorService.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+      return executorService.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+      executorService.execute(Context.current().wrap(command));
+    }
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
+      return super.newTaskFor(Context.current().wrap(runnable), value);
+    }
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(Callable<T> callable) {
+      return super.newTaskFor(Context.current().wrap(callable));
+    }
+  }
+}

--- a/styx-common/src/test/java/com/spotify/styx/util/GrpcContextUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/GrpcContextUtilTest.java
@@ -1,0 +1,166 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.util;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableList;
+import io.grpc.Context;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GrpcContextUtilTest {
+
+  private static final Context.Key<String> TEST_KEY = Context.key("test");
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+
+  @Mock ExecutorService executorService;
+
+  private final ExecutorService sut = GrpcContextUtil.currentContextExecutorService(Executors.newCachedThreadPool());
+
+  @Test
+  public void shouldForward() throws InterruptedException {
+    final ExecutorService mockSut = GrpcContextUtil.currentContextExecutorService(executorService);
+    mockSut.shutdown();
+    verify(executorService).shutdown();
+    mockSut.shutdownNow();
+    verify(executorService).shutdownNow();
+    mockSut.isShutdown();
+    verify(executorService).isShutdown();
+    mockSut.isTerminated();
+    verify(executorService).isTerminated();
+    mockSut.awaitTermination(7, TimeUnit.HOURS);
+    verify(executorService).awaitTermination(7, TimeUnit.HOURS);
+  }
+
+  @Test
+  public void executeShouldPropagateContext() throws Exception {
+    final CompletableFuture<String> value = new CompletableFuture<>();
+    final Runnable runnable = () -> value.complete(TEST_KEY.get());
+    Context.current().withValue(TEST_KEY, "foobar")
+        .run(() -> sut.execute(runnable));
+    assertThat(value.get(30, SECONDS), is("foobar"));
+  }
+
+  @Test
+  public void submitRunnableShouldPropagateContext() throws Exception {
+    final CompletableFuture<String> value = new CompletableFuture<>();
+    final Runnable runnable = () -> value.complete(TEST_KEY.get());
+    Context.current().withValue(TEST_KEY, "foobar")
+        .run(() -> sut.submit(runnable));
+    assertThat(value.get(30, SECONDS), is("foobar"));
+  }
+
+  @Test
+  public void submitRunnableWithValueShouldPropagateContext() throws Exception {
+    final CompletableFuture<String> value = new CompletableFuture<>();
+    final Runnable runnable = () -> value.complete(TEST_KEY.get());
+    Context.current().withValue(TEST_KEY, "foobar")
+        .run(() -> sut.submit(runnable, "quux"));
+    assertThat(value.get(30, SECONDS), is("foobar"));
+  }
+
+  @Test
+  public void submitCallableShouldPropagateContext() throws Exception {
+    final Callable<String> callable = TEST_KEY::get;
+    final Future<String> value = Context.current().withValue(TEST_KEY, "foobar")
+        .call(() -> sut.submit(callable));
+    assertThat(value.get(30, SECONDS), is("foobar"));
+  }
+
+  @Test
+  public void invokeAllShouldPropagateContext() throws Exception {
+    final Callable<String> callable = TEST_KEY::get;
+    final List<Future<String>> futures = Context.current().withValue(TEST_KEY, "foobar")
+        .call(() -> sut.invokeAll(ImmutableList.of(callable)));
+    assertThat(futures.get(0).get(30, SECONDS), is("foobar"));
+  }
+
+  @Test
+  public void invokeAllWithTimeoutShouldPropagateContext() throws Exception {
+    final Callable<String> callable = TEST_KEY::get;
+    final List<Future<String>> futures = Context.current().withValue(TEST_KEY, "foobar")
+        .call(() -> sut.invokeAll(ImmutableList.of(callable), 30, SECONDS));
+    assertThat(futures.get(0).get(30, SECONDS), is("foobar"));
+  }
+
+  @Test
+  public void invokeAnyShouldPropagateContext() throws Exception {
+    final Callable<String> callable = TEST_KEY::get;
+    final String result = Context.current().withValue(TEST_KEY, "foobar")
+        .call(() -> sut.invokeAny(ImmutableList.of(callable)));
+    assertThat(result, is("foobar"));
+  }
+
+  @Test
+  public void invokeAnyWithTimeoutShouldPropagateContext() throws Exception {
+    final Callable<String> callable = TEST_KEY::get;
+    final String result = Context.current().withValue(TEST_KEY, "foobar")
+        .call(() -> sut.invokeAny(ImmutableList.of(callable), 30, SECONDS));
+    assertThat(result, is("foobar"));
+  }
+
+  @Test
+  public void shouldPropagateContextForCfRunAsync() throws Exception {
+    final CompletableFuture<String> value = new CompletableFuture<>();
+    final Runnable runnable = () -> value.complete(TEST_KEY.get());
+    Context.current().withValue(TEST_KEY, "foobar")
+        .run(() -> CompletableFuture.runAsync(runnable, sut));
+    assertThat(value.get(30, SECONDS), is("foobar"));
+  }
+
+  @Test
+  public void shouldPropagateContextForCfSupplyAsync() throws Exception {
+    final Supplier<String> get = TEST_KEY::get;
+    final CompletableFuture<String> cf = Context.current().withValue(TEST_KEY, "foobar")
+        .call(() -> CompletableFuture.supplyAsync(get, sut));
+    assertThat(cf.get(30, SECONDS), is("foobar"));
+  }
+
+  @Test
+  public void shouldNotBeConstructable() throws ReflectiveOperationException {
+    final Constructor<GrpcContextUtil> constructor = GrpcContextUtil.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    exception.expect(InvocationTargetException.class);
+    exception.expectCause(instanceOf(UnsupportedOperationException.class));
+    constructor.newInstance();
+  }
+}

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -133,6 +133,7 @@ class KubernetesDockerRunner implements DockerRunner {
   static final String LOGGING = "STYX_LOGGING";
   private static final int DEFAULT_POLL_PODS_INTERVAL_SECONDS = 60;
   private static final int DEFAULT_POD_DELETION_DELAY_SECONDS = 120;
+  private static final long PROCESS_POD_UPDATE_INTERVAL_SECONDS = 5;
   private static final Time DEFAULT_TIME = Instant::now;
   static final String STYX_WORKFLOW_SA_ENV_VARIABLE = "GOOGLE_APPLICATION_CREDENTIALS";
   static final String STYX_WORKFLOW_SA_SECRET_NAME = "styx-wf-sa-keys";
@@ -519,7 +520,8 @@ class KubernetesDockerRunner implements DockerRunner {
         TimeUnit.SECONDS);
 
     final PodWatcher watcher = new PodWatcher();
-    executor.scheduleWithFixedDelay(guard(watcher::processPodUpdates), 0, 5, TimeUnit.SECONDS);
+    executor.scheduleWithFixedDelay(guard(watcher::processPodUpdates),
+        PROCESS_POD_UPDATE_INTERVAL_SECONDS, PROCESS_POD_UPDATE_INTERVAL_SECONDS, TimeUnit.SECONDS);
 
     watch = client.pods().watch(watcher);
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -134,6 +134,7 @@ class KubernetesDockerRunner implements DockerRunner {
   private static final int DEFAULT_POLL_PODS_INTERVAL_SECONDS = 60;
   private static final int DEFAULT_POD_DELETION_DELAY_SECONDS = 120;
   private static final long PROCESS_POD_UPDATE_INTERVAL_SECONDS = 5;
+  private static final int K8S_EVENT_PROCESSING_THREADS = 32;
   private static final Time DEFAULT_TIME = Instant::now;
   static final String STYX_WORKFLOW_SA_ENV_VARIABLE = "GOOGLE_APPLICATION_CREDENTIALS";
   static final String STYX_WORKFLOW_SA_SECRET_NAME = "styx-wf-sa-keys";
@@ -180,7 +181,8 @@ class KubernetesDockerRunner implements DockerRunner {
     this.podDeletionDelaySeconds = podDeletionDelaySeconds;
     this.time = Objects.requireNonNull(time);
     this.executor = register(closer, Objects.requireNonNull(executor), "kubernetes-poll");
-    this.eventExecutor = currentContextExecutorService(register(closer, new ForkJoinPool(32), "kubernetes-event"));
+    this.eventExecutor = currentContextExecutorService(
+        register(closer, new ForkJoinPool(K8S_EVENT_PROCESSING_THREADS), "kubernetes-event"));
   }
 
   KubernetesDockerRunner(NamespacedKubernetesClient client, StateManager stateManager, Stats stats,

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -691,11 +691,12 @@ class KubernetesDockerRunner implements DockerRunner {
 
     private final ConcurrentMap<String, WorkflowInstance> podUpdates = new ConcurrentHashMap<>();
 
+    /**
+     * @implNote In order to be able to keep up with the stream of events from k8s, this method should
+     *           not perform any expensive processing or blocking IO.
+     */
     @Override
     public void eventReceived(Action action, Pod pod) {
-
-      // NOTE: In order to be able to keep up with the stream of events from k8s, this method should
-      //       not perform any expensive processing or blocking IO.
 
       if (pod == null) {
         return;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
@@ -23,7 +23,6 @@ package com.spotify.styx.docker;
 import static com.spotify.styx.docker.DockerRunner.LOG;
 import static com.spotify.styx.docker.KubernetesDockerRunner.DOCKER_TERMINATION_LOGGING_ANNOTATION;
 import static com.spotify.styx.docker.KubernetesDockerRunner.getMainContainerStatus;
-import static java.util.Collections.emptyList;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -40,8 +39,6 @@ import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodStatus;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.Watcher.Action;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -140,13 +137,8 @@ final class KubernetesPodEventTranslator {
   static List<Event> translate(
       WorkflowInstance workflowInstance,
       RunState state,
-      Action action,
       Pod pod,
       Stats stats) {
-
-    if (action == Watcher.Action.DELETED) {
-      return emptyList();
-    }
 
     final List<Event> generatedEvents = Lists.newArrayList();
     final Optional<Event> hasError = isInErrorState(workflowInstance, pod);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -44,7 +44,6 @@ import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.ContainerStatusBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodStatus;
-import io.fabric8.kubernetes.client.Watcher;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -299,22 +298,13 @@ public class KubernetesPodEventTranslatorTest {
     assertGeneratesNoEvents(RunState.State.FAILED, pod);
   }
 
-  @Test
-  public void shouldIgnoreDeletedEvents() {
-    setTerminated(pod, "Succeeded", 0, null);
-    RunState state = RunState.create(WFI, RunState.State.TERMINATED);
-
-    List<Event> events = translate(WFI, state, Watcher.Action.DELETED, pod, Stats.NOOP);
-    assertThat(events, empty());
-  }
-
   private void assertGeneratesEventsAndTransitions(
       RunState.State initialState,
       Pod pod,
       Event... expectedEvents) {
 
     RunState state = RunState.create(WFI, initialState);
-    List<Event> events = translate(WFI, state, Watcher.Action.MODIFIED, pod, Stats.NOOP);
+    List<Event> events = translate(WFI, state, pod, Stats.NOOP);
     assertThat(events, contains(expectedEvents));
 
     // ensure no exceptions are thrown when transitioning
@@ -328,7 +318,7 @@ public class KubernetesPodEventTranslatorTest {
       Pod pod) {
 
     RunState state = RunState.create(WFI, initialState);
-    List<Event> events = translate(WFI, state, Watcher.Action.MODIFIED, pod, Stats.NOOP);
+    List<Event> events = translate(WFI, state, pod, Stats.NOOP);
 
     assertThat(events, empty());
   }


### PR DESCRIPTION
* Make pod watcher asynchronous to avoid falling behind and getting disconnected.
* Let events for a pod coalesce in order to avoid re-processing for each small incremental pod update event.
* Process pod update event batches on the same thread as the poller, eliminate race conditions.
* Parallelize processing of pod update events to defeat IO latency.