### PR TITLE
Unhalt backfill

### DIFF
--- a/doc/api.apib
+++ b/doc/api.apib
@@ -630,6 +630,7 @@ Workflow Instance belonging to a Backfill entity.
         {
             "concurrency": 20,
             "description": "fixed bug and reproduce data",
+            "halted": false,
             "id": "backfill-1489054446085-52684",
         }
 

--- a/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/BackfillResource.java
@@ -379,6 +379,7 @@ public final class BackfillResource implements Closeable {
           final BackfillBuilder backfillBuilder = oldBackfill.get().builder();
           backfillInput.concurrency().ifPresent(backfillBuilder::concurrency);
           backfillInput.description().ifPresent(backfillBuilder::description);
+          backfillInput.halted().ifPresent(backfillBuilder::halted);
           return tx.store(backfillBuilder.build());
         }
       });

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -679,12 +679,15 @@ public class BackfillResourceTest extends VersionedApiTest {
   public void shouldUpdateBackfill() throws Exception {
     sinceVersion(Api.Version.V3);
 
+    storage.storeBackfill(BACKFILL_1.builder().halted(true).build());
     assertThat(storage.backfill(BACKFILL_1.id()).get().concurrency(), equalTo(1));
+    assertThat(storage.backfill(BACKFILL_1.id()).get().halted(), is(true));
 
     final EditableBackfillInput backfillInput = EditableBackfillInput.newBuilder()
         .id(BACKFILL_1.id())
         .concurrency(4)
         .description("foobar")
+        .halted(false)
         .build();
     final String json = Json.OBJECT_MAPPER.writeValueAsString(backfillInput);
 
@@ -697,10 +700,12 @@ public class BackfillResourceTest extends VersionedApiTest {
     assertJson(response, "id", equalTo(BACKFILL_1.id()));
     assertJson(response, "concurrency", equalTo(4));
     assertJson(response, "description", is("foobar"));
+    assertJson(response, "halted", is(false));
 
     assertThat(storage.backfill(BACKFILL_1.id()).get(), is(BACKFILL_1.builder()
         .concurrency(4)
         .description("foobar")
+        .halted(false)
         .build()));
   }
 

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -210,6 +210,9 @@ public final class CliMain {
             case HALT:
               backfillHalt();
               break;
+            case UNHALT:
+              backfillUnhalt();
+              break;
             case SHOW:
               backfillShow();
               break;
@@ -499,6 +502,14 @@ public final class CliMain {
                            + "` to check the backfill status.");
   }
 
+  private void backfillUnhalt() throws ExecutionException, InterruptedException {
+    final String id = namespace.getString(parser.backfillUnhaltId.getDest());
+
+    styxClient.backfillUnhalt(id).toCompletableFuture().get();
+    cliOutput.printMessage("Backfill unhalted! Use `styx backfill show " + id
+                           + "` to check the backfill status.");
+  }
+
   private void backfillShow() throws ExecutionException, InterruptedException {
     final String id = namespace.getString(parser.backfillShowId.getDest());
     final boolean noTruncate = namespace.getBoolean((parser.backfillShowNoTruncate.getDest()));
@@ -657,6 +668,10 @@ public final class CliMain {
     final Subparser backfillHalt = BackfillCommand.HALT.parser(backfillParser);
     final Argument backfillHaltId =
         backfillHalt.addArgument("backfill").help("Backfill ID");
+
+    final Subparser backfillUnhalt = BackfillCommand.UNHALT.parser(backfillParser);
+    final Argument backfillUnhaltId =
+        backfillUnhalt.addArgument("backfill").help("Backfill ID");
 
     final Subparser backfillList = BackfillCommand.LIST.parser(backfillParser);
     final Argument backfillListWorkflow =
@@ -865,6 +880,7 @@ public final class CliMain {
     CREATE("", "Create a backfill"),
     EDIT("e", "Edit a backfill"),
     HALT("h", "Halt a backfill"),
+    UNHALT("u", "Unhalt a halted backfill"),
     SHOW("get", "Show info about a specific backfill");
 
     private final String alias;

--- a/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
@@ -199,7 +199,7 @@ public class CliMainTest {
   }
 
   @Test
-  public void testBackfillCreate() throws Exception {
+  public void testBackfillCreate() {
     final String component = "quux";
     final String start = "2017-01-01T00:00:00Z";
     final String end = "2017-01-30T00:00:00Z";
@@ -291,7 +291,7 @@ public class CliMainTest {
   }
 
   @Test
-  public void testBackfillCreateReverse() throws Exception {
+  public void testBackfillCreateReverse() {
     final String component = "quux";
     final Instant start = Instant.parse("2017-01-01T00:00:00Z");
     final Instant end = Instant.parse("2017-01-30T00:00:00Z");
@@ -327,7 +327,7 @@ public class CliMainTest {
   }
 
   @Test
-  public void testBackfillCreateWithDescription() throws Exception {
+  public void testBackfillCreateWithDescription() {
     final String component = "quux";
     final String start = "2017-01-01T00:00:00Z";
     final String end = "2017-01-30T00:00:00Z";
@@ -364,7 +364,7 @@ public class CliMainTest {
   }
   
   @Test
-  public void testBackfillShow() throws Exception {
+  public void testBackfillShow() {
     final String backfillId = "backfill-2";
 
     final Backfill backfill = Backfill.newBuilder()
@@ -391,7 +391,7 @@ public class CliMainTest {
   }
 
   @Test
-  public void testBackfillShowTruncating() throws Exception {
+  public void testBackfillShowTruncating() {
     final String backfillId = "backfill-2";
 
     final Backfill backfill = Backfill.newBuilder()
@@ -418,7 +418,7 @@ public class CliMainTest {
   }
 
   @Test
-  public void testBackfillEdit() throws Exception {
+  public void testBackfillEdit() {
     final String backfillId = "backfill-2";
 
     final Backfill backfill = Backfill.newBuilder()
@@ -442,7 +442,33 @@ public class CliMainTest {
   }
 
   @Test
-  public void testBackfillList() throws Exception {
+  public void testBackfillUnhalt() {
+    final String backfillId = "backfill-2";
+
+    final Backfill backfill = Backfill.newBuilder()
+        .id(backfillId)
+        .start(Instant.parse("2017-01-01T00:00:00Z"))
+        .end(Instant.parse("2017-01-30T00:00:00Z"))
+        .workflowId(WorkflowId.create("quux", backfillId))
+        .concurrency(1)
+        .description("Description")
+        .nextTrigger(Instant.parse("2017-01-01T00:00:00Z"))
+        .schedule(Schedule.DAYS)
+        .build();
+
+    when(client.backfillUnhalt(backfillId))
+        .thenReturn(CompletableFuture.completedFuture(backfill));
+
+    CliMain.run(cliContext, "backfill", "unhalt", backfillId);
+
+    verify(client).backfillUnhalt(backfillId);
+    verify(cliOutput).printMessage(
+        "Backfill unhalted! Use `styx backfill show backfill-2` to check the backfill status.");
+  }
+
+
+  @Test
+  public void testBackfillList() {
     final String component = "quux";
     final String workflow = "foo";
     final String start = "2017-01-01T00:00:00Z";
@@ -472,7 +498,7 @@ public class CliMainTest {
   }
 
   @Test
-  public void testBackfillListTruncating() throws Exception {
+  public void testBackfillListTruncating() {
     final String component = "quux";
     final String workflow = "foo";
     final String start = "2017-01-01T00:00:00Z";

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxBackfillClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxBackfillClient.java
@@ -95,6 +95,13 @@ public interface StyxBackfillClient extends AutoCloseable {
   CompletionStage<Void> backfillHalt(String backfillId);
 
   /**
+   * Unhalt a unhalt {@link Backfill}
+   *
+   * @param backfillId backfill id
+   */
+  CompletionStage<Backfill> backfillUnhalt(String backfillId);
+
+  /**
    * Get an existing {@link Backfill}
    *
    * @param backfillId    backfill id

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxOkHttpClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxOkHttpClient.java
@@ -306,6 +306,16 @@ class StyxOkHttpClient implements StyxClient {
   }
 
   @Override
+  public CompletionStage<Backfill> backfillUnhalt(String backfillId) {
+    final EditableBackfillInput editableBackfillInput = EditableBackfillInput.newBuilder()
+        .id(backfillId)
+        .halted(false)
+        .build();
+    final Builder url = urlBuilder("backfills", backfillId);
+    return execute(forUri(url, "PUT", editableBackfillInput), Backfill.class);
+  }
+
+  @Override
   public CompletionStage<BackfillPayload> backfill(String backfillId, boolean includeStatus) {
     final Builder url = urlBuilder("backfills", backfillId);
     url.addQueryParameter("status", Boolean.toString(includeStatus));

--- a/styx-common/src/main/java/com/spotify/styx/model/EditableBackfillInput.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/EditableBackfillInput.java
@@ -32,6 +32,8 @@ public interface EditableBackfillInput {
 
   Optional<String> description();
 
+  Optional<Boolean> halted();
+
   static EditableBackfillInputBuilder newBuilder() {
     return new EditableBackfillInputBuilder();
   }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Support unhalting a halted backfill.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users halt a running backfill for certain reason and afterwards might want to unhalt it instead of creating a new one and trying to figure out what partitions have been backfilled already manually.

A caveat is halted instances will NOT be revived. So this unhalting may not be that useful after all.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
unit test and running cil manually.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
