### PR TITLE
use && instead of &

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -317,7 +317,7 @@ class PrettyCliOutput implements CliOutput {
       return header.length();
     }
 
-    if (!noTruncate & length > (TRUNCATED_LENGTH + ELLIPSIS.length())) {
+    if (!noTruncate && length > (TRUNCATED_LENGTH + ELLIPSIS.length())) {
       return TRUNCATED_LENGTH + ELLIPSIS.length();
     } else {
       return length;


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
use && instead of &

## Motivation and Context
```
[WARNING] styx/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java:[320,21] [ShortCircuitBoolean] Prefer the short-circuiting boolean operators && and || to & and |.
    (see http://errorprone.info/bugpattern/ShortCircuitBoolean)
  Did you mean 'if (!noTruncate && length > (TRUNCATED_LENGTH + ELLIPSIS.length())) {'?
```

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
