### PR TITLE
refactor fjp/executor shutdown

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -197,7 +197,7 @@ public class StyxApi implements AppInit {
 
     final Connection bigTable = closer.register(createBigTableConnection(config));
     final Datastore datastore = createDatastore(config, stats);
-    return new AggregateStorage(bigTable, datastore, DEFAULT_RETRY_BASE_DELAY_BT);
+    return closer.register(new AggregateStorage(bigTable, datastore, DEFAULT_RETRY_BASE_DELAY_BT));
   }
 
   private static Stats stats(Environment environment) {

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -155,8 +155,10 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage = spy(new AggregateStorage(bigtable, localDatastore.getOptions().getService(),
         Duration.ZERO));
 
+    final BackfillResource backfillResource = closer.register(
+        new BackfillResource(SCHEDULER_BASE, storage, workflowValidator));
     environment.routingEngine()
-        .registerRoutes(new BackfillResource(SCHEDULER_BASE, storage, workflowValidator).routes());
+        .registerRoutes(backfillResource.routes());
   }
 
   @BeforeClass

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -61,7 +61,7 @@ public class AggregateStorage implements Storage {
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
     datastoreStorage.close();
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/util/CloserUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/CloserUtil.java
@@ -1,0 +1,75 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.util;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import com.google.common.io.Closer;
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CloserUtil {
+
+  static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+
+  private CloserUtil() {
+    throw new UnsupportedOperationException();
+  }
+
+  private static final Logger log = LoggerFactory.getLogger(CloserUtil.class);
+
+  public static <T extends ExecutorService> T register(Closer closer, T executorService, String name) {
+    return register(closer, executorService, name, DEFAULT_TIMEOUT);
+  }
+
+  public static <T extends ExecutorService> T register(Closer closer, T executorService, String name,
+      Duration timeout) {
+    closer.register(closeable(executorService, name, timeout));
+    return executorService;
+  }
+
+  public static Closeable closeable(ExecutorService executor, String name) {
+    return closeable(executor, name, DEFAULT_TIMEOUT);
+  }
+
+  public static Closeable closeable(ExecutorService executor, String name, Duration timeout) {
+    return () -> close(executor, name, timeout);
+  }
+
+  private static void close(ExecutorService executor, String name, Duration timeout) {
+    log.debug("Shutting down executor: {}", name);
+    executor.shutdown();
+    try {
+      executor.awaitTermination(timeout.toNanos(), NANOSECONDS);
+    } catch (InterruptedException ignored) {
+      log.warn("Interrupted");
+      Thread.currentThread().interrupt();
+    }
+    final List<Runnable> runnables = executor.shutdownNow();
+    if (!runnables.isEmpty()) {
+      log.warn("{} task(s) in {} did not execute", runnables.size(), name);
+    }
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/util/CloserUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/CloserUtil.java
@@ -32,13 +32,13 @@ import org.slf4j.LoggerFactory;
 
 public class CloserUtil {
 
+  private static final Logger log = LoggerFactory.getLogger(CloserUtil.class);
+
   static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
 
   private CloserUtil() {
     throw new UnsupportedOperationException();
   }
-
-  private static final Logger log = LoggerFactory.getLogger(CloserUtil.class);
 
   public static <T extends ExecutorService> T register(Closer closer, T executorService, String name) {
     return register(closer, executorService, name, DEFAULT_TIMEOUT);

--- a/styx-common/src/test/java/com/spotify/styx/storage/AggregateStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/AggregateStorageTest.java
@@ -23,7 +23,6 @@ package com.spotify.styx.storage;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;

--- a/styx-common/src/test/java/com/spotify/styx/storage/AggregateStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/AggregateStorageTest.java
@@ -23,13 +23,16 @@ package com.spotify.styx.storage;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.RunState;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,6 +54,17 @@ public class AggregateStorageTest {
   @Before
   public void setUp() throws Exception {
     sut = new AggregateStorage(bigtable, datastore);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    sut.close();
+  }
+
+  @Test
+  public void shouldCloseDatastore() throws IOException {
+    sut.close();
+    verify(datastore).close();
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -220,6 +220,7 @@ public class DatastoreStorageTest {
   @After
   public void tearDown() throws Exception {
     helper.reset();
+    storage.close();
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/util/CloserUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/CloserUtilTest.java
@@ -1,0 +1,97 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.util;
+
+import static com.spotify.styx.util.CloserUtil.DEFAULT_TIMEOUT;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closer;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CloserUtilTest {
+
+  @Mock private ExecutorService executorService;
+  @Mock private Runnable runnable;
+
+  private final Closer closer = Closer.create();
+
+  @Test
+  public void shouldCloseRegisteredExecutorService() throws IOException, InterruptedException {
+    final ExecutorService registeredExecutorService = CloserUtil.register(closer, executorService, "foobar");
+    assertThat(registeredExecutorService, is(executorService));
+    when(executorService.shutdownNow()).thenReturn(ImmutableList.of(runnable));
+    closer.close();
+    verifyShutdown(executorService);
+  }
+
+  @Test
+  public void closeableShouldCloseExecutorService() throws IOException, InterruptedException {
+    final Closeable closeable = CloserUtil.closeable(executorService, "foobar");
+    when(executorService.shutdownNow()).thenReturn(ImmutableList.of(runnable));
+    closeable.close();
+    verifyShutdown(executorService);
+  }
+
+  @Test
+  public void shouldHandleInterruption() throws IOException, InterruptedException {
+    // Interruptions break code coverage in Java 8
+    // https://github.com/jacoco/eclemma/issues/64
+    // https://bugs.openjdk.java.net/browse/JDK-8154017
+    assumeThat("should be Java 9+", isJava9OrGreater(), is(true));
+    final Closeable closeable = CloserUtil.closeable(executorService, "foobar");
+    when(executorService.shutdownNow()).thenReturn(ImmutableList.of(runnable));
+    doThrow(new InterruptedException()).when(executorService).awaitTermination(anyLong(), any());
+    closeable.close();
+    assertThat(Thread.currentThread().isInterrupted(), is(true));
+    verifyShutdown(executorService);
+  }
+
+  private static void verifyShutdown(ExecutorService executorService) throws InterruptedException {
+    verify(executorService).shutdown();
+    verify(executorService).awaitTermination(DEFAULT_TIMEOUT.toNanos(), NANOSECONDS);
+    verify(executorService).shutdownNow();
+  }
+
+  private static boolean isJava9OrGreater() {
+    try {
+      Class.forName("java.lang.ProcessHandle");
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+}

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -755,7 +755,8 @@ public class StyxScheduler implements AppInit {
     }
   }
 
-  private static boolean isDevMode(Config config) {
+  @VisibleForTesting
+  static boolean isDevMode(Config config) {
     return STYX_MODE_DEVELOPMENT.equals(config.getString(STYX_MODE));
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -23,13 +23,13 @@ package com.spotify.styx;
 import static com.spotify.apollo.environment.ConfigUtil.optionalInt;
 import static com.spotify.styx.state.OutputHandler.fanOutput;
 import static com.spotify.styx.state.StateUtil.getResourcesUsageMap;
+import static com.spotify.styx.util.CloserUtil.closeable;
 import static com.spotify.styx.util.Connections.createBigTableConnection;
 import static com.spotify.styx.util.Connections.createDatastore;
 import static com.spotify.styx.util.GuardedRunnable.runGuarded;
 import static com.spotify.styx.util.ShardedCounter.NUM_SHARDS;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
@@ -106,7 +106,6 @@ import io.opencensus.common.Scope;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.samplers.Samplers;
-import java.io.Closeable;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
@@ -321,16 +320,17 @@ public class StyxScheduler implements AppInit {
     final Publisher publisher = publisherFactory.apply(environment);
     closer.register(publisher);
 
+    // TODO: is the shutdown timeout of 1 second here sane?
     final ScheduledExecutorService tickExecutor = executorFactory.create(3, tickTf);
-    closer.register(executorCloser("tick-executor", tickExecutor));
+    closer.register(closeable(tickExecutor, "tick-executor", Duration.ofSeconds(1)));
     final StripedExecutorService eventProcessingExecutor = new StripedExecutorService(
         optionalInt(config, STYX_EVENT_PROCESSING_THREADS).orElse(DEFAULT_STYX_EVENT_PROCESSING_THREADS));
-    closer.register(executorCloser("event-processing", eventProcessingExecutor));
+    closer.register(closeable(eventProcessingExecutor, "event-processing", Duration.ofSeconds(1)));
     final ExecutorService eventConsumerExecutor = Executors.newSingleThreadExecutor();
-    closer.register(executorCloser("event-consumer", eventConsumerExecutor));
+    closer.register(closeable(eventConsumerExecutor, "event-consumer", Duration.ofSeconds(1)));
     final ExecutorService schedulerExecutor = Executors.newWorkStealingPool(
         optionalInt(config, STYX_SCHEDULER_THREADS).orElse(DEFAULT_STYX_SCHEDULER_THREADS));
-    closer.register(executorCloser("scheduler", schedulerExecutor));
+    closer.register(closeable(schedulerExecutor, "scheduler", Duration.ofSeconds(1)));
 
     final Stats stats = statsFactory.apply(environment);
     final Storage storage = MeteredStorageProxy.instrument(
@@ -753,21 +753,6 @@ public class StyxScheduler implements AppInit {
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }
-  }
-
-  private static Closeable executorCloser(String name, ExecutorService executor) {
-    return () -> {
-      LOG.info("Shutting down executor: {}", name);
-      executor.shutdown();
-      try {
-        executor.awaitTermination(1, SECONDS);
-      } catch (InterruptedException ignored) {
-      }
-      final List<Runnable> runnables = executor.shutdownNow();
-      if (!runnables.isEmpty()) {
-        LOG.warn("{} task(s) in {} did not execute", runnables.size(), name);
-      }
-    };
   }
 
   private static boolean isDevMode(Config config) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -22,7 +22,6 @@ package com.spotify.styx.state;
 
 import static com.spotify.styx.state.StateUtil.isConsumingResources;
 import static com.spotify.styx.util.MDCUtil.withMDC;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
@@ -45,7 +44,6 @@ import com.spotify.styx.util.ShardedCounter;
 import com.spotify.styx.util.Time;
 import eu.javaspecialists.tjsn.concurrency.stripedexecutor.StripedExecutorService;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -80,8 +80,6 @@ public class QueuedStateManager implements StateManager {
 
   private static final long NO_EVENTS_PROCESSED = -1L;
 
-  private static final Duration SHUTDOWN_GRACE_PERIOD = Duration.ofSeconds(5);
-
   private final LongAdder queuedEvents = new LongAdder();
 
   private final Time time;
@@ -400,18 +398,6 @@ public class QueuedStateManager implements StateManager {
       return;
     }
     running = false;
-
-    eventProcessingExecutor.shutdown();
-    try {
-      if (!eventProcessingExecutor
-          .awaitTermination(SHUTDOWN_GRACE_PERIOD.toMillis(), MILLISECONDS)) {
-        throw new IOException(
-            "Graceful shutdown failed, event loop did not finish within grace period");
-      }
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new IOException(e);
-    }
   }
 
   @VisibleForTesting

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
@@ -259,6 +259,14 @@ public class StyxSchedulerTest {
     verifyNoMoreInteractions(stateManager);
   }
 
+  @Test
+  public void shouldReflectDevMode() {
+    final Config devConfig = ConfigFactory.parseMap(ImmutableMap.of("styx.mode", "development"));
+    final Config prodConfig = ConfigFactory.parseMap(ImmutableMap.of("styx.mode", "production"));
+    assertThat(StyxScheduler.isDevMode(devConfig), is(true));
+    assertThat(StyxScheduler.isDevMode(prodConfig), is(false));
+  }
+
   private void shardsWithValue(ArgumentCaptor<Shard> shardArgumentCaptor, long value, long times) {
     assertThat(shardArgumentCaptor.getAllValues()
             .stream()

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
@@ -72,7 +72,7 @@ public class TriggerManagerTest {
   private final ExecutorService executor = Executors.newCachedThreadPool();
 
   @After
-  public void tearDown() {
+  public void tearDown() throws IOException {
     executor.shutdownNow();
     triggerManager.close();
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
@@ -138,10 +138,9 @@ public class QueuedStateManagerTest {
   }
 
   @After
-  public void tearDown() throws Exception {
-    if (stateManager != null) {
-      stateManager.close();
-    }
+  public void tearDown() {
+    eventTransitionExecutor.shutdownNow();
+    eventConsumerExecutor.shutdownNow();
   }
 
   @Test


### PR DESCRIPTION
Have a single well-tested method for shutting down executor services and use that instead of duplicating variations of the same shutdown logic everywhere.

One of the tests breaks code coverage on Java 8 so it is disabled there but it will be run by our Java 10+ CI pipeline.