### PR TITLE
add query parameters to url

### DIFF
--- a/styx-api-service/pom.xml
+++ b/styx-api-service/pom.xml
@@ -66,6 +66,10 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
@@ -83,6 +83,20 @@ public class SchedulerProxyResourceTest extends VersionedApiTest {
   }
 
   @Test
+  public void testTriggerWorkflowWithQueryParameter() throws Exception {
+    sinceVersion(Api.Version.V3);
+
+    serviceHelper.stubClient()
+        .respond(Response.forStatus(Status.ACCEPTED))
+        .to(SCHEDULER_BASE + "/api/v0/trigger?bar=foo&foo=foo&foo=bar");
+
+    Response<ByteString> response =
+        awaitResponse(serviceHelper.request("POST", path("/trigger?foo=foo&foo=bar&bar=foo")));
+
+    assertThat(response, hasStatus(withCode(Status.ACCEPTED)));
+  }
+
+  @Test
   public void verifyPassesHeaders() throws Exception {
     sinceVersion(Api.Version.V3);
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Apollo doesn't put query parameters back to url, so they all get lost.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To address https://github.com/spotify/styx/pull/607#issuecomment-431038204

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit test

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
