### PR TITLE
remove old unnecessary / unused counter init code

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/model/StyxConfig.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/StyxConfig.java
@@ -43,11 +43,6 @@ public interface StyxConfig {
   boolean debugEnabled();
 
   /**
-   * Get the flag for enabling resource sync at startup.
-   */
-  boolean resourcesSyncEnabled();
-
-  /**
    * Controls whether workflow instance execution gating should be performed. If set to false,
    * instances will be executed without checking for blockers.
    */

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -129,7 +129,6 @@ public class DatastoreStorage implements Closeable {
   public static final String PROPERTY_CONFIG_CLIENT_BLACKLIST = "clientBlacklist";
   public static final String PROPERTY_CONFIG_EXECUTION_GATING_ENABLED = "executionGatingEnabled";
   public static final String PROPERTY_CONFIG_DEBUG_ENABLED = "debug";
-  public static final String PROPERTY_CONFIG_RESOURCES_SYNC_ENABLED = "resourcesSyncEnabled";
 
   public static final String PROPERTY_WORKFLOW_JSON = "json";
   public static final String PROPERTY_WORKFLOW_ENABLED = "enabled";
@@ -173,7 +172,6 @@ public class DatastoreStorage implements Closeable {
   public static final boolean DEFAULT_WORKFLOW_ENABLED = false;
   public static final boolean DEFAULT_CONFIG_DEBUG_ENABLED = false;
   public static final boolean DEFAULT_CONFIG_EXECUTION_GATING_ENABLED = false;
-  public static final boolean DEFAULT_CONFIG_RESOURCES_SYNC_ENABLED = false;
   private static final boolean DEFAULT_CONFIG_BOOTSTRAP_ACTIVE_WFI_ENABLED = false;
 
   public static final int ACTIVE_WORKFLOW_INSTANCE_INDEX_SHARDS = 128;
@@ -223,8 +221,6 @@ public class DatastoreStorage implements Closeable {
         .globalConcurrency(readOpt(entity, PROPERTY_CONFIG_CONCURRENCY))
         .globalEnabled(read(entity, PROPERTY_CONFIG_ENABLED, DEFAULT_CONFIG_ENABLED))
         .debugEnabled(read(entity, PROPERTY_CONFIG_DEBUG_ENABLED, DEFAULT_CONFIG_DEBUG_ENABLED))
-        .resourcesSyncEnabled(read(entity, PROPERTY_CONFIG_RESOURCES_SYNC_ENABLED,
-            DEFAULT_CONFIG_RESOURCES_SYNC_ENABLED))
         .submissionRateLimit(readOpt(entity, PROPERTY_SUBMISSION_RATE_LIMIT))
         .globalDockerRunnerId(
             read(entity, PROPERTY_CONFIG_DOCKER_RUNNER_ID, DEFAULT_CONFIG_DOCKER_RUNNER_ID))

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -26,7 +26,6 @@ import static com.spotify.styx.model.Schedule.HOURS;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_ALL_TRIGGERED;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_COMPONENT;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_CONCURRENCY;
-import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_CONFIG_RESOURCES_SYNC_ENABLED;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_END;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_HALTED;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_NEXT_TRIGGER;
@@ -519,16 +518,6 @@ public class DatastoreStorageTest {
   }
 
   @Test
-  public void getsResourcesSyncEnabled() throws IOException {
-    Entity config = Entity.newBuilder(DatastoreStorage.globalConfigKey(datastore.newKeyFactory()))
-        .set(PROPERTY_CONFIG_RESOURCES_SYNC_ENABLED, true)
-        .build();
-    helper.getOptions().getService().put(config);
-
-    assertThat(storage.config().resourcesSyncEnabled(), is(true));
-  }
-
-  @Test
   public void shouldReturnEmptyClientBlacklist() throws IOException {
     Entity config = Entity.newBuilder(DatastoreStorage.globalConfigKey(datastore.newKeyFactory()))
         .set(DatastoreStorage.PROPERTY_CONFIG_CLIENT_BLACKLIST,
@@ -650,7 +639,6 @@ public class DatastoreStorageTest {
         .globalDockerRunnerId("default")
         .globalEnabled(true)
         .debugEnabled(false)
-        .resourcesSyncEnabled(false)
         .executionGatingEnabled(false)
         .build();
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -692,23 +692,4 @@ public class SystemTest extends StyxSchedulerServiceFixture {
     assertThat(getState(workflowInstance), is(Optional.empty()));
   }
   }
-
-  @RunWith(JUnitParamsRunner.class)
-  public static class CreatesCounterShardsForExistingResourcesTest extends SystemTest {
-  @Test
-  public void createsCounterShardsForExistingResources() throws Exception {
-    givenResource(RESOURCE_1);
-    givenResource(RESOURCE_2);
-    givenResource(RESOURCE_3);
-
-    styxStarts();
-
-    assertEquals(RESOURCE_1.concurrency(), storage.getLimitForCounter(RESOURCE_1.id()));
-    assertEquals(RESOURCE_2.concurrency(), storage.getLimitForCounter(RESOURCE_2.id()));
-    assertEquals(RESOURCE_3.concurrency(), storage.getLimitForCounter(RESOURCE_3.id()));
-    assertEquals(128, storage.shardsForCounter(RESOURCE_1.id()).size());
-    assertEquals(128, storage.shardsForCounter(RESOURCE_2.id()).size());
-    assertEquals(128, storage.shardsForCounter(RESOURCE_3.id()).size());
-  }
-  }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -28,7 +28,6 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
remove old unnecessary / unused counter init code

## Motivation and Context
It is unnecessary and a little unsettling to mutate all the counter limits on startup.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
