### PR TITLE
api: add instances?tail=true to get latest WFIs (alternative to #591)

### DIFF
--- a/doc/api.apib
+++ b/doc/api.apib
@@ -190,11 +190,15 @@ Returns 204 No Content if the Workflow was found and deleted, 404 Not Found othe
 + Response 204
 + Response 404
 
-## Workflow Instances [/{version}/workflows/{component_id}/{workflow_id}/instances{?offset,limit,start,stop}]
+## Workflow Instances [/{version}/workflows/{component_id}/{workflow_id}/instances{?offset,limit,tail,start,stop}]
 
-Query can be done in two different styles: `offset+limit` or `start+stop`.
+Query can be done in three different styles: `tail+limit`, `offset+limit`, or `start+stop`.
 
-By using `offset` and `limit`, the oldest workflow instances is specified by `offset`, and
+By using `tail=true` and `limit`, the oldest workflow instance is identified by
+`next_natural_trigger - limit`, and the latest is the most recently naturally triggered instance.
+Setting `tail=false` behaves the same as omitting it.
+
+By using `offset` and `limit`, the oldest workflow instance is specified by `offset`, and
 the max number of workflows instances is specified by `limit`.
 
 By using `start` and `stop`, the oldest workflow instance is specified by `start`, and the latest is
@@ -206,10 +210,11 @@ specified by `stop`; `start` is required while `stop` is optional.
             + `v3`
     + component_id: `styx-canary` (string) - Workflow Component
     + workflow_id: `StyxCanary` (string) - Workflow ID
-    + offset: `2017-01-01` (string) - the offset parameter
-    + limit: `10` (number) - max number of instances
-    + start: `2017-01-01` (string) - the start parameter
-    + stop: `2017-01-03` (string) - the stop parameter (exclusive)
+    + offset: `2017-01-01` (optional, string) - the offset parameter
+    + limit: `10` (optional, number) - max number of instances, default to `24 * 7`
+    + tail: `true` (optional, boolean) - return the newest workflow instances, default to false
+    + start: `2017-01-01` (optional, string) - the start parameter
+    + stop: `2017-01-03` (optional, string) - the stop parameter (exclusive)
 
 ### Get Workflow Instances [GET]
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/BigtableStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/BigtableStorage.java
@@ -116,7 +116,7 @@ public class BigtableStorage {
 
       if (!Strings.isNullOrEmpty(offset)) {
         final WorkflowInstance offsetInstance = WorkflowInstance.create(workflowId, offset);
-        scan.setStartRow(Bytes.toBytes(offsetInstance.toKey() + '#'));
+        scan.withStartRow(Bytes.toBytes(offsetInstance.toKey() + '#'), true);
       }
 
       final Set<WorkflowInstance> workflowInstancesSet = Sets.newHashSet();
@@ -148,11 +148,11 @@ public class BigtableStorage {
           .setFilter(new FirstKeyOnlyFilter());
 
       final WorkflowInstance startRow = WorkflowInstance.create(workflowId, start);
-      scan.setStartRow(Bytes.toBytes(startRow.toKey() + '#'));
+      scan.withStartRow(Bytes.toBytes(startRow.toKey() + '#'), true);
 
       if (!Strings.isNullOrEmpty(stop)) {
         final WorkflowInstance stopRow = WorkflowInstance.create(workflowId, stop);
-        scan.setStopRow(Bytes.toBytes(stopRow.toKey() + '#'));
+        scan.withStopRow(Bytes.toBytes(stopRow.toKey() + '#'), true);
       }
 
       final Set<WorkflowInstance> workflowInstancesSet = Sets.newHashSet();

--- a/styx-common/src/main/java/com/spotify/styx/storage/BigtableStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/BigtableStorage.java
@@ -116,7 +116,7 @@ public class BigtableStorage {
 
       if (!Strings.isNullOrEmpty(offset)) {
         final WorkflowInstance offsetInstance = WorkflowInstance.create(workflowId, offset);
-        scan.withStartRow(Bytes.toBytes(offsetInstance.toKey() + '#'), true);
+        scan.setStartRow(Bytes.toBytes(offsetInstance.toKey() + '#'));
       }
 
       final Set<WorkflowInstance> workflowInstancesSet = Sets.newHashSet();
@@ -148,11 +148,11 @@ public class BigtableStorage {
           .setFilter(new FirstKeyOnlyFilter());
 
       final WorkflowInstance startRow = WorkflowInstance.create(workflowId, start);
-      scan.withStartRow(Bytes.toBytes(startRow.toKey() + '#'), true);
+      scan.setStartRow(Bytes.toBytes(startRow.toKey() + '#'));
 
       if (!Strings.isNullOrEmpty(stop)) {
         final WorkflowInstance stopRow = WorkflowInstance.create(workflowId, stop);
-        scan.withStopRow(Bytes.toBytes(stopRow.toKey() + '#'), true);
+        scan.setStopRow(Bytes.toBytes(stopRow.toKey() + '#'));
       }
 
       final Set<WorkflowInstance> workflowInstancesSet = Sets.newHashSet();

--- a/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
@@ -26,6 +26,7 @@ import static com.spotify.styx.util.TimeUtil.instantsInReversedRange;
 import static com.spotify.styx.util.TimeUtil.isAligned;
 import static com.spotify.styx.util.TimeUtil.lastInstant;
 import static com.spotify.styx.util.TimeUtil.nextInstant;
+import static com.spotify.styx.util.TimeUtil.instantWithOffsetTo;
 import static java.time.Instant.parse;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
@@ -332,7 +333,6 @@ public class TimeUtilTest {
         instantsInRange(firstTimeHours, lastTimeHours, Schedule.parse("0 * * * *")).isEmpty());
   }
 
-
   @Test
   public void shouldGetExceptionIfLastInstantIsBeforeFirstInstantReversed() {
     final Instant firstTimeHours = parse("2016-01-19T09:00:00.00Z");
@@ -364,5 +364,31 @@ public class TimeUtilTest {
     expect.expectMessage("unaligned instant");
 
     instantsInReversedRange(firstTimeHours, lastTimeHours, Schedule.HOURS);
+  }
+
+  @Test
+  public void shouldGetCorrectInstantWithNegativeOffset() {
+    assertThat(instantWithOffsetTo(parse("2018-01-19T09:00:00.00Z"), -2, Schedule.HOURS),
+        is(parse("2018-01-19T07:00:00.00Z")));
+  }
+
+  @Test
+  public void shouldGetCorrectInstantWithPositiveOffset() {
+    assertThat(instantWithOffsetTo(parse("2018-01-19T09:00:00.00Z"), 2, Schedule.HOURS),
+        is(parse("2018-01-19T11:00:00.00Z")));
+  }
+
+  @Test
+  public void shouldGetCorrectInstantWithZeroOffset() {
+    assertThat(instantWithOffsetTo(parse("2018-01-19T09:00:00.00Z"), 0, Schedule.HOURS),
+        is(parse("2018-01-19T09:00:00.00Z")));
+  }
+
+  @Test
+  public void shouldGetExceptionIfReferenceInstantIsNotAlignedWithSchedule() {
+    expect.expect(IllegalArgumentException.class);
+    expect.expectMessage("unaligned reference instant");
+
+    instantWithOffsetTo(parse("2016-01-19T09:10:00.00Z"), 0, Schedule.HOURS);
   }
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Allow fetching the latest (by parameter) instances of a workflow.

Alternative to #591.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users want an easy way to to get the latest instances of a workflow for health checking purposes.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
