### PR TITLE
best effort replay ignoring missing event

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
@@ -79,7 +79,7 @@ public final class ReplayEvents {
       try {
         restoredState = restoredState.transition(sequenceEvent.event(), time);
       } catch (IllegalStateException e) {
-        LOG.warn("failed to transition state and move on to next event", e);
+        LOG.warn("failed to transition state, move on to next event", e);
       }
 
       latestTime.set(time.get());

--- a/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ReplayEvents.java
@@ -29,8 +29,12 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.SortedSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ReplayEvents {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ReplayEvents.class);
 
   private ReplayEvents() {
     throw new UnsupportedOperationException();
@@ -72,7 +76,12 @@ public final class ReplayEvents {
         initialTime.set(time.get());
       }
 
-      restoredState = restoredState.transition(sequenceEvent.event(), time);
+      try {
+        restoredState = restoredState.transition(sequenceEvent.event(), time);
+      } catch (IllegalStateException e) {
+        LOG.warn("failed to transition state and move on to next event", e);
+      }
+
       latestTime.set(time.get());
 
       if (backfillFound(triggerExecutionEventMet, backfillId, restoredState)) {


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
When searching and replaying events for backfill, ignore missing events and try to replay as much as possible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In case of lost of event in Bigtable for whatever reason, replay should try as much as it can.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit test.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
