### PR TITLE
include initial and latest timestamps in RunStateData

### DIFF
--- a/doc/api.apib
+++ b/doc/api.apib
@@ -459,14 +459,9 @@ Workflow Instance belonging to a Backfill entity.
                 },
                 "statuses": {
                     "active_states": [{
+                        "initial_timestamp": 1536838486145,
+                        "latest_timestamp": 1536838486185,
                         "state": "DONE",
-                        "workflow_instance": {
-                            "parameter": "2017-01-01T00",
-                            "workflow_id": {
-                                "component_id": "styx-canary",
-                                "id": "StyxCanary"
-                            }
-                        },
                         "state_data": {
                             "consecutive_failures": 0,
                             "execution_description": {
@@ -497,6 +492,13 @@ Workflow Instance belonging to a Backfill entity.
                                 "trigger_id": "backfill-1489054446085-53384"
                             },
                             "trigger_id": "backfill-1489054446085-53384"
+                        },
+                        "workflow_instance": {
+                            "parameter": "2017-01-01T00",
+                            "workflow_id": {
+                                "component_id": "styx-canary",
+                                "id": "StyxCanary"
+                            }
                         }
                     }]
                 }
@@ -571,14 +573,9 @@ Workflow Instance belonging to a Backfill entity.
             },
             "statuses": {
                 "active_states": [{
+                    "initial_timestamp": 1536838486145,
+                    "latest_timestamp": 1536838486185,
                     "state": "DONE",
-                    "workflow_instance": {
-                        "parameter": "2017-01-01T00",
-                        "workflow_id": {
-                            "component_id": "styx-canary",
-                            "id": "StyxCanary"
-                        }
-                    },
                     "state_data": {
                         "consecutive_failures": 0,
                         "execution_description": {
@@ -609,6 +606,13 @@ Workflow Instance belonging to a Backfill entity.
                             "trigger_id": "backfill-1489054446085-53384"
                         },
                         "trigger_id": "backfill-1489054446085-53384"
+                    },
+                    "workflow_instance": {
+                        "parameter": "2017-01-01T00",
+                        "workflow_id": {
+                            "component_id": "styx-canary",
+                            "id": "StyxCanary"
+                        }
                     }
                 }]
             }
@@ -665,14 +669,8 @@ Resources related to inspect detailed status of Workflow Instances.
 
         {
             "active_states": [{
+                "latest_timestamp": 1536838486185,
                 "state": "RUNNING",
-                "workflow_instance": {
-                    "parameter": "2017-01-01T01",
-                    "workflow_id": {
-                        "component_id": "styx-canary",
-                        "id": "StyxCanary"
-                    }
-                },
                 "state_data": {
                     "consecutive_failures": 0,
                     "execution_description": {
@@ -702,6 +700,13 @@ Resources related to inspect detailed status of Workflow Instances.
                         "@type": "natural"
                     },
                     "trigger_id": "natural-trigger"
+                },
+                "workflow_instance": {
+                    "parameter": "2017-01-01T01",
+                    "workflow_id": {
+                        "component_id": "styx-canary",
+                        "id": "StyxCanary"
+                    }
                 }
             }]
         }

--- a/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
@@ -98,7 +98,7 @@ public class StatusResource {
       runStates.addAll(
           activeStates.values().stream().map(this::runStateToRunStateData).collect(toList()));
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     return RunStateDataPayload.create(runStates);
@@ -113,7 +113,7 @@ public class StatusResource {
         .build();
   }
 
-  public EventsPayload eventsForWorkflowInstance(String cid, String eid, String iid) {
+  private EventsPayload eventsForWorkflowInstance(String cid, String eid, String iid) {
     final WorkflowId workflowId = WorkflowId.create(cid, eid);
     final WorkflowInstance workflowInstance = WorkflowInstance.create(workflowId, iid);
 

--- a/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
@@ -32,6 +32,7 @@ import com.spotify.apollo.entity.JacksonEntityCodec;
 import com.spotify.apollo.route.AsyncHandler;
 import com.spotify.apollo.route.Middleware;
 import com.spotify.apollo.route.Route;
+import com.spotify.styx.api.RunStateDataPayload.RunStateData;
 import com.spotify.styx.model.SequenceEvent;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
@@ -84,10 +85,10 @@ public class StatusResource {
     return rc.pathArgs().get(name);
   }
 
-  public RunStateDataPayload activeStates(RequestContext requestContext) {
+  private RunStateDataPayload activeStates(RequestContext requestContext) {
     final Optional<String> componentOpt = requestContext.request().parameter("component");
 
-    final List<RunStateDataPayload.RunStateData> runStates = Lists.newArrayList();
+    final List<RunStateData> runStates = Lists.newArrayList();
     try {
 
       final Map<WorkflowInstance, RunState> activeStates = componentOpt.isPresent()
@@ -103,12 +104,13 @@ public class StatusResource {
     return RunStateDataPayload.create(runStates);
   }
 
-  private RunStateDataPayload.RunStateData runStateToRunStateData(RunState state) {
-    return RunStateDataPayload.RunStateData.create(
-        state.workflowInstance(),
-        state.state().toString(),
-        state.data()
-    );
+  private RunStateData runStateToRunStateData(RunState state) {
+    return RunStateData.newBuilder()
+        .workflowInstance(state.workflowInstance())
+        .state(state.state().name())
+        .stateData(state.data())
+        .latestTimestamp(state.timestamp())
+        .build();
   }
 
   public EventsPayload eventsForWorkflowInstance(String cid, String eid, String iid) {

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -180,7 +180,7 @@ public class BackfillResourceTest extends VersionedApiTest {
   }
 
   @AfterClass
-  public static void tearDownClass() throws Exception {
+  public static void tearDownClass() {
     if (localDatastore != null) {
       try {
         localDatastore.stop(org.threeten.bp.Duration.ofSeconds(30));
@@ -471,9 +471,23 @@ public class BackfillResourceTest extends VersionedApiTest {
     assertThat(response, hasStatus(belongsToFamily(StatusType.Family.SUCCESSFUL)));
     assertJson(response, "backfill.id", equalTo(BACKFILL_5.id()));
     assertJson(response, "statuses.active_states[0].state", equalTo("DONE"));
+    assertJson(response, "statuses.active_states[0].initial_timestamp", is(1));
+    assertJson(response, "statuses.active_states[0].latest_timestamp", is(7));
+    assertJson(response, "statuses.active_states[1].state", equalTo("DONE"));
+    assertJson(response, "statuses.active_states[1].initial_timestamp", is(1));
+    assertJson(response, "statuses.active_states[1].latest_timestamp", is(7));
+    assertJson(response, "statuses.active_states[2].state", equalTo("DONE"));
+    assertJson(response, "statuses.active_states[2].initial_timestamp", is(1));
+    assertJson(response, "statuses.active_states[2].latest_timestamp", is(7));
     assertJson(response, "statuses.active_states[3].state", equalTo("DONE"));
+    assertJson(response, "statuses.active_states[3].initial_timestamp", is(1));
+    assertJson(response, "statuses.active_states[3].latest_timestamp", is(7));
     assertJson(response, "statuses.active_states[4].state", equalTo("DONE"));
+    assertJson(response, "statuses.active_states[4].initial_timestamp", is(1));
+    assertJson(response, "statuses.active_states[4].latest_timestamp", is(7));
     assertJson(response, "statuses.active_states[5].state", equalTo("DONE"));
+    assertJson(response, "statuses.active_states[5].initial_timestamp", is(1));
+    assertJson(response, "statuses.active_states[5].latest_timestamp", is(7));
     assertJson(response, "statuses.active_states", hasSize(6));
   }
 
@@ -486,7 +500,6 @@ public class BackfillResourceTest extends VersionedApiTest {
     storage.writeEvent(SequenceEvent.create(Event.started(wfi),                                 5L, 5L));
     storage.writeEvent(SequenceEvent.create(Event.terminate(wfi, Optional.of(0)),               6L, 6L));
     storage.writeEvent(SequenceEvent.create(Event.success(wfi),                                 7L, 7L));
-    storage.writeActiveState(wfi, RunState.create(wfi, State.DONE, StateData.zero(), Instant.now(), 8L));
   }
 
   @Test

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -69,6 +69,7 @@ import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.AggregateStorage;
 import com.spotify.styx.storage.BigtableMocker;
 import com.spotify.styx.storage.BigtableStorage;
+import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.WorkflowValidator;
 import java.io.IOException;
 import java.time.Duration;
@@ -97,7 +98,7 @@ public class BackfillResourceTest extends VersionedApiTest {
   private static LocalDatastoreHelper localDatastore;
   private Connection bigtable = setupBigTableMockTable();
 
-  private AggregateStorage storage;
+  private Storage storage;
 
   private static final Backfill BACKFILL_1 = Backfill.newBuilder()
       .id("backfill-1")

--- a/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
@@ -24,6 +24,7 @@ import static com.spotify.apollo.test.unit.ResponseMatchers.hasPayload;
 import static com.spotify.apollo.test.unit.ResponseMatchers.hasStatus;
 import static com.spotify.apollo.test.unit.StatusTypeMatchers.withCode;
 import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -31,6 +32,7 @@ import static org.junit.Assert.assertThat;
 import com.spotify.apollo.Environment;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.Status;
+import com.spotify.styx.api.RunStateDataPayload.RunStateData;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.SequenceEvent;
 import com.spotify.styx.model.TriggerParameters;
@@ -116,7 +118,20 @@ public class StatusResourceTest extends VersionedApiTest {
     RunStateDataPayload
         parsed = Json.OBJECT_MAPPER.readValue(json, RunStateDataPayload.class);
 
-    assertThat(parsed.activeStates(), hasSize(2));
+    assertThat(parsed.activeStates(), containsInAnyOrder(
+        RunStateData.newBuilder()
+            .workflowInstance(PERSISTENT_STATE.workflowInstance())
+            .state(PERSISTENT_STATE.state().name())
+            .stateData(PERSISTENT_STATE.data())
+            .latestTimestamp(PERSISTENT_STATE.timestamp())
+            .build(),
+        RunStateData.newBuilder()
+            .workflowInstance(OTHER_PERSISTENT_STATE.workflowInstance())
+            .state(OTHER_PERSISTENT_STATE.state().name())
+            .stateData(OTHER_PERSISTENT_STATE.data())
+            .latestTimestamp(OTHER_PERSISTENT_STATE.timestamp())
+            .build()
+    ));
   }
 
   @Test

--- a/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
@@ -23,12 +23,17 @@ package com.spotify.styx.api;
 import static com.spotify.apollo.test.unit.ResponseMatchers.hasPayload;
 import static com.spotify.apollo.test.unit.ResponseMatchers.hasStatus;
 import static com.spotify.apollo.test.unit.StatusTypeMatchers.withCode;
+import static com.spotify.apollo.test.unit.StatusTypeMatchers.withReasonPhrase;
 import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import com.spotify.apollo.Environment;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.Status;
@@ -43,10 +48,19 @@ import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.Trigger;
-import com.spotify.styx.storage.InMemStorage;
+import com.spotify.styx.storage.AggregateStorage;
+import com.spotify.styx.storage.BigtableMocker;
+import com.spotify.styx.storage.BigtableStorage;
 import com.spotify.styx.storage.Storage;
+import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.logging.Level;
 import okio.ByteString;
+import org.apache.hadoop.hbase.client.Connection;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class StatusResourceTest extends VersionedApiTest {
@@ -61,20 +75,51 @@ public class StatusResourceTest extends VersionedApiTest {
   private static final WorkflowInstance OTHER_WFI =
       WorkflowInstance.create(WorkflowId.create(OTHER_COMPONENT_ID, ID), PARAMETER);
 
-  public static final RunState PERSISTENT_STATE = RunState.create(WFI, State.RUNNING,
+  private static final RunState PERSISTENT_STATE = RunState.create(WFI, State.RUNNING,
       StateData.zero(), Instant.now(), 42L);
 
-  public static final RunState OTHER_PERSISTENT_STATE = RunState.create(WFI, State.RUNNING,
+  private static final RunState OTHER_PERSISTENT_STATE = RunState.create(OTHER_WFI, State.RUNNING,
       StateData.zero(), Instant.now(), 84L);
 
-  private Storage storage = new InMemStorage();
+  private static LocalDatastoreHelper localDatastore;
+  private Connection bigtable = setupBigTableMockTable();
+
+  private Storage storage;
 
   public StatusResourceTest(Api.Version version) {
     super(StatusResource.BASE, version);
   }
 
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    final java.util.logging.Logger datastoreEmulatorLogger =
+        java.util.logging.Logger.getLogger(LocalDatastoreHelper.class.getName());
+    datastoreEmulatorLogger.setLevel(Level.OFF);
+
+    localDatastore = LocalDatastoreHelper.create(1.0); // 100% global consistency
+    localDatastore.start();
+  }
+
+  @AfterClass
+  public static void tearDownClass() {
+    if (localDatastore != null) {
+      try {
+        localDatastore.stop(org.threeten.bp.Duration.ofSeconds(30));
+      } catch (Throwable e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    localDatastore.reset();
+  }
+
   @Override
   protected void init(Environment environment) {
+    storage = spy(new AggregateStorage(bigtable, localDatastore.getOptions().getService(),
+        Duration.ZERO));
     final StatusResource statusResource = new StatusResource(storage);
 
     environment.routingEngine()
@@ -156,5 +201,32 @@ public class StatusResourceTest extends VersionedApiTest {
 
     assertThat(parsed.activeStates(), hasSize(1));
     assertThat(parsed.activeStates().get(0).workflowInstance().workflowId().componentId(), is(COMPONENT_ID));
+  }
+
+  @Test
+  public void testGetActiveStatesFailedDueToStorageIOException() throws Exception {
+    sinceVersion(Api.Version.V3);
+
+    IOException ioException = new IOException("forced failure");
+    when(storage.readActiveStates()).thenThrow(ioException);
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("GET", path("/activeStates")));
+
+    assertThat(response, hasStatus(withCode(Status.INTERNAL_SERVER_ERROR)));
+    assertThat(response, hasStatus(withReasonPhrase(is(": \"" + ioException.toString() + "\""))));
+  }
+
+  private Connection setupBigTableMockTable() {
+    Connection bigtable = mock(Connection.class);
+    try {
+      new BigtableMocker(bigtable)
+          .setNumFailures(0)
+          .setupTable(BigtableStorage.EVENTS_TABLE_NAME)
+          .finalizeMocking();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return bigtable;
   }
 }

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -36,6 +36,7 @@ import static org.fusesource.jansi.Ansi.Color.YELLOW;
 import com.google.common.base.Joiner;
 import com.spotify.styx.api.BackfillPayload;
 import com.spotify.styx.api.RunStateDataPayload;
+import com.spotify.styx.api.RunStateDataPayload.RunStateData;
 import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Schedule;
@@ -323,7 +324,7 @@ class PrettyCliOutput implements CliOutput {
     }
   }
 
-  private Ansi getAnsiForState(RunStateDataPayload.RunStateData RunStateData) {
+  private Ansi getAnsiForState(RunStateData RunStateData) {
     final String state = RunStateData.state();
     switch (state) {
       case "WAITING":    return coloredBright(BLACK, state);

--- a/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
@@ -220,7 +220,7 @@ public class PrettyCliOutputTest {
   }
 
   @Test
-  public void shouldPrintStates() throws Exception {
+  public void shouldPrintStates() {
     final RunStateDataPayload states = RunStateDataPayload.create(ImmutableList.of(
         RunStateData.create(
             WorkflowInstance.create(WorkflowId.create("c0", "w0"), "2016-09-01"),

--- a/styx-common/src/main/java/com/spotify/styx/api/RunStateDataPayload.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/RunStateDataPayload.java
@@ -20,51 +20,59 @@
 
 package com.spotify.styx.api;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.auto.value.AutoValue;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.StateData;
+import io.norberg.automatter.AutoMatter;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Value type for all current active states
  */
-@AutoValue
-public abstract class RunStateDataPayload {
+@AutoMatter
+public interface RunStateDataPayload {
 
-  @JsonProperty
-  //todo change the name of this variable, remove 'active'
-  public abstract List<RunStateData> activeStates();
+  // todo change the name of this variable, remove 'active'
+  // however this will be a breaking change
+  List<RunStateData> activeStates();
 
-  @AutoValue
-  public abstract static class RunStateData {
+  @AutoMatter
+  interface RunStateData {
 
-    public static final Comparator<RunStateData> PARAMETER_COMPARATOR =
+    Comparator<RunStateData> PARAMETER_COMPARATOR =
         Comparator.comparing(a -> a.workflowInstance().parameter());
 
-    @JsonProperty
-    public abstract WorkflowInstance workflowInstance();
+    WorkflowInstance workflowInstance();
 
-    @JsonProperty
-    public abstract String state();
+    String state();
 
-    @JsonProperty
-    public abstract StateData stateData();
+    StateData stateData();
 
-    @JsonCreator
-    public static RunStateData create(
-        @JsonProperty("workflow_instance") WorkflowInstance workflowInstance,
-        @JsonProperty("state") String state,
-        @JsonProperty("state_data") StateData stateData) {
-      return new AutoValue_RunStateDataPayload_RunStateData(workflowInstance, state, stateData);
+    Optional<Long> initialTimestamp();
+
+    Optional<Long> latestTimestamp();
+
+    RunStateDataBuilder builder();
+
+    static RunStateDataBuilder newBuilder() {
+      return new RunStateDataBuilder();
+    }
+
+    static RunStateData create(
+        WorkflowInstance workflowInstance,
+        String state,
+        StateData stateData) {
+      return newBuilder()
+          .workflowInstance(workflowInstance)
+          .state(state)
+          .stateData(stateData)
+          .build();
     }
   }
 
-  @JsonCreator
-  public static RunStateDataPayload create(
-      @JsonProperty("active_states") List<RunStateData> runStateDataList) {
-    return new AutoValue_RunStateDataPayload(runStateDataList);
+  static RunStateDataPayload create(
+      List<RunStateData> runStateDataList) {
+    return new RunStateDataPayloadBuilder().activeStates(runStateDataList).build();
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
@@ -66,7 +66,7 @@ public final class ReplayEvents {
 
       if (triggerExecutionEventMet) {
         if (backfillFound) {
-          return Optional.of(restoredState);
+          break;
         }
         restoredState = RunState.fresh(workflowInstance, time);
       }

--- a/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx.util;
 
+import com.spotify.styx.api.RunStateDataPayload.RunStateData;
 import com.spotify.styx.model.SequenceEvent;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.RunState;
@@ -35,7 +36,7 @@ public final class ReplayEvents {
     throw new UnsupportedOperationException();
   }
 
-  public static Optional<RunState> getBackfillRunState(
+  public static Optional<RunStateData> getBackfillRunStateData(
       WorkflowInstance workflowInstance,
       Storage storage,
       String backfillId) {
@@ -50,6 +51,9 @@ public final class ReplayEvents {
 
     boolean backfillFound = false;
 
+    final SettableTime initialTime = new SettableTime();
+    final SettableTime latestTime = new SettableTime();
+
     // events are written after the datastore transition transaction is successfully
     // committed, so we can trust the sequence of events faithfully reflect the state
     // transition if they have all been successfully written to bigtable
@@ -63,17 +67,31 @@ public final class ReplayEvents {
         if (backfillFound) {
           break;
         }
+
         restoredState = RunState.fresh(workflowInstance, time);
+        initialTime.set(time.get());
       }
 
       restoredState = restoredState.transition(sequenceEvent.event(), time);
+      latestTime.set(time.get());
 
       if (backfillFound(triggerExecutionEventMet, backfillId, restoredState)) {
         backfillFound = true;
       }
     }
 
-    return backfillFound ? Optional.of(restoredState) : Optional.empty();
+    if (backfillFound) {
+      final RunStateData runStateData = RunStateData.newBuilder()
+          .workflowInstance(restoredState.workflowInstance())
+          .state(restoredState.state().name())
+          .stateData(restoredState.data())
+          .initialTimestamp(initialTime.get().toEpochMilli())
+          .latestTimestamp(latestTime.get().toEpochMilli())
+          .build();
+      return Optional.of(runStateData);
+    } else {
+      return Optional.empty();
+    }
   }
 
   private static SortedSet<SequenceEvent> getSequenceEvents(

--- a/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
@@ -73,7 +73,7 @@ public final class ReplayEvents {
 
       restoredState = restoredState.transition(sequenceEvent.event(), time);
 
-      if (triggerExecutionEventMet && triggerIdMatches(backfillId, restoredState)) {
+      if (backfillFound(triggerExecutionEventMet, backfillId, restoredState)) {
         backfillFound = true;
       }
     }
@@ -81,8 +81,9 @@ public final class ReplayEvents {
     return backfillFound ? Optional.of(restoredState) : Optional.empty();
   }
 
-  private static Boolean triggerIdMatches(String backfillId, RunState restoredState) {
-    return restoredState.data().trigger()
+  private static boolean backfillFound(boolean triggerExecutionEventMet,
+                                       String backfillId, RunState restoredState) {
+    return triggerExecutionEventMet && restoredState.data().trigger()
         .map(trigger -> backfillId.equals(TriggerUtil.triggerId(trigger)))
         .orElse(false);
   }

--- a/styx-common/src/test/java/com/spotify/styx/util/GrpcContextUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/GrpcContextUtilTest.java
@@ -154,6 +154,6 @@ public class GrpcContextUtilTest {
 
   @Test
   public void shouldNotBeConstructable() throws ReflectiveOperationException {
-    ClassEnforcer.assertNotInstantiable(GrpcContextUtil.class);
+    assertThat(ClassEnforcer.assertNotInstantiable(GrpcContextUtil.class), is(true));
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
@@ -63,7 +63,7 @@ public class ReplayEventsTest {
 
   @Test
   public void shouldNotBeConstructable() throws ReflectiveOperationException {
-    ClassEnforcer.assertNotInstantiable(ReplayEvents.class);
+    assertThat(ClassEnforcer.assertNotInstantiable(ReplayEvents.class), is(true));
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ReplayEventsTest.java
@@ -54,11 +54,16 @@ public class ReplayEventsTest {
           "BAR", "bar")
       .build();
 
-  Storage storage;
+  private Storage storage;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() {
     storage = mock(Storage.class);
+  }
+
+  @Test
+  public void shouldNotBeConstructable() throws ReflectiveOperationException {
+    ClassEnforcer.assertNotInstantiable(ReplayEvents.class);
   }
 
   @Test

--- a/styx-test/src/main/java/com/spotify/styx/util/ClassEnforcer.java
+++ b/styx-test/src/main/java/com/spotify/styx/util/ClassEnforcer.java
@@ -38,7 +38,7 @@ public class ClassEnforcer {
    * @throws ReflectiveOperationException if cls does not have a default constructor
    * @throws AssertionError if
    */
-  public static void assertNotInstantiable(Class<?> cls) throws ReflectiveOperationException {
+  public static boolean assertNotInstantiable(Class<?> cls) throws ReflectiveOperationException {
     if (cls.getDeclaredConstructors().length != 1) {
       throw new AssertionError("Class should only have a single private constructor: " + cls.getName());
     }
@@ -51,7 +51,7 @@ public class ClassEnforcer {
       constructor.newInstance();
     } catch (InvocationTargetException e) {
       if (e.getCause() instanceof UnsupportedOperationException) {
-        return;
+        return true;
       }
     }
     throw new AssertionError("Constructor should throw UnsupportedOperationException: " + cls.getName());

--- a/styx-test/src/test/java/com/spotify/styx/util/ClassEnforcerTest.java
+++ b/styx-test/src/test/java/com/spotify/styx/util/ClassEnforcerTest.java
@@ -83,7 +83,7 @@ public class ClassEnforcerTest {
   private static class FailingInstantiable {
 
     private FailingInstantiable() {
-      throw new NullPointerException();
+      throw new RuntimeException();
     }
   }
 
@@ -100,7 +100,7 @@ public class ClassEnforcerTest {
       throw new UnsupportedOperationException();
     }
 
-    public InstantiableWithArgs(String arg) {
+    public InstantiableWithArgs(String ignored) {
     }
   }
 }

--- a/styx-test/src/test/java/com/spotify/styx/util/ClassEnforcerTest.java
+++ b/styx-test/src/test/java/com/spotify/styx/util/ClassEnforcerTest.java
@@ -20,6 +20,9 @@
 
 package com.spotify.styx.util;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -30,7 +33,7 @@ public class ClassEnforcerTest {
 
   @Test
   public void shouldAssertNotInstantiable() throws ReflectiveOperationException {
-    ClassEnforcer.assertNotInstantiable(ClassEnforcer.class);
+    assertThat(ClassEnforcer.assertNotInstantiable(ClassEnforcer.class), is(true));
   }
 
   @Test

--- a/styx-test/src/test/java/com/spotify/styx/util/ClassEnforcerTest.java
+++ b/styx-test/src/test/java/com/spotify/styx/util/ClassEnforcerTest.java
@@ -100,7 +100,7 @@ public class ClassEnforcerTest {
       throw new UnsupportedOperationException();
     }
 
-    public InstantiableWithArgs(String ignored) {
+    public InstantiableWithArgs(String ignored) { // NOPMD
     }
   }
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Include those timestamps so that for completed workflow instance the client will be able to tell when it started and when it finished.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Timestamps can be used to check how long it took for the workflow instance to complete.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [x] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [x] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [x] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
