### PR TITLE
encode urls as uris so that URI.create is ok

### DIFF
--- a/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxApolloClient.java
@@ -111,7 +111,7 @@ class StyxApolloClient implements StyxClient {
         .addPathSegment("activeStates");
     componentId.ifPresent(id -> urlBuilder.addQueryParameter("component", id));
     return executeRequest(
-        Request.forUri(urlBuilder.build().toString()),
+        Request.forUri(urlBuilder.build().uri().toString()),
         RunStateDataPayload.class);
   }
 
@@ -126,7 +126,7 @@ class StyxApolloClient implements StyxClient {
         .addPathSegment(workflowId)
         .addPathSegment(parameter);
     return executeRequest(
-        Request.forUri(urlBuilder.build().toString()))
+        Request.forUri(urlBuilder.build().uri().toString()))
         .thenApply(response -> {
           final JsonNode jsonNode;
           try {
@@ -173,14 +173,14 @@ class StyxApolloClient implements StyxClient {
         .addPathSegment("workflows")
         .addPathSegment(componentId)
         .addPathSegment(workflowId);
-    return executeRequest(Request.forUri(urlBuilder.build().toString()), Workflow.class);
+    return executeRequest(Request.forUri(urlBuilder.build().uri().toString()), Workflow.class);
   }
 
   @Override
   public CompletionStage<List<Workflow>> workflows() {
     final HttpUrl.Builder urlBuilder = getUrlBuilder()
         .addPathSegment("workflows");
-    return executeRequest(Request.forUri(urlBuilder.build().toString()), Workflow[].class)
+    return executeRequest(Request.forUri(urlBuilder.build().uri().toString()), Workflow[].class)
         .thenApply(ImmutableList::copyOf);
   }
 
@@ -195,7 +195,7 @@ class StyxApolloClient implements StyxClient {
     } catch (JsonProcessingException e) {
       return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
     }
-    final Request request = Request.forUri(urlBuilder.build().toString(), "POST").withPayload(payload);
+    final Request request = Request.forUri(urlBuilder.build().uri().toString(), "POST").withPayload(payload);
     return executeRequest(request, Workflow.class);
   }
 
@@ -205,7 +205,7 @@ class StyxApolloClient implements StyxClient {
         .addPathSegment("workflows")
         .addPathSegment(componentId)
         .addPathSegment(workflowId);
-    return executeRequest(Request.forUri(urlBuilder.build().toString(), "DELETE"))
+    return executeRequest(Request.forUri(urlBuilder.build().uri().toString(), "DELETE"))
         .thenApply(response -> null);
   }
 
@@ -216,7 +216,7 @@ class StyxApolloClient implements StyxClient {
         .addPathSegment(componentId)
         .addPathSegment(workflowId)
         .addPathSegment("state");
-    return executeRequest(Request.forUri(urlBuilder.build().toString()), WorkflowState.class);
+    return executeRequest(Request.forUri(urlBuilder.build().uri().toString()), WorkflowState.class);
   }
 
   @Override
@@ -229,7 +229,7 @@ class StyxApolloClient implements StyxClient {
         .addPathSegment(workflowId)
         .addPathSegment("instances")
         .addPathSegment(parameter);
-    return executeRequest(Request.forUri(urlBuilder.build().toString()),
+    return executeRequest(Request.forUri(urlBuilder.build().uri().toString()),
         WorkflowInstanceExecutionData.class);
   }
 
@@ -247,7 +247,7 @@ class StyxApolloClient implements StyxClient {
     } catch (JsonProcessingException e) {
       return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
     }
-    return executeRequest(Request.forUri(urlBuilder.build().toString(), "PATCH")
+    return executeRequest(Request.forUri(urlBuilder.build().uri().toString(), "PATCH")
                               .withPayload(payload), WorkflowState.class);
   }
 
@@ -264,7 +264,7 @@ class StyxApolloClient implements StyxClient {
     try {
       final ByteString payload = serialize(workflowInstance);
       return executeRequest(
-          Request.forUri(urlBuilder.build().toString(), "POST").withPayload(payload))
+          Request.forUri(urlBuilder.build().uri().toString(), "POST").withPayload(payload))
           .thenApply(response -> (Void) null);
     } catch (JsonProcessingException e) {
       return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
@@ -284,7 +284,7 @@ class StyxApolloClient implements StyxClient {
     try {
       final ByteString payload = serialize(workflowInstance);
       return executeRequest(
-          Request.forUri(urlBuilder.build().toString(), "POST").withPayload(payload))
+          Request.forUri(urlBuilder.build().uri().toString(), "POST").withPayload(payload))
           .thenApply(response -> (Void) null);
     } catch (JsonProcessingException e) {
       return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
@@ -304,7 +304,7 @@ class StyxApolloClient implements StyxClient {
     try {
       final ByteString payload = serialize(workflowInstance);
       return executeRequest(
-          Request.forUri(urlBuilder.build().toString(), "POST").withPayload(payload))
+          Request.forUri(urlBuilder.build().uri().toString(), "POST").withPayload(payload))
           .thenApply(response -> (Void) null);
     } catch (JsonProcessingException e) {
       return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
@@ -316,7 +316,7 @@ class StyxApolloClient implements StyxClient {
     final HttpUrl.Builder urlBuilder = getUrlBuilder().addPathSegment("resources");
     try {
       final ByteString payload = serialize(Resource.create(resourceId, concurrency));
-      return executeRequest(Request.forUri(urlBuilder.build().toString(), "POST")
+      return executeRequest(Request.forUri(urlBuilder.build().uri().toString(), "POST")
           .withPayload(payload), Resource.class);
     } catch (JsonProcessingException e) {
       return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
@@ -330,7 +330,7 @@ class StyxApolloClient implements StyxClient {
         .addPathSegment(resourceId);
     try {
       final ByteString payload = serialize(Resource.create(resourceId, concurrency));
-      return executeRequest(Request.forUri(urlBuilder.build().toString(), "PUT")
+      return executeRequest(Request.forUri(urlBuilder.build().uri().toString(), "PUT")
           .withPayload(payload), Resource.class);
     } catch (JsonProcessingException e) {
       return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
@@ -342,13 +342,13 @@ class StyxApolloClient implements StyxClient {
     final HttpUrl.Builder urlBuilder = getUrlBuilder()
         .addPathSegment("resources")
         .addPathSegment(resourceId);
-    return executeRequest(Request.forUri(urlBuilder.build().toString()), Resource.class);
+    return executeRequest(Request.forUri(urlBuilder.build().uri().toString()), Resource.class);
   }
 
   @Override
   public CompletionStage<ResourcesPayload> resourceList() {
     final HttpUrl.Builder urlBuilder = getUrlBuilder().addPathSegment("resources");
-    return executeRequest(Request.forUri(urlBuilder.build().toString()), ResourcesPayload.class);
+    return executeRequest(Request.forUri(urlBuilder.build().uri().toString()), ResourcesPayload.class);
   }
 
   @Override
@@ -379,7 +379,7 @@ class StyxApolloClient implements StyxClient {
     final HttpUrl.Builder urlBuilder = getUrlBuilder().addPathSegment("backfills");
     try {
       final ByteString payload = serialize(backfill);
-      return executeRequest(Request.forUri(urlBuilder.build().toString(), "POST")
+      return executeRequest(Request.forUri(urlBuilder.build().uri().toString(), "POST")
           .withPayload(payload), Backfill.class);
     } catch (JsonProcessingException e) {
       return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
@@ -397,7 +397,7 @@ class StyxApolloClient implements StyxClient {
         .addPathSegment(backfillId);
     try {
       final ByteString payload = serialize(editableBackfillInput);
-      return executeRequest(Request.forUri(urlBuilder.build().toString(), "PUT")
+      return executeRequest(Request.forUri(urlBuilder.build().uri().toString(), "PUT")
           .withPayload(payload), Backfill.class);
     } catch (JsonProcessingException e) {
       return CompletableFutures.exceptionallyCompletedFuture(new RuntimeException(e));
@@ -409,7 +409,7 @@ class StyxApolloClient implements StyxClient {
     final HttpUrl.Builder urlBuilder = getUrlBuilder()
         .addPathSegment("backfills")
         .addPathSegment(backfillId);
-    return executeRequest(Request.forUri(urlBuilder.build().toString(), "DELETE"))
+    return executeRequest(Request.forUri(urlBuilder.build().uri().toString(), "DELETE"))
         .thenApply(response -> null);
   }
 
@@ -419,7 +419,7 @@ class StyxApolloClient implements StyxClient {
         .addPathSegment("backfills")
         .addPathSegment(backfillId);
     urlBuilder.addQueryParameter("status", Boolean.toString(includeStatus));
-    return executeRequest(Request.forUri(urlBuilder.build().toString()), BackfillPayload.class);
+    return executeRequest(Request.forUri(urlBuilder.build().uri().toString()), BackfillPayload.class);
   }
 
   @Override
@@ -432,7 +432,7 @@ class StyxApolloClient implements StyxClient {
     workflowId.ifPresent(w -> urlBuilder.addQueryParameter("workflow", w));
     urlBuilder.addQueryParameter("showAll", Boolean.toString(showAll));
     urlBuilder.addQueryParameter("status", Boolean.toString(includeStatus));
-    return executeRequest(Request.forUri(urlBuilder.build().toString()), BackfillsPayload.class);
+    return executeRequest(Request.forUri(urlBuilder.build().uri().toString()), BackfillsPayload.class);
   }
 
   private <T> CompletionStage<T> executeRequest(final Request request,

--- a/styx-client/src/test/java/com/spotify/styx/client/StyxApolloClientTest.java
+++ b/styx-client/src/test/java/com/spotify/styx/client/StyxApolloClientTest.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
 import com.spotify.apollo.Client;
 import com.spotify.apollo.Request;
@@ -219,17 +218,17 @@ public class StyxApolloClientTest {
     when(client.send(any(Request.class))).thenReturn(
         CompletableFuture.completedFuture(Response.forStatus(Status.OK)));
     final StyxApolloClient styx = new StyxApolloClient(client, CLIENT_HOST, auth);
-    styx.workflow("foo-comp[strange characters]", "bar-wf[strange characters]")
+    styx.workflow("f[ ]o-cmp", "bar-w[f]")
         .toCompletableFuture();
     verify(client, timeout(30_000)).send(requestCaptor.capture());
     final Request request = requestCaptor.getValue();
     final URI uri = URI.create(
-        API_URL + "/workflows/foo-comp%5Bstrange%20characters%5D/bar-wf%5Bstrange%20characters%5D");
+        API_URL + "/workflows/f%5B%20%5Do-cmp/bar-w%5Bf%5D");
     assertThat(request.uri(), is(uri.toString()));
   }
 
   @Test
-  public void createOrUpdateWorkflow() throws IOException {
+  public void createOrUpdateWorkflow() throws Exception {
     when(client.send(any(Request.class))).thenReturn(CompletableFuture.completedFuture(
         Response.forStatus(Status.OK).withPayload(Json.serialize(WORKFLOW_1))));
     final StyxApolloClient styx = new StyxApolloClient(client, CLIENT_HOST, auth);
@@ -246,7 +245,7 @@ public class StyxApolloClientTest {
   }
 
   @Test
-  public void shouldCreateBackfill() throws IOException {
+  public void shouldCreateBackfill() throws Exception {
     when(client.send(any(Request.class))).thenReturn(CompletableFuture.completedFuture(
         Response.forStatus(Status.OK).withPayload(Json.serialize(BACKFILL))));
     final StyxApolloClient styx = new StyxApolloClient(client, CLIENT_HOST, auth);
@@ -264,7 +263,7 @@ public class StyxApolloClientTest {
   }
 
   @Test
-  public void shouldCreateBackfillFromInput() throws IOException {
+  public void shouldCreateBackfillFromInput() throws Exception {
     final BackfillInput backfillInput = BACKFILL_INPUT.builder()
         .reverse(true)
         .build();
@@ -284,7 +283,7 @@ public class StyxApolloClientTest {
   }
 
   @Test
-  public void shouldCreateBackfillWithDescription() throws IOException {
+  public void shouldCreateBackfillWithDescription() throws Exception {
     final BackfillInput backfillInput = BACKFILL_INPUT.builder()
         .description("Description")
         .build();
@@ -306,7 +305,7 @@ public class StyxApolloClientTest {
   }
 
   @Test
-  public void shouldUpdateBackfillConcurrency() throws IOException {
+  public void shouldUpdateBackfillConcurrency() throws Exception {
     final EditableBackfillInput backfillInput = EditableBackfillInput.newBuilder()
         .id(BACKFILL.id())
         .concurrency(4)
@@ -327,7 +326,7 @@ public class StyxApolloClientTest {
   }
 
   @Test
-  public void shouldUpdateWorkflowState() throws IOException {
+  public void shouldUpdateWorkflowState() throws Exception {
     final WorkflowState workflowState = WorkflowState.builder()
         .enabled(true)
         .nextNaturalTrigger(Instant.parse("2017-01-03T21:00:00Z"))
@@ -360,7 +359,7 @@ public class StyxApolloClientTest {
   }
 
   @Test
-  public void testTokenFailure() throws IOException, java.security.GeneralSecurityException {
+  public void testTokenFailure() throws Exception {
     final IOException rootCause = new IOException("netsplit!");
     when(auth.getToken(any())).thenThrow(rootCause);
     final StyxApolloClient styx = new StyxApolloClient(client, CLIENT_HOST, auth);
@@ -410,7 +409,7 @@ public class StyxApolloClientTest {
   }
 
   @Test
-  public void testSendsRequestId() throws JsonProcessingException {
+  public void testSendsRequestId() throws Exception {
     final StyxApolloClient styx = new StyxApolloClient(client, CLIENT_HOST, auth);
     when(client.send(requestCaptor.capture())).thenReturn(CompletableFuture.completedFuture(
         Response.forStatus(Status.OK).withPayload(Json.serialize(Collections.emptyList()))));
@@ -420,7 +419,7 @@ public class StyxApolloClientTest {
   }
 
   @Test
-  public void testUsesServerRequestIdOnMismatch() throws JsonProcessingException, InterruptedException {
+  public void testUsesServerRequestIdOnMismatch() throws Exception {
     final StyxApolloClient styx = new StyxApolloClient(client, CLIENT_HOST, auth);
     final String responseRequestId = "foobar";
     when(client.send(any())).thenReturn(CompletableFuture.completedFuture(
@@ -439,7 +438,7 @@ public class StyxApolloClientTest {
   }
 
   @Test
-  public void testUsesClientRequestIdOnNoResponseRequestId() throws JsonProcessingException, InterruptedException {
+  public void testUsesClientRequestIdOnNoResponseRequestId() throws Exception {
     final StyxApolloClient styx = new StyxApolloClient(client, CLIENT_HOST, auth);
     when(client.send(requestCaptor.capture())).thenReturn(CompletableFuture.completedFuture(
         Response.forStatus(Status.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
encode urls in a more compatible way

## Motivation and Context
apollo client seems to use URI.create before passing to underlying
client and URI.create throws on unencoded characters like [ and ]

## Have you tested this? If so, how?
I have included unit tests.

## Checklist for PR author(s)
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered