### PR TITLE
set parameter in ExecutionDescription

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx.state.handlers;
 
+import static com.spotify.styx.state.handlers.HandlerUtil.argsReplace;
 import static java.util.Objects.requireNonNull;
 
 import com.spotify.styx.docker.DockerRunner;
@@ -32,8 +33,6 @@ import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.util.IsClosedException;
 import com.spotify.styx.util.ResourceNotFoundException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -140,12 +139,5 @@ public class DockerRunnerHandler implements OutputHandler {
         .commitSha(state.data().executionDescription().flatMap(ExecutionDescription::commitSha))
         .env(executionDescription.env())
         .build();
-  }
-
-  private static List<String> argsReplace(List<String> template, String parameter) {
-    List<String> result = new ArrayList<>(template);
-
-    Collections.replaceAll(result, "{}", parameter);
-    return result;
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx.state.handlers;
 
+import static com.spotify.styx.state.handlers.HandlerUtil.argsReplace;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -124,13 +125,14 @@ public class ExecutionDescriptionHandler implements OutputHandler {
 
     final List<String> dockerArgs = workflow.configuration().dockerArgs()
         .orElse(Collections.emptyList());
+    final List<String> command = argsReplace(dockerArgs, workflowInstance.parameter());
 
     final Map<String, String> env = new HashMap<>(workflow.configuration().env());
     data.triggerParameters().ifPresent(p -> env.putAll(p.env()));
 
     return ExecutionDescription.builder()
         .dockerImage(dockerImage)
-        .dockerArgs(dockerArgs)
+        .dockerArgs(command)
         .dockerTerminationLogging(workflow.configuration().dockerTerminationLogging())
         .secret(workflow.configuration().secret())
         .serviceAccount(workflow.configuration().serviceAccount())

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/HandlerUtil.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/HandlerUtil.java
@@ -1,15 +1,15 @@
 /*-
  * -\-\-
- * Spotify styx
+ * Spotify Styx Scheduler Service
  * --
- * Copyright (C) 2018 Spotify AB
+ * Copyright (C) 2016 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/HandlerUtil.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/HandlerUtil.java
@@ -1,0 +1,38 @@
+/*-
+ * -\-\-
+ * Spotify styx
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.state.handlers;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class HandlerUtil {
+  private HandlerUtil() {
+    throw new UnsupportedOperationException();
+  }
+
+  static List<String> argsReplace(List<String> template, String parameter) {
+    List<String> result = new ArrayList<>(template);
+
+    Collections.replaceAll(result, "{}", parameter);
+    return result;
+  }
+}

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
@@ -130,7 +130,7 @@ public class ExecutionDescriptionHandlerTest {
     assertThat(executionIdCaptor.getValue(), startsWith("styx-run-"));
     assertThat(executionDescriptionCaptor.getValue().dockerImage(), is(DOCKER_IMAGE));
     assertThat(executionDescriptionCaptor.getValue().commitSha(), hasValue(COMMIT_SHA));
-    assertThat(executionDescriptionCaptor.getValue().dockerArgs(), contains("--date", "{}", "--bar"));
+    assertThat(executionDescriptionCaptor.getValue().dockerArgs(), contains("--date", "2016-03-14", "--bar"));
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/HandlerUtilTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/HandlerUtilTest.java
@@ -1,15 +1,15 @@
 /*-
  * -\-\-
- * Spotify styx
+ * Spotify Styx Scheduler Service
  * --
- * Copyright (C) 2018 Spotify AB
+ * Copyright (C) 2016 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/HandlerUtilTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/HandlerUtilTest.java
@@ -1,0 +1,47 @@
+/*-
+ * -\-\-
+ * Spotify styx
+ * --
+ * Copyright (C) 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.state.handlers;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.spotify.styx.util.ClassEnforcer;
+import org.junit.Test;
+
+public class HandlerUtilTest {
+  @Test
+  public void shouldNotBeConstructable() throws ReflectiveOperationException {
+    assertThat(ClassEnforcer.assertNotInstantiable(HandlerUtil.class), is(true));
+  }
+  
+  @Test
+  public void shouldReplaceArgs() {
+    assertThat(HandlerUtil.argsReplace(ImmutableList.of("foo", "bar", "{}"), "foobar"),
+        is(ImmutableList.of("foo", "bar", "foobar")));
+  }
+
+  @Test
+  public void shouldDoNothingIfNoPlaceholder() {
+    assertThat(HandlerUtil.argsReplace(ImmutableList.of("foo", "bar", "foobar"), "barfoo"),
+        is(ImmutableList.of("foo", "bar", "foobar")));
+  }
+}


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Set parameter in execution description, instead of the `{}` placeholder.

This PR changes event content, so technically backward incompatible.

## Motivation and Context
When users see an execution description in `styx events` etc, the `{}` part is confusing; they think they made an error by somehow failing to set a date.
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [x] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [x] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
