### PR TITLE
json: ignore unknown properties when deserializing

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/api/BackfillPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/BackfillPayload.java
@@ -21,14 +21,12 @@
 package com.spotify.styx.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.spotify.styx.model.Backfill;
 import java.util.Optional;
 
 @AutoValue
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class BackfillPayload {
 
   @JsonProperty

--- a/styx-common/src/main/java/com/spotify/styx/api/BackfillsPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/BackfillsPayload.java
@@ -21,13 +21,11 @@
 package com.spotify.styx.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import java.util.List;
 
 @AutoValue
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class BackfillsPayload {
 
   @JsonProperty

--- a/styx-common/src/main/java/com/spotify/styx/api/EventsPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/EventsPayload.java
@@ -21,7 +21,6 @@
 package com.spotify.styx.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.spotify.styx.model.Event;
@@ -31,14 +30,12 @@ import java.util.List;
  * convert Event to EventsPayload (with associated timestamps)
  */
 @AutoValue
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class EventsPayload {
 
   @JsonProperty
   public abstract List<TimestampedEvent> events();
 
   @AutoValue
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public abstract static class TimestampedEvent {
 
     @JsonProperty

--- a/styx-common/src/main/java/com/spotify/styx/api/ResourcesPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/ResourcesPayload.java
@@ -21,14 +21,12 @@
 package com.spotify.styx.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.spotify.styx.model.Resource;
 import java.util.List;
 
 @AutoValue
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class ResourcesPayload {
 
   @JsonProperty

--- a/styx-common/src/main/java/com/spotify/styx/api/RunStateDataPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/RunStateDataPayload.java
@@ -21,7 +21,6 @@
 package com.spotify.styx.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.spotify.styx.model.WorkflowInstance;
@@ -33,7 +32,6 @@ import java.util.List;
  * Value type for all current active states
  */
 @AutoValue
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class RunStateDataPayload {
 
   @JsonProperty
@@ -41,7 +39,6 @@ public abstract class RunStateDataPayload {
   public abstract List<RunStateData> activeStates();
 
   @AutoValue
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public abstract static class RunStateData {
 
     public static final Comparator<RunStateData> PARAMETER_COMPARATOR =

--- a/styx-common/src/main/java/com/spotify/styx/model/Backfill.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/Backfill.java
@@ -20,13 +20,11 @@
 
 package com.spotify.styx.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.norberg.automatter.AutoMatter;
 import java.time.Instant;
 import java.util.Optional;
 
 @AutoMatter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public interface Backfill {
 
   String id();

--- a/styx-common/src/main/java/com/spotify/styx/model/BackfillInput.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/BackfillInput.java
@@ -20,13 +20,11 @@
 
 package com.spotify.styx.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.norberg.automatter.AutoMatter;
 import java.time.Instant;
 import java.util.Optional;
 
 @AutoMatter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public interface BackfillInput {
 
   Instant start();

--- a/styx-common/src/main/java/com/spotify/styx/model/EditableBackfillInput.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/EditableBackfillInput.java
@@ -20,12 +20,10 @@
 
 package com.spotify.styx.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.norberg.automatter.AutoMatter;
 import java.util.Optional;
 
 @AutoMatter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public interface EditableBackfillInput {
 
   String id();

--- a/styx-common/src/main/java/com/spotify/styx/model/ExecutionDescription.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/ExecutionDescription.java
@@ -20,14 +20,12 @@
 
 package com.spotify.styx.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.norberg.automatter.AutoMatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 @AutoMatter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public interface ExecutionDescription {
 
   String dockerImage();

--- a/styx-common/src/main/java/com/spotify/styx/model/Resource.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/Resource.java
@@ -21,7 +21,6 @@
 package com.spotify.styx.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
@@ -29,7 +28,6 @@ import com.google.auto.value.AutoValue;
  * A data object containing the state of a {@link Workflow}
  */
 @AutoValue
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class Resource {
 
   @JsonProperty

--- a/styx-common/src/main/java/com/spotify/styx/model/TriggerRequest.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/TriggerRequest.java
@@ -20,12 +20,10 @@
 
 package com.spotify.styx.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.norberg.automatter.AutoMatter;
 import java.util.Optional;
 
 @AutoMatter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public interface TriggerRequest {
 
   WorkflowId workflowId();

--- a/styx-common/src/main/java/com/spotify/styx/model/Workflow.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/Workflow.java
@@ -21,12 +21,10 @@
 package com.spotify.styx.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class Workflow {
 
   @JsonProperty

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
@@ -20,7 +20,6 @@
 
 package com.spotify.styx.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.spotify.styx.model.Schedule.WellKnown;
 import com.spotify.styx.util.TimeUtil;
 import io.norberg.automatter.AutoMatter;
@@ -34,7 +33,6 @@ import java.util.Optional;
  * A specification of a scheduled workflow
  */
 @AutoMatter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public interface WorkflowConfiguration {
 
   String id();

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowState.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowState.java
@@ -21,7 +21,6 @@
 package com.spotify.styx.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import java.time.Instant;
@@ -31,7 +30,6 @@ import java.util.Optional;
  * A data object containing the state of a {@link com.spotify.styx.model.Workflow}
  */
 @AutoValue
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class WorkflowState {
 
   @JsonProperty

--- a/styx-common/src/main/java/com/spotify/styx/serialization/Json.java
+++ b/styx-common/src/main/java/com/spotify/styx/serialization/Json.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.serialization;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static com.fasterxml.jackson.databind.PropertyNamingStrategy.SNAKE_CASE;
 import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
@@ -57,6 +58,7 @@ public final class Json {
       .enable(ACCEPT_SINGLE_VALUE_AS_ARRAY)
       .disable(WRITE_DATES_AS_TIMESTAMPS)
       .registerModule(ADT_MODULE)
+      .disable(FAIL_ON_UNKNOWN_PROPERTIES)
       .registerModule(new JavaTimeModule())
       .registerModule(new Jdk8Module())
       .registerModule(new AutoMatterModule());
@@ -65,6 +67,7 @@ public final class Json {
       .setPropertyNamingStrategy(SNAKE_CASE)
       .enable(ACCEPT_SINGLE_VALUE_AS_ARRAY)
       .disable(WRITE_DATES_AS_TIMESTAMPS)
+      .disable(FAIL_ON_UNKNOWN_PROPERTIES)
       .registerModule(ADT_MODULE)
       .registerModule(new Jdk8Module())
       .registerModule(new JavaTimeModule())

--- a/styx-common/src/main/java/com/spotify/styx/state/Message.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/Message.java
@@ -21,14 +21,12 @@
 package com.spotify.styx.state;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.norberg.automatter.AutoMatter;
 
 /**
  * A value type for holding a message.
  */
 @AutoMatter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public interface Message {
   MessageLevel level();
   String line();

--- a/styx-common/src/main/java/com/spotify/styx/state/StateData.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/StateData.java
@@ -20,7 +20,6 @@
 
 package com.spotify.styx.state;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.collect.Iterables;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.TriggerParameters;
@@ -36,7 +35,6 @@ import java.util.Set;
  * suited for copy-modifying values. Another plus is the boilerplate-free Jackson integration.
  */
 @AutoMatter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public interface StateData {
 
   int tries();

--- a/styx-common/src/test/java/com/spotify/styx/serialization/JsonTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/serialization/JsonTest.java
@@ -1,0 +1,70 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.serialization;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.spotify.styx.model.Event;
+import com.spotify.styx.state.Trigger;
+import com.spotify.styx.testdata.TestData;
+import javaslang.control.Try.CheckedFunction;
+import org.junit.Test;
+
+public class JsonTest {
+
+  private static final Event EVENT = Event.retry(TestData.WORKFLOW_INSTANCE);
+  private static final Trigger TRIGGER = Trigger.adhoc("foobar");
+
+  @Test
+  public void jsonMapperShouldIgnoreUnknownProperties() throws Throwable {
+    assertIgnoresUnknownProperties(EVENT, node -> Json.OBJECT_MAPPER.convertValue(node, Event.class));
+  }
+
+  @Test
+  public void yamlMapperShouldIgnoreUnknownProperties() throws Throwable {
+    assertIgnoresUnknownProperties(EVENT, node -> Json.YAML_MAPPER.convertValue(node, Event.class));
+  }
+
+  @Test
+  public void deserializeEventShouldIgnoreUnknownProperties() throws Throwable {
+    assertIgnoresUnknownProperties(EVENT, node -> Json.deserializeEvent(Json.serialize(node)));
+  }
+
+  @Test
+  public void deserializeTriggerShouldIgnoreUnknownProperties() throws Throwable {
+    assertIgnoresUnknownProperties(TRIGGER, node -> Json.deserializeTrigger(Json.serialize(node)));
+  }
+
+  @Test
+  public void deserializeShouldIgnoreUnknownProperties() throws Throwable {
+    assertIgnoresUnknownProperties(EVENT, node -> Json.deserialize(Json.serialize(node), Event.class));
+  }
+
+  private <T> void assertIgnoresUnknownProperties(T value, CheckedFunction<ObjectNode, T> deserialize)
+      throws Throwable {
+    final ObjectNode node = Json.OBJECT_MAPPER.convertValue(value, ObjectNode.class);
+    node.put("non_existent_field", "foobar");
+    final T deserialized = deserialize.apply(node);
+    assertThat(deserialized, is(value));
+  }
+}

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
@@ -25,7 +25,6 @@ import static com.spotify.styx.docker.KubernetesDockerRunner.DOCKER_TERMINATION_
 import static com.spotify.styx.docker.KubernetesDockerRunner.getMainContainerStatus;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Lists;
 import com.spotify.styx.model.Event;
@@ -51,7 +50,6 @@ final class KubernetesPodEventTranslator {
     throw new UnsupportedOperationException();
   }
 
-  @JsonIgnoreProperties(ignoreUnknown = true)
   private static class TerminationLogMessage {
     int exitCode;
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Make the json parser ignore unknown properties when deserializing.

## Motivation and Context
Allow forwards compatibility, e.g. cli should not fail to deserialize
json with new "unknown" properties from a newer server.

In practice this is already manually configured for most classes.
Instead, make it the default by configuring the mapper directly.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [x] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [x] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
