### PR TITLE
handle datastore exceptions

### DIFF
--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -31,6 +31,8 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -489,6 +491,22 @@ public class BackfillResourceTest extends VersionedApiTest {
     assertThat(response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
     assertJson(response, "backfill.id", equalTo(BACKFILL_1.id()));
     assertNoJson(response, "statuses");
+  }
+
+  @Test
+  public void shouldHandleGetBackfillFailure() throws Exception {
+    sinceVersion(Api.Version.V3);
+    doThrow(new IOException("error!")).when(storage).backfill(BACKFILL_1.id());
+    final Response<ByteString> response = awaitResponse(serviceHelper.request("GET", path("/" + BACKFILL_1.id())));
+    assertThat(response, hasStatus(belongsToFamily(StatusType.Family.SERVER_ERROR)));
+  }
+
+  @Test
+  public void shouldHandleListBackfillsFailure() throws Exception {
+    sinceVersion(Api.Version.V3);
+    doThrow(new IOException("error!")).when(storage).backfills(anyBoolean());
+    final Response<ByteString> response = awaitResponse(serviceHelper.request("GET", path("")));
+    assertThat(response, hasStatus(belongsToFamily(StatusType.Family.SERVER_ERROR)));
   }
 
   @Test

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -52,7 +52,7 @@ public class AggregateStorage implements Storage {
 
   public AggregateStorage(Connection connection, Datastore datastore, Duration retryBaseDelay) {
     this(new BigtableStorage(connection, retryBaseDelay),
-         new DatastoreStorage(datastore, retryBaseDelay));
+         new DatastoreStorage(new CheckedDatastore(datastore), retryBaseDelay));
   }
 
   AggregateStorage(BigtableStorage bigtableStorage, DatastoreStorage datastoreStorage) {
@@ -219,17 +219,17 @@ public class AggregateStorage implements Storage {
   }
 
   @Override
-  public Map<Integer, Long> shardsForCounter(String counterId) {
+  public Map<Integer, Long> shardsForCounter(String counterId) throws IOException {
     return datastoreStorage.shardsForCounter(counterId);
   }
 
   @Override
-  public void deleteShardsForCounter(String counterId) {
+  public void deleteShardsForCounter(String counterId) throws IOException {
     datastoreStorage.deleteShardsForCounter(counterId);
   }
 
   @Override
-  public long getLimitForCounter(String counterId) {
+  public long getLimitForCounter(String counterId) throws IOException {
     return datastoreStorage.getLimitForCounter(counterId);
   }
 
@@ -259,7 +259,7 @@ public class AggregateStorage implements Storage {
   }
 
   @Override
-  public Optional<Backfill> backfill(String id) {
+  public Optional<Backfill> backfill(String id) throws IOException {
     return datastoreStorage.getBackfill(id);
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/CheckedDatastore.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/CheckedDatastore.java
@@ -36,15 +36,25 @@ class CheckedDatastore extends CheckedDatastoreReaderWriter {
 
   private final Datastore datastore;
 
+  /**
+   * Create a new {@link CheckedDatastore} wrapping a {@link Datastore}.
+   */
   CheckedDatastore(Datastore datastore) {
     super(datastore);
     this.datastore = Objects.requireNonNull(datastore);
   }
 
+  /**
+   * @see Datastore#newKeyFactory()
+   */
   KeyFactory newKeyFactory() {
     return datastore.newKeyFactory();
   }
 
+  /**
+   * @see Datastore#newTransaction()
+   * @throws DatastoreIOException if the underlying client throws {@link DatastoreException}
+   */
   CheckedDatastoreTransaction newTransaction() throws DatastoreIOException {
     try {
       return new CheckedDatastoreTransaction(this, datastore.newTransaction());
@@ -53,6 +63,10 @@ class CheckedDatastore extends CheckedDatastoreReaderWriter {
     }
   }
 
+  /**
+   * @see Datastore#allocateId(IncompleteKey)
+   * @throws IOException if the underlying client throws {@link DatastoreException}
+   */
   Key allocateId(IncompleteKey newKey) throws IOException {
     return call(() -> datastore.allocateId(newKey));
   }

--- a/styx-common/src/main/java/com/spotify/styx/storage/CheckedDatastore.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/CheckedDatastore.java
@@ -1,0 +1,59 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.storage;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreException;
+import com.google.cloud.datastore.IncompleteKey;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyFactory;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A wrapper for {@link Datastore} that translates unchecked {@link DatastoreException}s to checked
+ * {@link DatastoreIOException}s.
+ */
+class CheckedDatastore extends CheckedDatastoreReaderWriter {
+
+  private final Datastore datastore;
+
+  CheckedDatastore(Datastore datastore) {
+    super(datastore);
+    this.datastore = Objects.requireNonNull(datastore);
+  }
+
+  KeyFactory newKeyFactory() {
+    return datastore.newKeyFactory();
+  }
+
+  CheckedDatastoreTransaction newTransaction() throws DatastoreIOException {
+    try {
+      return new CheckedDatastoreTransaction(this, datastore.newTransaction());
+    } catch (DatastoreException e) {
+      throw new DatastoreIOException(e);
+    }
+  }
+
+  Key allocateId(IncompleteKey newKey) throws IOException {
+    return call(() -> datastore.allocateId(newKey));
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/storage/CheckedDatastoreReaderWriter.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/CheckedDatastoreReaderWriter.java
@@ -1,0 +1,108 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.storage;
+
+import static com.google.common.collect.Iterables.toArray;
+
+import com.google.cloud.datastore.DatastoreException;
+import com.google.cloud.datastore.DatastoreReaderWriter;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.EntityQuery;
+import com.google.cloud.datastore.FullEntity;
+import com.google.cloud.datastore.Key;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * A wrapper for {@link DatastoreReaderWriter} that translates unchecked {@link DatastoreException}s to checked
+ * {@link DatastoreIOException}s.
+ */
+class CheckedDatastoreReaderWriter {
+
+  private final DatastoreReaderWriter rw;
+
+  CheckedDatastoreReaderWriter(DatastoreReaderWriter rw) {
+    this.rw = Objects.requireNonNull(rw);
+  }
+
+  Entity put(FullEntity<?> entity) throws IOException {
+    return call(() -> rw.put(entity));
+  }
+
+  Entity add(FullEntity<?> entity) throws IOException {
+    return call(() -> rw.add(entity));
+  }
+
+  void update(Entity entity) throws IOException {
+    run(() -> rw.update(entity));
+  }
+
+  Entity get(Key key) throws IOException {
+    return call(() -> rw.get(key));
+  }
+
+  List<Entity> get(Iterable<Key> keys) throws IOException {
+    return call(() -> ImmutableList.copyOf(rw.get(toArray(keys, Key.class))));
+  }
+
+  void get(Iterable<Key> keys, IOConsumer<Entity> f) throws IOException {
+    run(() -> rw.get(toArray(keys, Key.class)).forEachRemaining(IOConsumer.unchecked(f)));
+  }
+
+  List<Entity> query(EntityQuery query) throws IOException {
+    return call(() -> ImmutableList.copyOf(rw.run(query)));
+  }
+
+  void query(EntityQuery query, IOConsumer<Entity> f) throws IOException {
+    run(() -> rw.run(query).forEachRemaining(IOConsumer.unchecked(f)));
+  }
+
+  void delete(Key... keys) throws IOException {
+    run(() -> rw.delete(keys));
+  }
+
+  static <T> T call(Supplier<T> f) throws IOException {
+    try {
+      return f.get();
+    } catch (DatastoreException e) {
+      // Wrap unchecked DatastoreException in a checked DatastoreIOException
+      throw new DatastoreIOException(e);
+    } catch (RuntimeIOException e) {
+      // Propagate IOException from lambda
+      throw e.getCause();
+    }
+  }
+
+  static void run(Runnable f) throws IOException {
+    try {
+      f.run();
+    } catch (DatastoreException e) {
+      // Wrap unchecked DatastoreException in a checked DatastoreIOException
+      throw new DatastoreIOException(e);
+    } catch (RuntimeIOException e) {
+      // Propagate IOException from lambda
+      throw e.getCause();
+    }
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/storage/CheckedDatastoreReaderWriter.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/CheckedDatastoreReaderWriter.java
@@ -25,9 +25,9 @@ import static com.google.common.collect.Iterables.toArray;
 import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.DatastoreReaderWriter;
 import com.google.cloud.datastore.Entity;
-import com.google.cloud.datastore.EntityQuery;
 import com.google.cloud.datastore.FullEntity;
 import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.Query;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
@@ -42,46 +42,99 @@ class CheckedDatastoreReaderWriter {
 
   private final DatastoreReaderWriter rw;
 
+  /**
+   * Create a new {@link CheckedDatastoreReaderWriter} wrapping a {@link DatastoreReaderWriter}.
+   */
   CheckedDatastoreReaderWriter(DatastoreReaderWriter rw) {
     this.rw = Objects.requireNonNull(rw);
   }
 
+  /**
+   * @see DatastoreReaderWriter#put(FullEntity)
+   * @throws IOException if the underlying client throws {@link DatastoreException}
+   */
   Entity put(FullEntity<?> entity) throws IOException {
     return call(() -> rw.put(entity));
   }
 
+  /**
+   * @see DatastoreReaderWriter#add(FullEntity)
+   * @throws IOException if the underlying client throws {@link DatastoreException}
+   */
   Entity add(FullEntity<?> entity) throws IOException {
     return call(() -> rw.add(entity));
   }
 
-  void update(Entity entity) throws IOException {
-    run(() -> rw.update(entity));
+  /**
+   * @see DatastoreReaderWriter#update(Entity...)
+   * @throws IOException if the underlying client throws {@link DatastoreException}
+   */
+  void update(Entity... entites) throws IOException {
+    run(() -> rw.update(entites));
   }
 
+  /**
+   * @see DatastoreReaderWriter#get(Key)
+   * @throws IOException if the underlying client throws {@link DatastoreException}
+   */
   Entity get(Key key) throws IOException {
     return call(() -> rw.get(key));
   }
 
+  /**
+   * Only use this method if the results are small enough that gathering them in list is acceptable.
+   * Otherwise use {@link #get(Iterable, IOConsumer)}.
+   * @see DatastoreReaderWriter#get(Key...)
+   * @throws IOException if the underlying client throws {@link DatastoreException}
+   */
   List<Entity> get(Iterable<Key> keys) throws IOException {
     return call(() -> ImmutableList.copyOf(rw.get(toArray(keys, Key.class))));
   }
 
+  /**
+   * Prefer this method over {@link #get(Iterable)} to avoid gathering large results in a list.
+   * @see DatastoreReaderWriter#get(Key...)
+   * @throws IOException if the underlying client throws {@link DatastoreException}
+   *                     or if {@code f} throws {@link IOException}.
+   */
   void get(Iterable<Key> keys, IOConsumer<Entity> f) throws IOException {
     run(() -> rw.get(toArray(keys, Key.class)).forEachRemaining(IOConsumer.unchecked(f)));
   }
 
-  List<Entity> query(EntityQuery query) throws IOException {
+  /**
+   * Only use this method if the results are small enough that gathering them in list is acceptable.
+   * Otherwise use {@link #query(Query, IOConsumer)}.
+   * @see DatastoreReaderWriter#run(Query)
+   * @throws IOException if the underlying client throws {@link DatastoreException}
+   */
+  <T> List<T> query(Query<T> query) throws IOException {
     return call(() -> ImmutableList.copyOf(rw.run(query)));
   }
 
-  void query(EntityQuery query, IOConsumer<Entity> f) throws IOException {
+  /**
+   * Prefer this method over {@link #query(Query)} to avoid gathering large results in a list.
+   * @see DatastoreReaderWriter#run(Query)
+   * @throws IOException if the underlying client throws {@link DatastoreException}
+   *                     or if {@code f} throws {@link IOException}.
+   */
+  <T> void query(Query<T> query, IOConsumer<T> f) throws IOException {
     run(() -> rw.run(query).forEachRemaining(IOConsumer.unchecked(f)));
   }
 
+  /**
+   * @see DatastoreReaderWriter#delete(Key...)
+   * @throws IOException if the underlying client throws {@link DatastoreException}
+   */
   void delete(Key... keys) throws IOException {
     run(() -> rw.delete(keys));
   }
 
+  /**
+   * Invokes a {@link Supplier} and translates {@link DatastoreException} and {@link RuntimeIOException}
+   * to checked exceptions.
+   * @throws DatastoreIOException if {@code f} threw {@link DatastoreException}
+   * @throws IOException if {@code f} threw {@link RuntimeIOException}
+   */
   static <T> T call(Supplier<T> f) throws IOException {
     try {
       return f.get();
@@ -94,15 +147,16 @@ class CheckedDatastoreReaderWriter {
     }
   }
 
+  /**
+   * Invokes a {@link Runnable} and translates {@link DatastoreException} and {@link RuntimeIOException}
+   * to checked exceptions.
+   * @throws DatastoreIOException if {@code f} threw {@link DatastoreException}
+   * @throws IOException if {@code f} threw {@link RuntimeIOException}
+   */
   static void run(Runnable f) throws IOException {
-    try {
+    call(() -> {
       f.run();
-    } catch (DatastoreException e) {
-      // Wrap unchecked DatastoreException in a checked DatastoreIOException
-      throw new DatastoreIOException(e);
-    } catch (RuntimeIOException e) {
-      // Propagate IOException from lambda
-      throw e.getCause();
-    }
+      return null;
+    });
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/CheckedDatastoreTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/CheckedDatastoreTransaction.java
@@ -1,0 +1,66 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.storage;
+
+import com.google.cloud.datastore.DatastoreException;
+import com.google.cloud.datastore.Transaction;
+import com.google.cloud.datastore.Transaction.Response;
+import java.util.Objects;
+
+/**
+ * A wrapper for {@link Transaction} that translates unchecked {@link DatastoreException}s to checked
+ * {@link DatastoreIOException}s.
+ */
+class CheckedDatastoreTransaction extends CheckedDatastoreReaderWriter {
+
+  private final CheckedDatastore datastore;
+  final Transaction tx;
+
+  CheckedDatastoreTransaction(CheckedDatastore datastore, Transaction tx) {
+    super(tx);
+    this.datastore = Objects.requireNonNull(datastore);
+    this.tx = Objects.requireNonNull(tx);
+  }
+
+  Response commit() throws DatastoreIOException {
+    try {
+      return tx.commit();
+    } catch (DatastoreException e) {
+      throw new DatastoreIOException(e);
+    }
+  }
+
+  void rollback() throws DatastoreIOException {
+    try {
+      tx.rollback();
+    } catch (DatastoreException e) {
+      throw new DatastoreIOException(e);
+    }
+  }
+
+  boolean isActive() {
+    return tx.isActive();
+  }
+
+  CheckedDatastore getDatastore() {
+    return datastore;
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/storage/CheckedDatastoreTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/CheckedDatastoreTransaction.java
@@ -34,12 +34,19 @@ class CheckedDatastoreTransaction extends CheckedDatastoreReaderWriter {
   private final CheckedDatastore datastore;
   final Transaction tx;
 
+  /**
+   * Create a new {@link CheckedDatastoreTransaction} wrapping a {@link Transaction}.
+   */
   CheckedDatastoreTransaction(CheckedDatastore datastore, Transaction tx) {
     super(tx);
     this.datastore = Objects.requireNonNull(datastore);
     this.tx = Objects.requireNonNull(tx);
   }
 
+  /**
+   * @see Transaction#commit()
+   * @throws DatastoreIOException if the underlying client throws {@link DatastoreException}
+   */
   Response commit() throws DatastoreIOException {
     try {
       return tx.commit();
@@ -48,6 +55,10 @@ class CheckedDatastoreTransaction extends CheckedDatastoreReaderWriter {
     }
   }
 
+  /**
+   * @see Transaction#rollback()
+   * @throws DatastoreIOException if the underlying client throws {@link DatastoreException}
+   */
   void rollback() throws DatastoreIOException {
     try {
       tx.rollback();
@@ -56,10 +67,16 @@ class CheckedDatastoreTransaction extends CheckedDatastoreReaderWriter {
     }
   }
 
+  /**
+   * @see Transaction#isActive()
+   */
   boolean isActive() {
     return tx.isActive();
   }
 
+  /**
+   * @see Transaction#getDatastore()
+   */
   CheckedDatastore getDatastore() {
     return datastore;
   }

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreIOException.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreIOException.java
@@ -1,8 +1,8 @@
-/*-
+/*
  * -\-\-
- * Spotify Styx Common
+ * Spotify Styx Scheduler Service
  * --
- * Copyright (C) 2016 - 2018 Spotify AB
+ * Copyright (C) 2018 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,26 @@
  * -/-/-
  */
 
-package com.spotify.styx.util;
+package com.spotify.styx.storage;
 
+import com.google.cloud.datastore.DatastoreException;
 import java.io.IOException;
+import java.util.Objects;
 
 /**
- * Factory for creating counter snapshot instances
+ * A checked version of {@link DatastoreException} that is used to force callers to handle errors.
  */
-public interface CounterSnapshotFactory {
+public class DatastoreIOException extends IOException {
 
-  CounterSnapshot create(String counterId) throws IOException;
+  private final DatastoreException cause;
+
+  public DatastoreIOException(DatastoreException cause) {
+    super(cause);
+    this.cause = Objects.requireNonNull(cause);
+  }
+
+  @Override
+  public synchronized DatastoreException getCause() {
+    return cause;
+  }
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -408,7 +408,7 @@ public class DatastoreStorage implements Closeable {
 
     // Strongly consistently read values for the above keys in parallel
     return gatherIO(Lists.partition(keys, MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH_READ).stream()
-        .map(batch -> asyncIO(() -> this.readRunStateBatch(batch)))
+        .map(batch -> asyncIO(() -> readRunStateBatch(batch)))
         .collect(toList()), 30, TimeUnit.SECONDS)
         .stream()
         .flatMap(Collection::stream)

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -735,11 +735,9 @@ public class DatastoreStorage implements Closeable {
 
   List<Resource> getResources() throws IOException {
     final EntityQuery query = Query.newEntityQueryBuilder().setKind(KIND_RESOURCE).build();
-    final List<Entity> results = datastore.query(query);
     final List<Resource> resources = Lists.newArrayList();
-    for (Entity result : results) {
-      resources.add(entityToResource(result));
-    }
+    datastore.query(query, entity ->
+        resources.add(entityToResource(entity)));
     return resources;
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
@@ -50,13 +50,10 @@ import static com.spotify.styx.util.ShardedCounter.PROPERTY_LIMIT;
 import static com.spotify.styx.util.ShardedCounter.PROPERTY_SHARD_INDEX;
 import static com.spotify.styx.util.ShardedCounter.PROPERTY_SHARD_VALUE;
 
-import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Entity.Builder;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.StringValue;
-import com.google.cloud.datastore.Transaction;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Workflow;
@@ -74,9 +71,9 @@ import java.util.Optional;
 
 public class DatastoreStorageTransaction implements StorageTransaction {
 
-  private final Transaction tx;
+  private final CheckedDatastoreTransaction tx;
 
-  public DatastoreStorageTransaction(Transaction transaction) {
+  public DatastoreStorageTransaction(CheckedDatastoreTransaction transaction) {
     this.tx = Objects.requireNonNull(transaction);
   }
 
@@ -84,8 +81,8 @@ public class DatastoreStorageTransaction implements StorageTransaction {
   public void commit() throws TransactionException {
     try {
       tx.commit();
-    } catch (DatastoreException e) {
-      throw new TransactionException(e);
+    } catch (DatastoreIOException e) {
+      throw new TransactionException(e.getCause());
     }
   }
 
@@ -93,8 +90,8 @@ public class DatastoreStorageTransaction implements StorageTransaction {
   public void rollback() throws TransactionException {
     try {
       tx.rollback();
-    } catch (DatastoreException e) {
-      throw new TransactionException(e);
+    } catch (DatastoreIOException e) {
+      throw new TransactionException(e.getCause());
     }
   }
 
@@ -104,12 +101,12 @@ public class DatastoreStorageTransaction implements StorageTransaction {
   }
 
   @Override
-  public void updateCounter(ShardedCounter shardedCounter, String resource, int delta) {
+  public void updateCounter(ShardedCounter shardedCounter, String resource, int delta) throws IOException {
     shardedCounter.updateCounter(this, resource, delta);
   }
 
   @Override
-  public Optional<Shard> shard(String counterId, int shardIndex) {
+  public Optional<Shard> shard(String counterId, int shardIndex) throws IOException {
     // TODO there's no need for this to be transactional
     final Key shardKey = tx.getDatastore().newKeyFactory().setKind(KIND_COUNTER_SHARD)
         .newKey(counterId + "-" + shardIndex);
@@ -122,7 +119,7 @@ public class DatastoreStorageTransaction implements StorageTransaction {
   }
 
   @Override
-  public void store(Shard shard) {
+  public void store(Shard shard) throws IOException {
     tx.put(Entity.newBuilder(tx.getDatastore().newKeyFactory().setKind(KIND_COUNTER_SHARD)
                                  .newKey(shard.counterId() + "-" + shard.index()))
                         .set(PROPERTY_COUNTER_ID, shard.counterId())
@@ -132,22 +129,22 @@ public class DatastoreStorageTransaction implements StorageTransaction {
   }
 
   @Override
-  public void updateLimitForCounter(String counterId, long limit) {
+  public void updateLimitForCounter(String counterId, long limit) throws IOException {
     final Key limitKey = tx.getDatastore().newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(counterId);
     tx.put(Entity.newBuilder(limitKey).set(PROPERTY_LIMIT, limit).build());
   }
 
   @Override
-  public void store(Resource resource) {
+  public void store(Resource resource) throws IOException {
     tx.put(resourceToEntity(tx.getDatastore(), resource));
   }
 
   @Override
-  public void deleteCounterLimit(String counterId) {
+  public void deleteCounterLimit(String counterId) throws IOException {
     tx.delete(tx.getDatastore().newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(counterId));
   }
 
-  private Entity resourceToEntity(Datastore datastore, Resource resource) {
+  private Entity resourceToEntity(CheckedDatastore datastore, Resource resource) {
     final Key key = datastore.newKeyFactory().setKind(KIND_RESOURCE).newKey(resource.id());
     return Entity.newBuilder(key)
         .set(PROPERTY_CONCURRENCY, resource.concurrency())
@@ -276,14 +273,14 @@ public class DatastoreStorageTransaction implements StorageTransaction {
   }
 
   @Override
-  public WorkflowInstance deleteActiveState(WorkflowInstance instance) {
+  public WorkflowInstance deleteActiveState(WorkflowInstance instance) throws IOException {
     tx.delete(activeWorkflowInstanceIndexShardEntryKey(tx.getDatastore().newKeyFactory(), instance));
     tx.delete(activeWorkflowInstanceKey(tx.getDatastore().newKeyFactory(), instance));
     return instance;
   }
 
   @Override
-  public Backfill store(Backfill backfill) {
+  public Backfill store(Backfill backfill) throws IOException {
     final Key key = DatastoreStorage.backfillKey(tx.getDatastore().newKeyFactory(), backfill.id());
     Entity.Builder builder = Entity.newBuilder(key)
         .set(PROPERTY_CONCURRENCY, backfill.concurrency())
@@ -306,7 +303,7 @@ public class DatastoreStorageTransaction implements StorageTransaction {
   }
 
   @Override
-  public Optional<Backfill> backfill(String id) {
+  public Optional<Backfill> backfill(String id) throws IOException {
     final Key key = DatastoreStorage.backfillKey(tx.getDatastore().newKeyFactory(), id);
     final Entity entity = tx.get(key);
     if (entity == null) {

--- a/styx-common/src/main/java/com/spotify/styx/storage/IOConsumer.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/IOConsumer.java
@@ -1,8 +1,8 @@
-/*-
+/*
  * -\-\-
- * Spotify Styx Common
+ * Spotify Styx Scheduler Service
  * --
- * Copyright (C) 2016 - 2018 Spotify AB
+ * Copyright (C) 2018 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,26 @@
  * -/-/-
  */
 
-package com.spotify.styx.util;
+package com.spotify.styx.storage;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 /**
- * Factory for creating counter snapshot instances
+ * A variant of {@link Consumer} that can throw {@link IOException}.
  */
-public interface CounterSnapshotFactory {
+@FunctionalInterface
+public interface IOConsumer<T> {
 
-  CounterSnapshot create(String counterId) throws IOException;
+  void accept(T t) throws IOException;
+
+  static <T> Consumer<T> unchecked(IOConsumer<T> f) {
+    return t -> {
+      try {
+        f.accept(t);
+      } catch (IOException e) {
+        throw new RuntimeIOException(e);
+      }
+    };
+  }
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/IOOperation.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/IOOperation.java
@@ -1,8 +1,8 @@
-/*-
+/*
  * -\-\-
- * Spotify Styx Common
+ * Spotify Styx Scheduler Service
  * --
- * Copyright (C) 2016 - 2018 Spotify AB
+ * Copyright (C) 2018 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,28 @@
  * -/-/-
  */
 
-package com.spotify.styx.util;
+package com.spotify.styx.storage;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
 
 /**
- * Factory for creating counter snapshot instances
+ * An operation that can throw {@link IOException}.
  */
-public interface CounterSnapshotFactory {
+@FunctionalInterface
+interface IOOperation<T> {
 
-  CounterSnapshot create(String counterId) throws IOException;
+  T execute() throws IOException;
+
+  default CompletableFuture<T> executeAsync(Executor executor) {
+    return CompletableFuture.supplyAsync(() -> {
+      try {
+        return execute();
+      } catch (IOException e) {
+        throw new CompletionException(e);
+      }
+    }, executor);
+  }
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/RuntimeIOException.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/RuntimeIOException.java
@@ -1,8 +1,8 @@
-/*-
+/*
  * -\-\-
- * Spotify Styx Common
+ * Spotify Styx Scheduler Service
  * --
- * Copyright (C) 2016 - 2018 Spotify AB
+ * Copyright (C) 2018 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,27 @@
  * -/-/-
  */
 
-package com.spotify.styx.util;
+package com.spotify.styx.storage;
 
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.Objects;
 
 /**
- * Factory for creating counter snapshot instances
+ * An unchecked exception that can be used to propagate {@link IOException}s out of e.g.
+ * {@link Iterator#forEachRemaining} etc where checked exceptions cannot be thrown.
  */
-public interface CounterSnapshotFactory {
+class RuntimeIOException extends RuntimeException {
 
-  CounterSnapshot create(String counterId) throws IOException;
+  private final IOException cause;
+
+  RuntimeIOException(IOException cause) {
+    super(cause);
+    this.cause = Objects.requireNonNull(cause);
+  }
+
+  @Override
+  public synchronized IOException getCause() {
+    return cause;
+  }
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -279,15 +279,15 @@ public interface Storage extends Closeable {
 
   List<Backfill> backfillsForWorkflowId(boolean showAll, WorkflowId workflowId) throws IOException;
 
-  Optional<Backfill> backfill(String id);
+  Optional<Backfill> backfill(String id) throws IOException;
 
   void storeBackfill(Backfill backfill) throws IOException;
 
-  Map<Integer, Long> shardsForCounter(String counterId);
+  Map<Integer, Long> shardsForCounter(String counterId) throws IOException;
 
-  void deleteShardsForCounter(String counterId);
+  void deleteShardsForCounter(String counterId) throws IOException;
 
-  long getLimitForCounter(String counterId);
+  long getLimitForCounter(String counterId) throws IOException;
 
   /**
    * Run a function in a transaction that is committed if successful. Any exception thrown by the

--- a/styx-common/src/main/java/com/spotify/styx/storage/StorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/StorageTransaction.java
@@ -70,7 +70,7 @@ public interface StorageTransaction {
    * @param id Id of the backfill
    * @return Optionally a backfill, if one was found for the given id
    */
-  Optional<Backfill> backfill(String id);
+  Optional<Backfill> backfill(String id) throws IOException;
 
   /**
    * Updates the next natural trigger for a {@link Workflow}.
@@ -111,14 +111,14 @@ public interface StorageTransaction {
   /**
    * Remove an active workflow instance state.
    */
-  WorkflowInstance deleteActiveState(WorkflowInstance instance);
+  WorkflowInstance deleteActiveState(WorkflowInstance instance) throws IOException;
 
   /**
    * Stores a backfill
    *
    * @param backfill the backfill to store
    */
-  Backfill store(Backfill backfill);
+  Backfill store(Backfill backfill) throws IOException;
 
   /**
    * Commit all the storage operations previously called.
@@ -142,30 +142,30 @@ public interface StorageTransaction {
   /**
    * Update counter by delta for the specified resource.
    */
-  void updateCounter(ShardedCounter shardedCounter, String resource, int delta);
+  void updateCounter(ShardedCounter shardedCounter, String resource, int delta) throws IOException;
 
   /**
    * Reads a counter shard
    */
-  Optional<Shard> shard(String counterId, int shardIndex);
+  Optional<Shard> shard(String counterId, int shardIndex) throws IOException;
 
   /**
    * Stores a shard
    */
-  void store(Shard shard);
+  void store(Shard shard) throws IOException;
 
   /**
    * Updates the limit for the given counter
    */
-  void updateLimitForCounter(String counterId, long limit);
+  void updateLimitForCounter(String counterId, long limit) throws IOException;
 
   /**
    * Stores a resource
    */
-  void store(Resource resource);
+  void store(Resource resource) throws IOException;
 
   /**
    * Deletes the limit configured for the given counter
    */
-  void deleteCounterLimit(String counterId);
+  void deleteCounterLimit(String counterId) throws IOException;
 }

--- a/styx-common/src/test/java/com/spotify/styx/storage/CheckedDatastoreReaderWriterTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/CheckedDatastoreReaderWriterTest.java
@@ -110,16 +110,16 @@ public class CheckedDatastoreReaderWriterTest {
 
   @Test
   public void updateShouldThrowCheckedException() throws IOException {
-    doThrow(CAUSE).when(rw).update(entity1);
+    doThrow(CAUSE).when(rw).update(entity1, entity2);
     exception.expect(IOException.class);
     exception.expectCause(is((Throwable) CAUSE));
-    sut.update(entity1);
+    sut.update(entity1, entity2);
   }
 
   @Test
   public void update() throws IOException {
-    sut.update(entity1);
-    verify(rw).update(entity1);
+    sut.update(entity1, entity2);
+    verify(rw).update(entity1, entity2);
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/storage/CheckedDatastoreReaderWriterTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/CheckedDatastoreReaderWriterTest.java
@@ -1,0 +1,310 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.storage;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.datastore.DatastoreException;
+import com.google.cloud.datastore.DatastoreReaderWriter;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.EntityQuery;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.QueryResults;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CheckedDatastoreReaderWriterTest {
+
+  private static final DatastoreException CAUSE = new DatastoreException(17, "foo", "bar");
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+
+  @Mock private Supplier<String> supplier;
+  @Mock private Runnable runnable;
+  @Mock private Iterator<Entity> entityIterator;
+  @Mock private IOConsumer<Entity> entityConsumer;
+  @Mock private DatastoreReaderWriter rw;
+  @Mock(answer = CALLS_REAL_METHODS) private MockQueryResults queryResults;
+
+  private final Key key1 = Key.newBuilder("foo", "bar", 17).build();
+  private final Key key2 = Key.newBuilder("foo", "bar", 4711).build();
+  private final Entity entity1 = Entity.newBuilder(key1).build();
+  private final Entity entity2 = Entity.newBuilder(key2).build();
+  private final EntityQuery query = EntityQuery.newEntityQueryBuilder().build();
+
+  private CheckedDatastoreReaderWriter sut;
+
+  @Before
+  public void setUp() throws Exception {
+    sut = new CheckedDatastoreReaderWriter(rw);
+  }
+
+  @Test
+  public void putShouldThrowCheckedException() throws IOException {
+    when(rw.put(entity1)).thenThrow(CAUSE);
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    sut.put(entity1);
+  }
+
+  @Test
+  public void put() throws IOException {
+    when(rw.put(entity1)).thenReturn(entity1);
+    assertThat(sut.put(entity1), is(entity1));
+    verify(rw).put(entity1);
+  }
+
+  @Test
+  public void addShouldThrowCheckedException() throws IOException {
+    when(rw.add(entity1)).thenThrow(CAUSE);
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    sut.add(entity1);
+  }
+
+  @Test
+  public void add() throws IOException {
+    when(rw.add(entity1)).thenReturn(entity1);
+    assertThat(sut.add(entity1), is(entity1));
+    verify(rw).add(entity1);
+  }
+
+  @Test
+  public void updateShouldThrowCheckedException() throws IOException {
+    doThrow(CAUSE).when(rw).update(entity1);
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    sut.update(entity1);
+  }
+
+  @Test
+  public void update() throws IOException {
+    sut.update(entity1);
+    verify(rw).update(entity1);
+  }
+
+  @Test
+  public void getSingleShouldThrowCheckedException() throws IOException {
+    when(rw.get(key1)).thenThrow(CAUSE);
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    sut.get(key1);
+  }
+
+  @Test
+  public void getSingle() throws IOException {
+    when(rw.get(key1)).thenReturn(entity1);
+    assertThat(sut.get(key1), is(entity1));
+    verify(rw).get(key1);
+  }
+
+  @Test
+  public void getAndConsumeShouldThrowCheckedException() throws IOException {
+    when(rw.get(key1, key2)).thenThrow(CAUSE);
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    sut.get(ImmutableList.of(key1, key2), entity -> fail());
+  }
+
+  @Test
+  public void getAndConsume() throws IOException {
+    when(rw.get(key1, key2)).thenReturn(Stream.of(entity1, entity2).iterator());
+    sut.get(ImmutableList.of(key1, key2), entityConsumer);
+    verify(rw).get(key1, key2);
+    verify(entityConsumer).accept(entity1);
+    verify(entityConsumer).accept(entity2);
+  }
+
+  @Test
+  public void getAndConsumeShouldPropagateIOException() throws IOException {
+    final IOException cause = new IOException("foo");
+    doReturn(Stream.of(entity1, entity2).iterator()).when(rw).get(Mockito.any(Key[].class));
+    exception.expect(is(cause));
+    sut.get(ImmutableList.of(key1), entity -> { throw cause; });
+  }
+
+  @Test
+  public void getAndConsumeShouldHandleForEachRemainingThrowing() throws IOException {
+    doThrow(CAUSE).when(entityIterator).forEachRemaining(any());
+    doReturn(entityIterator).when(rw).get(Mockito.any(Key[].class));
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    sut.get(ImmutableList.of(key1), entity -> fail());
+  }
+
+  @Test
+  public void getListShouldThrowCheckedException() throws IOException {
+    when(rw.get(key1, key2)).thenThrow(CAUSE);
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    sut.get(ImmutableList.of(key1, key2));
+  }
+
+  @Test
+  public void getList() throws IOException {
+    when(rw.get(key1, key2)).thenReturn(Stream.of(entity1, entity2).iterator());
+    assertThat(sut.get(ImmutableList.of(key1, key2)), is(ImmutableList.of(entity1, entity2)));
+    verify(rw).get(key1, key2);
+  }
+
+  @Test
+  public void queryShouldThrowCheckedException() throws IOException {
+    when(rw.run(query)).thenThrow(CAUSE);
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    sut.query(query);
+  }
+
+  @Test
+  public void query() throws IOException {
+    when(rw.run(query)).thenReturn(queryResults);
+    when(queryResults.results()).thenReturn(Stream.of(entity1, entity2).iterator());
+    assertThat(sut.query(query), contains(entity1, entity2));
+    verify(rw).run(query);
+  }
+
+  @Test
+  public void queryAndConsumeShouldThrowCheckedException() throws IOException {
+    when(rw.run(query)).thenThrow(CAUSE);
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    sut.query(query, entity -> { });
+  }
+
+  @Test
+  public void queryAndConsume() throws IOException {
+    when(rw.run(query)).thenReturn(queryResults);
+    when(queryResults.results()).thenReturn(Stream.of(entity1, entity2).iterator());
+    sut.query(query, entityConsumer);
+    verify(entityConsumer).accept(entity1);
+    verify(entityConsumer).accept(entity2);
+    verify(rw).run(query);
+  }
+
+  @Test
+  public void queryAndConsumeShouldPropagateIOException() throws IOException {
+    final IOException cause = new IOException("foo");
+    when(queryResults.results()).thenReturn(Stream.of(entity1, entity2).iterator());
+    doReturn(queryResults).when(rw).run(any(EntityQuery.class));
+    exception.expect(is(cause));
+    sut.query(query, entity -> { throw cause; });
+  }
+
+  @Test
+  public void queryAndConsumeShouldHandleForEachRemainingThrowing() throws IOException {
+    doThrow(CAUSE).when(queryResults).forEachRemaining(any());
+    doReturn(queryResults).when(rw).run(any(EntityQuery.class));
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    sut.query(query, entity -> fail());
+  }
+
+  @Test
+  public void deleteShouldThrowCheckedException() throws IOException {
+    doThrow(CAUSE).when(rw).delete(key1, key2);
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    sut.delete(key1, key2);
+  }
+
+  @Test
+  public void delete() throws IOException {
+    sut.delete(key1, key1);
+    verify(rw).delete(key1, key1);
+  }
+
+  @Test
+  public void callShouldThrowCheckedException() throws IOException {
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    CheckedDatastoreReaderWriter.call(() -> { throw CAUSE; });
+  }
+
+  @Test
+  public void call() throws IOException {
+    when(supplier.get()).thenReturn("foobar");
+    assertThat(CheckedDatastoreReaderWriter.call(supplier), is("foobar"));
+    verify(supplier).get();
+  }
+
+  @Test
+  public void runShouldThrowCheckedException() throws IOException {
+    exception.expect(IOException.class);
+    exception.expectCause(is((Throwable) CAUSE));
+    CheckedDatastoreReaderWriter.run(() -> { throw CAUSE; });
+  }
+
+  @Test
+  public void run() throws IOException {
+    CheckedDatastoreReaderWriter.run(runnable);
+    verify(runnable).run();
+  }
+
+  @Test
+  public void callShouldPropagateIOException() throws IOException {
+    final IOException cause = new IOException("foobar");
+    exception.expect(is(cause));
+    CheckedDatastoreReaderWriter.call(() -> { throw new RuntimeIOException(cause); });
+  }
+
+  @Test
+  public void runShouldPropagateIOException() throws IOException {
+    final IOException cause = new IOException("foobar");
+    exception.expect(is(cause));
+    CheckedDatastoreReaderWriter.run(() -> { throw new RuntimeIOException(cause); });
+  }
+
+  private static abstract class MockQueryResults implements QueryResults<Entity> {
+
+    abstract Iterator<Entity> results();
+
+    @Override
+    public boolean hasNext() {
+      return results().hasNext();
+    }
+
+    @Override
+    public Entity next() {
+      return results().next();
+    }
+  }
+}

--- a/styx-common/src/test/java/com/spotify/styx/storage/CheckedDatastoreTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/CheckedDatastoreTest.java
@@ -1,0 +1,100 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.storage;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreException;
+import com.google.cloud.datastore.IncompleteKey;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.Transaction;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CheckedDatastoreTest {
+
+  private static final DatastoreException CAUSE = new DatastoreException(17, "foo", "bar");
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+
+  @Mock private Datastore datastore;
+  @Mock private Transaction transaction;
+  @Mock IncompleteKey incompleteKey;
+
+  private final KeyFactory keyFactory = new KeyFactory("foo");
+  private final Key key = Key.newBuilder("foo", "bar", 17).build();
+
+  private CheckedDatastore sut;
+
+  @Before
+  public void setUp() throws Exception {
+    sut = new CheckedDatastore(datastore);
+  }
+
+  @Test
+  public void newKeyFactory() {
+    when(datastore.newKeyFactory()).thenReturn(keyFactory);
+    assertThat(sut.newKeyFactory(), is(keyFactory));
+    verify(datastore).newKeyFactory();
+  }
+
+  @Test
+  public void newTransaction() throws DatastoreIOException {
+    when(datastore.newTransaction()).thenReturn(transaction);
+    assertThat(sut.newTransaction().tx, is(transaction));
+    verify(datastore).newTransaction();
+  }
+
+  @Test
+  public void newTransactionShouldThrowCheckedException() throws DatastoreIOException {
+    when(datastore.newTransaction()).thenThrow(CAUSE);
+    exception.expect(DatastoreIOException.class);
+    exception.expectCause(is(CAUSE));
+    sut.newTransaction();
+  }
+
+  @Test
+  public void allocateId() throws IOException {
+    when(datastore.allocateId(incompleteKey)).thenReturn(key);
+    assertThat(sut.allocateId(incompleteKey), is(key));
+    verify(datastore).allocateId(incompleteKey);
+  }
+
+  @Test
+  public void allocateIdShouldThrowCheckedException() throws IOException {
+    when(datastore.allocateId(incompleteKey)).thenThrow(CAUSE);
+    exception.expect(DatastoreIOException.class);
+    exception.expectCause(is(CAUSE));
+    sut.allocateId(incompleteKey);
+  }
+}

--- a/styx-common/src/test/java/com/spotify/styx/storage/CheckedDatastoreTransactionTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/CheckedDatastoreTransactionTest.java
@@ -1,0 +1,102 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.storage;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.datastore.DatastoreException;
+import com.google.cloud.datastore.Transaction;
+import com.google.cloud.datastore.Transaction.Response;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnitParamsRunner.class)
+public class CheckedDatastoreTransactionTest {
+
+  private static final DatastoreException CAUSE = new DatastoreException(17, "foo", "bar");
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+
+  @Mock private CheckedDatastore datastore;
+  @Mock private Transaction transaction;
+  @Mock private Response response;
+
+  private CheckedDatastoreTransaction sut;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    sut = new CheckedDatastoreTransaction(datastore, transaction);
+  }
+
+  @Test
+  public void commit() throws DatastoreIOException {
+    when(transaction.commit()).thenReturn(response);
+    assertThat(sut.commit(), is(response));
+    verify(transaction).commit();
+  }
+
+  @Test
+  public void rollback() throws DatastoreIOException {
+    sut.rollback();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void commitShouldThrowCheckedException() throws DatastoreIOException {
+    doThrow(CAUSE).when(transaction).commit();
+    exception.expect(DatastoreIOException.class);
+    exception.expectCause(is(CAUSE));
+    sut.commit();
+  }
+
+  @Test
+  public void rollbackShouldThrowCheckedException() throws DatastoreIOException {
+    doThrow(CAUSE).when(transaction).rollback();
+    exception.expect(DatastoreIOException.class);
+    exception.expectCause(is(CAUSE));
+    sut.rollback();
+  }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void isActive(boolean active) {
+    when(transaction.isActive()).thenReturn(active);
+    assertThat(sut.isActive(), is(active));
+    verify(transaction).isActive();
+  }
+
+  @Test
+  public void getDatastore() {
+    assertThat(sut.getDatastore(), is(datastore));
+  }
+}

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -212,7 +212,7 @@ public class DatastoreStorageTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    datastore = new CheckedDatastore(helper.getOptions().getService());
+    datastore = spy(new CheckedDatastore(helper.getOptions().getService()));
     storage = new DatastoreStorage(datastore, Duration.ZERO);
   }
 
@@ -414,6 +414,14 @@ public class DatastoreStorageTest {
         storage.readActiveStates(WORKFLOW_ID1.componentId());
 
     assertThat(activeStates, is(ImmutableMap.of(WORKFLOW_INSTANCE2, RUN_STATE2)));
+  }
+
+  @Test
+  public void readActiveStatesShouldPropagateIOException() throws Exception {
+    final IOException cause = new IOException("foobar");
+    doThrow(cause).when(datastore).query(any());
+    exception.expect(is(cause));
+    storage.readActiveStates();
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -68,7 +68,6 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StringValue;
-import com.google.cloud.datastore.Transaction;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -183,10 +182,10 @@ public class DatastoreStorageTest {
 
   private static LocalDatastoreHelper helper;
   private DatastoreStorage storage;
-  private Datastore datastore;
+  private CheckedDatastore datastore;
 
   @Mock TransactionFunction<String, FooException> transactionFunction;
-  @Mock Function<Transaction, DatastoreStorageTransaction> storageTransactionFactory;
+  @Mock Function<CheckedDatastoreTransaction, DatastoreStorageTransaction> storageTransactionFactory;
 
   @BeforeClass
   public static void setUpClass() throws Exception {
@@ -213,7 +212,7 @@ public class DatastoreStorageTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    datastore = helper.getOptions().getService();
+    datastore = new CheckedDatastore(helper.getOptions().getService());
     storage = new DatastoreStorage(datastore, Duration.ZERO);
   }
 
@@ -490,7 +489,7 @@ public class DatastoreStorageTest {
   }
 
   @Test
-  public void getsResourcesSyncEnabled() {
+  public void getsResourcesSyncEnabled() throws IOException {
     Entity config = Entity.newBuilder(DatastoreStorage.globalConfigKey(datastore.newKeyFactory()))
         .set(PROPERTY_CONFIG_RESOURCES_SYNC_ENABLED, true)
         .build();
@@ -500,7 +499,7 @@ public class DatastoreStorageTest {
   }
 
   @Test
-  public void shouldReturnEmptyClientBlacklist() {
+  public void shouldReturnEmptyClientBlacklist() throws IOException {
     Entity config = Entity.newBuilder(DatastoreStorage.globalConfigKey(datastore.newKeyFactory()))
         .set(DatastoreStorage.PROPERTY_CONFIG_CLIENT_BLACKLIST,
             ImmutableList.of()).build();
@@ -509,7 +508,7 @@ public class DatastoreStorageTest {
   }
 
   @Test
-  public void shouldReturnClientBlacklist() {
+  public void shouldReturnClientBlacklist() throws IOException {
     Entity config = Entity.newBuilder(DatastoreStorage.globalConfigKey(datastore.newKeyFactory()))
         .set(DatastoreStorage.PROPERTY_CONFIG_CLIENT_BLACKLIST,
             ImmutableList.of(StringValue.of("v1"), StringValue.of("v2"), StringValue.of("v3")))
@@ -616,7 +615,7 @@ public class DatastoreStorageTest {
   }
 
   @Test
-  public void testDefaultConfig() {
+  public void testDefaultConfig() throws IOException {
     final StyxConfig expectedConfig = StyxConfig.newBuilder()
         .globalDockerRunnerId("default")
         .globalEnabled(true)
@@ -707,7 +706,7 @@ public class DatastoreStorageTest {
   @Test
   public void runInTransactionShouldCallFunctionAndCommit() throws Exception {
     final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory);
-    final Transaction transaction = datastore.newTransaction();
+    final CheckedDatastoreTransaction transaction = datastore.newTransaction();
     final DatastoreStorageTransaction storageTransaction = spy(new DatastoreStorageTransaction(transaction));
     when(storageTransactionFactory.apply(any())).thenReturn(storageTransaction);
 
@@ -724,7 +723,7 @@ public class DatastoreStorageTest {
   @Test
   public void runInTransactionShouldCallFunctionAndRollbackOnFailure() throws Exception {
     final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory);
-    final Transaction transaction = datastore.newTransaction();
+    final CheckedDatastoreTransaction transaction = datastore.newTransaction();
     final DatastoreStorageTransaction storageTransaction = spy(new DatastoreStorageTransaction(transaction));
     when(storageTransactionFactory.apply(any())).thenReturn(storageTransaction);
 
@@ -748,7 +747,7 @@ public class DatastoreStorageTest {
   @Test
   public void runInTransactionShouldCallFunctionAndRollbackOnPreCommitConflict() throws Exception {
     final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory);
-    final Transaction transaction = datastore.newTransaction();
+    final CheckedDatastoreTransaction transaction = datastore.newTransaction();
     final DatastoreStorageTransaction storageTransaction = spy(new DatastoreStorageTransaction(transaction));
     when(storageTransactionFactory.apply(any())).thenReturn(storageTransaction);
 
@@ -770,7 +769,7 @@ public class DatastoreStorageTest {
   @Test
   public void runInTransactionShouldCallFunctionAndRollbackOnCommitConflict() throws Exception {
     final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory);
-    final Transaction transaction = datastore.newTransaction();
+    final CheckedDatastoreTransaction transaction = datastore.newTransaction();
     final DatastoreStorageTransaction storageTransaction = spy(new DatastoreStorageTransaction(transaction));
     when(storageTransactionFactory.apply(any())).thenReturn(storageTransaction);
 
@@ -793,7 +792,7 @@ public class DatastoreStorageTest {
   @Test
   public void runInTransactionShouldThrowIfRollbackFailsAfterConflict() throws Exception {
     final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory);
-    final Transaction transaction = datastore.newTransaction();
+    final CheckedDatastoreTransaction transaction = datastore.newTransaction();
     final DatastoreStorageTransaction storageTransaction = spy(new DatastoreStorageTransaction(transaction));
     when(storageTransactionFactory.apply(any())).thenReturn(storageTransaction);
 
@@ -817,9 +816,9 @@ public class DatastoreStorageTest {
 
   @Test
   public void runInTransactionShouldThrowIfDatastoreNewTransactionFails() throws Exception {
-    Datastore datastore = mock(Datastore.class);
+    CheckedDatastore datastore = mock(CheckedDatastore.class);
     final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory);
-    when(datastore.newTransaction()).thenThrow(new DatastoreException(1, "", ""));
+    when(datastore.newTransaction()).thenThrow(new DatastoreIOException(new DatastoreException(1, "", "")));
 
     when(transactionFunction.apply(any())).thenReturn("");
 
@@ -847,19 +846,19 @@ public class DatastoreStorageTest {
   }
 
   @Test
-  public void shouldReturnCounterLimit() {
+  public void shouldReturnCounterLimit() throws IOException {
     updateLimitInStorage("foo-resource", 10L);
 
     assertEquals(10L, storage.getLimitForCounter("foo-resource"));
   }
 
   @Test
-  public void shouldReturnDefaultGlobalCounterLimit() {
+  public void shouldReturnDefaultGlobalCounterLimit() throws IOException {
     assertEquals(Long.MAX_VALUE, storage.getLimitForCounter("GLOBAL_STYX_CLUSTER"));
   }
 
   @Test
-  public void shouldReturnGlobalCounterLimit() {
+  public void shouldReturnGlobalCounterLimit() throws IOException {
     final Key key = globalConfigKey(datastore.newKeyFactory());
     Entity.Builder builder = Entity.newBuilder(key)
         .set(PROPERTY_CONCURRENCY, 4000L);
@@ -869,7 +868,7 @@ public class DatastoreStorageTest {
   }
 
   @Test
-  public void shouldGetExceptionForUnknownCounter() {
+  public void shouldGetExceptionForUnknownCounter() throws IOException {
     updateLimitInStorage("foo-resource", 10L);
 
     exception.expect(IllegalArgumentException.class);
@@ -878,7 +877,7 @@ public class DatastoreStorageTest {
     storage.getLimitForCounter("bar-resource");
   }
 
-  private void updateLimitInStorage(String counterId, long limit) {
+  private void updateLimitInStorage(String counterId, long limit) throws IOException {
     datastore.put(Entity.newBuilder((datastore.newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey
         (counterId)))
         .set(PROPERTY_LIMIT, limit)

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTransactionTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTransactionTest.java
@@ -36,11 +36,9 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.KeyFactory;
-import com.google.cloud.datastore.Transaction;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Workflow;
@@ -69,7 +67,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class DatastoreStorageTransactionTest {
 
   private static LocalDatastoreHelper helper;
-  private static Datastore datastore;
+  private static CheckedDatastore datastore;
   private DatastoreStorage storage;
 
   @BeforeClass
@@ -96,7 +94,7 @@ public class DatastoreStorageTransactionTest {
 
   @Before
   public void setUp() throws Exception {
-    datastore = helper.getOptions().getService();
+    datastore = new CheckedDatastore(helper.getOptions().getService());
     storage = new DatastoreStorage(datastore, Duration.ZERO);
   }
 
@@ -107,7 +105,7 @@ public class DatastoreStorageTransactionTest {
 
   @Test
   public void shouldCommitEmptyTransaction() throws IOException {
-    final Transaction transaction = datastore.newTransaction();
+    final CheckedDatastoreTransaction transaction = datastore.newTransaction();
     DatastoreStorageTransaction storageTransaction = new DatastoreStorageTransaction(transaction);
     storageTransaction.commit();
     assertFalse(transaction.isActive());
@@ -115,7 +113,7 @@ public class DatastoreStorageTransactionTest {
 
   @Test
   public void shouldThrowIfUnexpectedDatastoreError() throws IOException {
-    final Transaction transaction = datastore.newTransaction();
+    final CheckedDatastoreTransaction transaction = datastore.newTransaction();
     DatastoreStorageTransaction storageTransaction = new DatastoreStorageTransaction(transaction);
 
     transaction.rollback();
@@ -129,7 +127,7 @@ public class DatastoreStorageTransactionTest {
 
   @Test
   public void shouldThrowIfRollbackFails() throws IOException {
-    final Transaction transaction = datastore.newTransaction();
+    final CheckedDatastoreTransaction transaction = datastore.newTransaction();
     DatastoreStorageTransaction storageTransaction = new DatastoreStorageTransaction(transaction);
 
     storageTransaction.commit();
@@ -143,9 +141,9 @@ public class DatastoreStorageTransactionTest {
 
   @Test
   public void shouldThrowIfTransactionFailed() throws IOException, InterruptedException {
-    final Transaction transaction1 = datastore.newTransaction();
-    final Transaction transaction2 = datastore.newTransaction();
-    final Transaction transaction3 = datastore.newTransaction();
+    final CheckedDatastoreTransaction transaction1 = datastore.newTransaction();
+    final CheckedDatastoreTransaction transaction2 = datastore.newTransaction();
+    final CheckedDatastoreTransaction transaction3 = datastore.newTransaction();
     DatastoreStorageTransaction storageTransaction1 = new DatastoreStorageTransaction(transaction1);
     DatastoreStorageTransaction storageTransaction2 = new DatastoreStorageTransaction(transaction2);
     DatastoreStorageTransaction storageTransaction3 = new DatastoreStorageTransaction(transaction3);

--- a/styx-common/src/test/java/com/spotify/styx/storage/IOConsumerTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/IOConsumerTest.java
@@ -1,0 +1,43 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.storage;
+
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class IOConsumerTest {
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+
+  @Test
+  public void shouldPropagateIOException() {
+    final IOException cause = new IOException();
+    final Consumer<String> consumer = IOConsumer.unchecked((String s) -> { throw cause; });
+    exception.expect(RuntimeIOException.class);
+    exception.expectCause(is(cause));
+    consumer.accept("foobar");
+  }
+}

--- a/styx-common/src/test/java/com/spotify/styx/storage/IOOperationTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/IOOperationTest.java
@@ -1,0 +1,57 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.storage;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class IOOperationTest {
+
+  private static final IOException CAUSE = new IOException("foobar");
+  private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+
+  private final IOOperation<String> operation = () -> "foobar";
+  private final IOOperation<String> throwingOperation = () -> { throw CAUSE; };
+
+  @Test
+  public void executeAsync() {
+    assertThat(operation.executeAsync(EXECUTOR).join(), is("foobar"));
+  }
+
+  @Test
+  public void executeAsyncShouldPropagateException() {
+    final CompletableFuture<String> f = throwingOperation.executeAsync(EXECUTOR);
+    exception.expect(CompletionException.class);
+    exception.expectCause(is(CAUSE));
+    f.join();
+  }
+}

--- a/styx-common/src/test/java/com/spotify/styx/util/FutureUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/FutureUtilTest.java
@@ -1,0 +1,123 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.util;
+
+import static com.spotify.styx.util.FutureUtil.exceptionallyCompletedFuture;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FutureUtilTest {
+
+  @Mock private Future<String> future;
+
+  @Rule public final ExpectedException exception = ExpectedException.none();
+
+  @Test
+  public void testExceptionallyCompletedFuture() throws ExecutionException, InterruptedException {
+    final IOException cause = new IOException("foo");
+    final CompletableFuture<Object> future = exceptionallyCompletedFuture(cause);
+    exception.expect(ExecutionException.class);
+    exception.expectCause(is(cause));
+    future.get();
+  }
+
+  @Test
+  public void gatherIOShouldReturnValues() throws IOException {
+    final List<Future<String>> futures = ImmutableList.of(completedFuture("foo"), completedFuture("bar"));
+    assertThat(FutureUtil.gatherIO(futures, 30, TimeUnit.SECONDS), contains("foo", "bar"));
+  }
+
+  @Test
+  public void gatherIOShouldPropagateIOException() throws IOException {
+    final IOException cause = new IOException("foo");
+    final List<Future<String>> futures = ImmutableList.of(completedFuture("foo"), exceptionallyCompletedFuture(cause));
+    exception.expect(is(cause));
+    FutureUtil.gatherIO(futures, 30, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void gatherIOShouldPropagateException() throws IOException {
+    final Exception cause = new Exception("foo");
+    final List<Future<String>> futures = ImmutableList.of(completedFuture("foo"), exceptionallyCompletedFuture(cause));
+    exception.expect(RuntimeException.class);
+    exception.expectCause(is(cause));
+    FutureUtil.gatherIO(futures, 30, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void gatherIOShouldPropagateTimeoutAsIOException()
+      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    final TimeoutException cause = new TimeoutException();
+    when(future.get(anyLong(), any())).thenThrow(cause);
+    final List<Future<String>> futures = ImmutableList.of(completedFuture("foo"), future);
+    exception.expect(IOException.class);
+    exception.expectCause(is(cause));
+    FutureUtil.gatherIO(futures, 30, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void gatherShouldPropagateInterruptedAsIOException()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    assumeThat("should be Java 9+", isJava9OrGreater(), is(true));
+    final InterruptedException cause = new InterruptedException();
+    when(future.get(anyLong(), any())).thenThrow(cause);
+    final List<Future<String>> futures = ImmutableList.of(completedFuture("foo"), future);
+    try {
+      FutureUtil.gatherIO(futures, 30, TimeUnit.SECONDS);
+      fail();
+    } catch (IOException e) {
+      assertThat(e.getCause(), is(cause));
+    }
+    assertThat(Thread.currentThread().isInterrupted(), is(true));
+  }
+
+  private static boolean isJava9OrGreater() {
+    try {
+      Class.forName("java.lang.ProcessHandle");
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+}

--- a/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterSnapshotFactoryTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterSnapshotFactoryTest.java
@@ -93,7 +93,7 @@ public class ShardedCounterSnapshotFactoryTest {
   }
 
   @Test
-  public void testCreate() {
+  public void testCreate() throws IOException {
     counterSnapshotFactory.create(RESOURCE_ID);
     assertEquals(128, storage.shardsForCounter(RESOURCE_ID).size());
   }

--- a/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
@@ -128,7 +128,7 @@ public class ShardedCounterTest {
   }
 
   @Test
-  public void shouldCreateCounterEmpty() {
+  public void shouldCreateCounterEmpty() throws IOException {
     assertEquals(shardedCounter.getCounter(COUNTER_ID1), 0L);
     QueryResults<Entity> results = getShardsForCounter(COUNTER_ID1);
 
@@ -167,7 +167,7 @@ public class ShardedCounterTest {
   }
 
   @Test
-  public void shouldIncrementCounter() {
+  public void shouldIncrementCounter() throws IOException {
     // init counter
     assertEquals(0, shardedCounter.getCounter(COUNTER_ID1));
 
@@ -189,7 +189,7 @@ public class ShardedCounterTest {
   }
 
   @Test
-  public void shouldDecrementCounter() {
+  public void shouldDecrementCounter() throws IOException {
     // init counter
     assertEquals(0, shardedCounter.getCounter(COUNTER_ID1));
 
@@ -212,7 +212,7 @@ public class ShardedCounterTest {
   }
 
   @Test
-  public void shouldDecrementShardWithExcessUsage() {
+  public void shouldDecrementShardWithExcessUsage() throws IOException {
     // init counter
     assertEquals(0, shardedCounter.getCounter(COUNTER_ID1));
 
@@ -240,7 +240,7 @@ public class ShardedCounterTest {
   }
 
   @Test
-  public void shouldDecrementShardWithALotOfExcessUsage() {
+  public void shouldDecrementShardWithALotOfExcessUsage() throws IOException {
     // init counter
     assertEquals(0, shardedCounter.getCounter(COUNTER_ID1));
 
@@ -268,7 +268,7 @@ public class ShardedCounterTest {
   }
 
   @Test
-  public void shouldDecrementShardWithNoExcessUsage() {
+  public void shouldDecrementShardWithNoExcessUsage() throws IOException {
     // init counter
     assertEquals(0, shardedCounter.getCounter(COUNTER_ID1));
 
@@ -294,7 +294,7 @@ public class ShardedCounterTest {
   }
 
   @Test(expected = CounterCapacityException.class)
-  public void shouldFailWhenIncreasingIfChosenShardIsFilledConcurrently() {
+  public void shouldFailWhenIncreasingIfChosenShardIsFilledConcurrently() throws IOException {
     // init counter and limit
     updateLimitInStorage(COUNTER_ID1, 1);
     assertEquals(0, shardedCounter.getCounter(COUNTER_ID1));
@@ -316,7 +316,7 @@ public class ShardedCounterTest {
   }
 
   @Test(expected = ShardNotFoundException.class)
-  public void shouldFailWhenIncreasingIfChosenShardIsMissing() {
+  public void shouldFailWhenIncreasingIfChosenShardIsMissing() throws IOException {
     // init counter and limit
     updateLimitInStorage(COUNTER_ID1, 1);
     assertEquals(0, shardedCounter.getCounter(COUNTER_ID1));
@@ -336,7 +336,7 @@ public class ShardedCounterTest {
   }
 
   @Test(expected = CounterCapacityException.class)
-  public void shouldNotIncrementIfUsageIsAboveLimitAndShardsHaveExcessUsage() {
+  public void shouldNotIncrementIfUsageIsAboveLimitAndShardsHaveExcessUsage() throws IOException {
     // init counter
     assertEquals(0, shardedCounter.getCounter(COUNTER_ID1));
 
@@ -379,7 +379,7 @@ public class ShardedCounterTest {
   }
 
   @Test(expected = ShardNotFoundException.class)
-  public void shouldThrowExceptionOnUninitializedShards() {
+  public void shouldThrowExceptionOnUninitializedShards() throws IOException {
     doReturn(new ShardedCounter.Snapshot(COUNTER_ID1, 100, new HashMap<>()))
         .when(counterSnapshotFactory).create(COUNTER_ID1);
     updateCounterInTransaction(COUNTER_ID1, -1L);
@@ -524,7 +524,7 @@ public class ShardedCounterTest {
   }
 
   @Test
-  public void shouldReportCacheHitMissMetrics() {
+  public void shouldReportCacheHitMissMetrics() throws IOException {
     InOrder inOrder = Mockito.inOrder(stats, counterSnapshotFactory);
 
     // Verify we get a miss first time

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
@@ -176,7 +176,7 @@ class BackfillTriggerManager {
                                           Workflow workflow,
                                           Instant initialNextTrigger,
                                           int remainingCapacity,
-                                          boolean reversed) {
+                                          boolean reversed) throws IOException {
     final Backfill backfill = tx.backfill(id).orElseThrow(() ->
         new RuntimeException("Error while fetching backfill " + id));
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -335,7 +335,7 @@ public class Scheduler {
     return resourceExhaustedCache.computeIfAbsent(resourceId, k -> {
       try {
         return !shardedCounter.counterHasSpareCapacity(resourceId);
-      } catch (RuntimeException e) {
+      } catch (RuntimeException | IOException e) {
         LOG.warn("Failed to check resource counter limit", e);
         return false;
       }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -453,8 +453,8 @@ public class StyxScheduler implements AppInit {
       // Initialize resources
       storage.resources().parallelStream().forEach(
           resource -> {
-            counterSnapshotFactory.create(resource.id());
             try {
+              counterSnapshotFactory.create(resource.id());
               storage.runInTransaction(tx -> {
                 shardedCounter.updateLimit(tx, resource.id(), resource.concurrency());
                 return null;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -264,7 +264,7 @@ public class QueuedStateManager implements StateManager {
   }
 
   private void updateResourceCounters(StorageTransaction tx, Event event,
-                                      RunState currentRunState, RunState nextRunState) {
+                                      RunState currentRunState, RunState nextRunState) throws IOException {
     // increment counters if event is dequeue
     if (isDequeue(event) && nextRunState.data().resourceIds().isPresent()) {
       tryUpdatingCounter(currentRunState, tx, nextRunState.data().resourceIds().get());


### PR DESCRIPTION
Wraps the `Datastore` client in a `CheckedDatastore` wrapper that throws `IOException` instead of `DatastoreException`.

This forces all callers to handle these errors and leverages all the exception handling we already had in place that was written assuming that storage errors result in `IOException`.

Addresses #355