### PR TITLE
Fix unsupported unit

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/TimeUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/TimeUtil.java
@@ -119,13 +119,11 @@ public class TimeUtil {
    */
   public static List<Instant> instantsInRange(Instant firstInstant, Instant lastInstant,
                                               Schedule schedule) {
-    if (!isAligned(firstInstant, schedule) || !isAligned(lastInstant, schedule)) {
-      throw new IllegalArgumentException("unaligned instant");
-    }
-
-    if (lastInstant.isBefore(firstInstant)) {
-      throw new IllegalArgumentException("last instant should not be before first instant");
-    }
+    Preconditions.checkArgument(
+        isAligned(firstInstant, schedule) && isAligned(lastInstant, schedule),
+        "unaligned instant");
+    Preconditions.checkArgument(!lastInstant.isBefore(firstInstant),
+        "last instant should not be before first instant");
 
     final ExecutionTime executionTime = ExecutionTime.forCron(cron(schedule));
     final List<Instant> instants = new ArrayList<>();
@@ -154,13 +152,11 @@ public class TimeUtil {
    */
   public static List<Instant> instantsInReversedRange(Instant firstInstant, Instant lastInstant,
                                                       Schedule schedule) {
-    if (!isAligned(firstInstant, schedule) || !isAligned(lastInstant, schedule)) {
-      throw new IllegalArgumentException("unaligned instant");
-    }
-
-    if (lastInstant.isAfter(firstInstant)) {
-      throw new IllegalArgumentException("last instant should not be after first instant");
-    }
+    Preconditions.checkArgument(
+        isAligned(firstInstant, schedule) && isAligned(lastInstant, schedule),
+        "unaligned instant");
+    Preconditions.checkArgument(!lastInstant.isAfter(firstInstant),
+        "last instant should not be after first instant");
 
     final ExecutionTime executionTime = ExecutionTime.forCron(cron(schedule));
     final List<Instant> instants = new ArrayList<>();

--- a/styx-common/src/main/java/com/spotify/styx/util/TimeUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/TimeUtil.java
@@ -263,7 +263,7 @@ public class TimeUtil {
   }
 
   public static Instant offsetInstant(Instant origin, Schedule schedule, int offset) {
-    Preconditions.checkArgument(isAligned(origin, schedule), "Unaligned origin");
+    Preconditions.checkArgument(isAligned(origin, schedule), "unaligned origin");
     return schedule.wellKnown().unit()
         .map(unit -> {
           try {

--- a/styx-common/src/main/java/com/spotify/styx/util/TimeUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/TimeUtil.java
@@ -36,10 +36,10 @@ import java.time.Period;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAmount;
+import java.time.temporal.UnsupportedTemporalTypeException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javaslang.control.Try;
 
 /**
  * Static utility functions for manipulating time based on {@link Schedule} and offsets.
@@ -269,7 +269,13 @@ public class TimeUtil {
   public static Instant offsetInstant(Instant origin, Schedule schedule, int offset) {
     Preconditions.checkArgument(isAligned(origin, schedule), "Unaligned origin");
     return schedule.wellKnown().unit()
-        .map(unit -> Try.of(() -> origin.plus(offset, unit)).orElse(null))
+        .map(unit -> {
+          try {
+            return origin.plus(offset, unit);
+          } catch (UnsupportedTemporalTypeException ignored) {
+            return null;
+          }
+        })
         .orElseGet(() -> {
           final ExecutionTime executionTime = ExecutionTime.forCron(cron(schedule));
           ZonedDateTime time = origin.atZone(UTC);

--- a/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
@@ -38,10 +38,14 @@ import static org.junit.Assert.assertTrue;
 import com.spotify.styx.model.Schedule;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 
+@RunWith(JUnitParamsRunner.class)
 public class TimeUtilTest {
 
   private static final Instant TIME = parse("2016-01-19T09:11:22.333Z");
@@ -369,21 +373,42 @@ public class TimeUtilTest {
   }
 
   @Test
-  public void shouldGetCorrectInstantWithNegativeOffset() {
-    assertThat(offsetInstant(parse("2018-01-19T09:00:00.00Z"), Schedule.HOURS, -2),
-        is(parse("2018-01-19T07:00:00.00Z")));
+  @Parameters({
+      "2018-01-19T09:00:00.00Z, hours, 2018-01-19T07:00:00.00Z",
+      "2018-01-19T00:00:00.00Z, days, 2018-01-17T00:00:00.00Z",
+      "2018-01-15T00:00:00.00Z, weeks, 2018-01-01T00:00:00Z",
+      "2018-01-01T00:00:00.00Z, months, 2017-11-01T00:00:00.00Z",
+      "2018-01-01T00:00:00.00Z, years, 2016-01-01T00:00:00.00Z",
+  })
+  public void shouldGetCorrectInstantWithNegativeOffset(String origin, String schedule,
+                                                        String expected) {
+    assertThat(offsetInstant(parse(origin), Schedule.parse(schedule), -2), is(parse(expected)));
   }
 
   @Test
-  public void shouldGetCorrectInstantWithPositiveOffset() {
-    assertThat(offsetInstant(parse("2018-01-19T09:00:00.00Z"), Schedule.HOURS, 2),
-        is(parse("2018-01-19T11:00:00.00Z")));
+  @Parameters({
+      "2018-01-19T09:00:00.00Z, hours, 2018-01-19T11:00:00.00Z",
+      "2018-01-19T00:00:00.00Z, days, 2018-01-21T00:00:00.00Z",
+      "2018-01-15T00:00:00.00Z, weeks, 2018-01-29T00:00:00Z",
+      "2018-01-01T00:00:00.00Z, months, 2018-03-01T00:00:00.00Z",
+      "2018-01-01T00:00:00.00Z, years, 2020-01-01T00:00:00.00Z",
+  })
+  public void shouldGetCorrectInstantWithPositiveOffset(String origin, String schedule,
+                                                        String expected) {
+    assertThat(offsetInstant(parse(origin), Schedule.parse(schedule), 2), is(parse(expected)));
   }
 
   @Test
-  public void shouldGetCorrectInstantWithZeroOffset() {
-    assertThat(offsetInstant(parse("2018-01-19T09:00:00.00Z"), Schedule.HOURS, 0),
-        is(parse("2018-01-19T09:00:00.00Z")));
+  @Parameters({
+      "2018-01-19T09:00:00.00Z, hours, 2018-01-19T09:00:00.00Z",
+      "2018-01-19T00:00:00.00Z, days, 2018-01-19T00:00:00.00Z",
+      "2018-01-15T00:00:00.00Z, weeks, 2018-01-15T00:00:00Z",
+      "2018-01-01T00:00:00.00Z, months, 2018-01-01T00:00:00.00Z",
+      "2018-01-01T00:00:00.00Z, years, 2018-01-01T00:00:00.00Z",
+  })
+  public void shouldGetCorrectInstantWithZeroOffset(String origin, String schedule,
+                                                    String expected) {
+    assertThat(offsetInstant(parse(origin), Schedule.parse(schedule), 0), is(parse(expected)));
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
@@ -432,7 +432,7 @@ public class TimeUtilTest {
   @Test
   public void shouldGetExceptionIfReferenceInstantIsNotAlignedWithSchedule() {
     expect.expect(IllegalArgumentException.class);
-    expect.expectMessage("Unaligned origin");
+    expect.expectMessage("unaligned origin");
 
     offsetInstant(parse("2016-01-19T09:10:00.00Z"), Schedule.HOURS, 0);
   }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
`Instant#plus()` doesn't support `weeks`, `months`, `years`, etc. This fixes that by falling back to computing step by step.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without needing to support those cases with a proper implementation of `plus` function, falling back seems good enough for those units in terms of performance.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [x] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
