### PR TITLE
cli: allow inline `-e NAME=val`

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -812,21 +812,18 @@ public final class CliMain {
 
     private Argument addEnvVarArgument(ArgumentParser parser, String... flags) {
       return parser.addArgument(flags).type(String.class)
-          .help("Environment variables")
           .action(append())
-          .setDefault(new ArrayList<>())
-          .nargs("*");
+          .help("Environment variables");
     }
 
     private Map<String, String> getEnvVars(Namespace namespace, Argument argument) {
-      final List<List<String>> args = namespace.getList(argument.getDest());
+      final List<String> args = namespace.getList(argument.getDest());
       return args == null
           ? Collections.emptyMap()
           : args.stream()
-                .flatMap(Collection::stream)
-                .map(s -> Splitter.on('=').splitToList(s))
-                .peek(kv -> Preconditions.checkArgument(kv.size() == 2))
-                .collect(toMap(kv -> kv.get(0), kv -> kv.get(1)));
+              .map(s -> Splitter.on('=').splitToList(s))
+              .peek(kv -> Preconditions.checkArgument(kv.size() == 2))
+              .collect(toMap(kv -> kv.get(0), kv -> kv.get(1)));
     }
   }
 

--- a/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
@@ -270,8 +270,8 @@ public class CliMainTest {
     when(client.backfillCreate(expectedInput))
         .thenReturn(CompletableFuture.completedFuture(backfill));
 
-    CliMain.run(cliContext, "backfill", "create", component, "foo", "2017-01-01", "2017-01-30",
-        "1", "-e", "FOO=foo", "BAR=bar", "--env", "BAZ=baz", "-e", "FOOBAR=");
+    CliMain.run(cliContext, "backfill", "create", "-e", "FOO=foo", component, "foo", "2017-01-01", "2017-01-30",
+        "1", "-e", "BAR=bar", "--env", "BAZ=baz", "-e", "FOOBAR=");
 
     verify(client).backfillCreate(expectedInput);
     verify(cliOutput).printBackfill(backfill, true);
@@ -282,8 +282,8 @@ public class CliMainTest {
     final String component = "quux";
 
     try {
-      CliMain.run(cliContext, "backfill", "create", component, "foo", "2017-01-01", "2017-01-30",
-          "1", "-e", "FOO=foo", "BAR=bar", "--env", "BAZ=baz", "-e", "FOOBAR");
+      CliMain.run(cliContext, "backfill", "create", "-e", "FOO=foo", component, "foo", "2017-01-01", "2017-01-30",
+          "1", "-e", "BAR=bar", "--env", "BAZ=baz", "-e", "FOOBAR");
       fail();
     } catch (CliExitException e) {
       assertThat(e.status(), is(ExitStatus.UnknownError));
@@ -810,7 +810,7 @@ public class CliMainTest {
     when(client.triggerWorkflowInstance("foo", "bar", "2017-01-02", expectedParameters))
         .thenReturn(CompletableFuture.completedFuture(null));
 
-    CliMain.run(cliContext, "t", "foo", "bar", "2017-01-02", "-e", "FOO=foo", "BAR=bar", "--env", "BAZ=baz");
+    CliMain.run(cliContext, "t", "-e", "FOO=foo", "foo", "bar", "2017-01-02", "-e", "BAR=bar", "--env", "BAZ=baz");
 
     verify(client).triggerWorkflowInstance("foo", "bar", "2017-01-02", expectedParameters);
   }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Allow `styx t -e FOO=bar comp wf param` and `styx backfill create -e FOO=bar comp wf start end conc`

## Motivation and Context
The `-e` argument swallowed all subsequent args that did not start with
`-`, including component, workflow id etc.

Now the `-e` argument will only take one subsequent `NAME=val` arg.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [x] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [x] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
