### PR TITLE
refactor "Resource limit reached" message handling

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/MessageUtil.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/MessageUtil.java
@@ -1,0 +1,48 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx;
+
+import static java.util.stream.Collectors.toList;
+
+import com.spotify.styx.model.Event;
+import com.spotify.styx.state.Message;
+import com.spotify.styx.state.RunState;
+import com.spotify.styx.state.StateManager;
+import java.util.List;
+
+public class MessageUtil {
+
+  private MessageUtil() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static void emitResourceLimitReachedMessage(StateManager stateManager, RunState runState,
+      List<String> depletedResources) {
+    if (depletedResources.isEmpty()) {
+      throw new IllegalArgumentException();
+    }
+    final List<String> depletedResourcesOrdered = depletedResources.stream().sorted().collect(toList());
+    final Message message = Message.info("Resource limit reached for: " + depletedResourcesOrdered);
+    if (!runState.data().message().map(message::equals).orElse(false)) {
+      stateManager.receiveIgnoreClosed(Event.info(runState.workflowInstance(), message), runState.counter());
+    }
+  }
+}

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -45,7 +45,6 @@ import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.InstanceState;
-import com.spotify.styx.state.Message;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.state.StateManager;
@@ -284,13 +283,8 @@ public class Scheduler {
         .collect(toList());
     if (!depletedResources.isEmpty()) {
       LOG.debug("Resource limit reached for instance, not dequeueing: {}: exhausted resources={}",
-          instanceState.workflowInstance(), depletedResources );
-      final Message message = Message.info(
-          String.format("Resource limit reached for: %s", depletedResources));
-      final RunState runState = instanceState.runState();
-      if (!runState.data().message().map(message::equals).orElse(false)) {
-        stateManager.receiveIgnoreClosed(Event.info(runState.workflowInstance(), message), runState.counter());
-      }
+          instanceState.workflowInstance(), depletedResources);
+      MessageUtil.emitResourceLimitReachedMessage(stateManager, instanceState.runState(), depletedResources);
       return;
     }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/MessageUtilTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/MessageUtilTest.java
@@ -35,6 +35,7 @@ import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -77,5 +78,10 @@ public class MessageUtilTest {
   public void shouldEmitResourceLimitReachedMessage() {
     MessageUtil.emitResourceLimitReachedMessage(stateManager, RUNSTATE_WITH_STALE_MESSAGE, DEPLETED_RESOURCES);
     verify(stateManager).receiveIgnoreClosed(INFO, RUNSTATE_WITH_MESSAGE.counter());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldFailIfNoResources() {
+    MessageUtil.emitResourceLimitReachedMessage(stateManager, RUNSTATE_WITH_STALE_MESSAGE, Collections.emptyList());
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/MessageUtilTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/MessageUtilTest.java
@@ -1,0 +1,81 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx;
+
+import static com.spotify.styx.state.RunState.State.QUEUED;
+import static com.spotify.styx.testdata.TestData.WORKFLOW_INSTANCE;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import com.google.common.collect.ImmutableList;
+import com.spotify.styx.model.Event;
+import com.spotify.styx.state.Message;
+import com.spotify.styx.state.RunState;
+import com.spotify.styx.state.StateData;
+import com.spotify.styx.state.StateManager;
+import java.time.Instant;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MessageUtilTest {
+
+  private static final List<String> DEPLETED_RESOURCES = ImmutableList.of("foo", "bar"); // Unordered
+  private static final Message MESSAGE = Message.info("Resource limit reached for: [bar, foo]");
+  private static final Message STALE_MESSAGE = Message.info("Resource limit reached for: [baz]");
+  private static final Event INFO = Event.info(WORKFLOW_INSTANCE, MESSAGE);
+  private static final StateData DATA_WITH_MESSAGE = StateData.newBuilder()
+      .messages(MESSAGE)
+      .build();
+  private static final StateData DATA_WITH_STALE_MESSAGE = StateData.newBuilder()
+      .messages(STALE_MESSAGE)
+      .build();
+  private static final RunState RUNSTATE_WITH_MESSAGE = RunState.create(
+      WORKFLOW_INSTANCE, QUEUED, DATA_WITH_MESSAGE, Instant.now(), 17);
+  private static final RunState RUNSTATE_WITH_STALE_MESSAGE = RunState.create(
+      WORKFLOW_INSTANCE, QUEUED, DATA_WITH_STALE_MESSAGE, Instant.now(), 17);
+
+  @Mock private StateManager stateManager;
+
+  @Before
+  public void setUp() {
+    assertThat(DEPLETED_RESOURCES.stream().sorted(), is(not(DEPLETED_RESOURCES)));
+  }
+
+  @Test
+  public void shouldNotEmitResourceLimitReachedMessage() {
+    MessageUtil.emitResourceLimitReachedMessage(stateManager, RUNSTATE_WITH_MESSAGE, DEPLETED_RESOURCES);
+    verifyZeroInteractions(stateManager);
+  }
+
+  @Test
+  public void shouldEmitResourceLimitReachedMessage() {
+    MessageUtil.emitResourceLimitReachedMessage(stateManager, RUNSTATE_WITH_STALE_MESSAGE, DEPLETED_RESOURCES);
+    verify(stateManager).receiveIgnoreClosed(INFO, RUNSTATE_WITH_MESSAGE.counter());
+  }
+}


### PR DESCRIPTION
Use same message emission code in both `Scheduler` and
`QueuedStateManager` to ensure that duplicate messages are not emitted.