### PR TITLE
remove resource kind

### DIFF
--- a/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
@@ -42,7 +42,6 @@ import com.spotify.apollo.Response;
 import com.spotify.apollo.StatusType;
 import com.spotify.styx.model.Resource;
 import com.spotify.styx.storage.AggregateStorage;
-import com.spotify.styx.util.ShardedCounter;
 import java.time.Duration;
 import java.util.logging.Level;
 import okio.ByteString;
@@ -52,12 +51,10 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class ResourceResourceTest extends VersionedApiTest {
 
-  @Mock private ShardedCounter shardedCounter;
   private static LocalDatastoreHelper localDatastore;
 
   private AggregateStorage storage;
@@ -94,7 +91,7 @@ public class ResourceResourceTest extends VersionedApiTest {
   }
 
   @AfterClass
-  public static void tearDownClass() throws Exception {
+  public static void tearDownClass() {
     if (localDatastore != null) {
       try {
         localDatastore.stop(org.threeten.bp.Duration.ofSeconds(30));
@@ -107,7 +104,6 @@ public class ResourceResourceTest extends VersionedApiTest {
   @Before
   public void setUp() throws Exception {
     storage.storeResource(RESOURCE_1);
-    storage.updateLimitForCounter(RESOURCE_1.id(), RESOURCE_1.concurrency());
   }
 
   @After
@@ -168,7 +164,7 @@ public class ResourceResourceTest extends VersionedApiTest {
     assertJson(response, "concurrency", equalTo(2));
 
     assertThat(storage.resource(RESOURCE_2.id()), hasValue(RESOURCE_2));
-    verify(storage).updateLimitForCounter(RESOURCE_2.id(), RESOURCE_2.concurrency());
+    verify(storage).storeResource(RESOURCE_2);
     assertThat(storage.getLimitForCounter(RESOURCE_2.id()), is(RESOURCE_2.concurrency()));
   }
 
@@ -185,7 +181,7 @@ public class ResourceResourceTest extends VersionedApiTest {
     assertJson(response, "concurrency", equalTo(21));
 
     assertThat(storage.resource(RESOURCE_1.id()), hasValue(Resource.create(RESOURCE_1.id(), 21)));
-    verify(storage).updateLimitForCounter(RESOURCE_1.id(), 21L);
+    verify(storage).storeResource(Resource.create(RESOURCE_1.id(), 21L));
     assertThat(storage.getLimitForCounter(RESOURCE_1.id()), is(21L));
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -215,7 +215,7 @@ public class AggregateStorage implements Storage {
 
   @Override
   public void storeResource(Resource resource) throws IOException {
-    datastoreStorage.postResource(resource);
+    datastoreStorage.storeResource(resource);
   }
 
   @Override

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -214,6 +214,11 @@ public class AggregateStorage implements Storage {
   }
 
   @Override
+  public void storeResource(Resource resource) throws IOException {
+    datastoreStorage.postResource(resource);
+  }
+
+  @Override
   public void storeBackfill(Backfill backfill) throws IOException {
     datastoreStorage.storeBackfill(backfill);
   }
@@ -224,18 +229,8 @@ public class AggregateStorage implements Storage {
   }
 
   @Override
-  public void deleteShardsForCounter(String counterId) throws IOException {
-    datastoreStorage.deleteShardsForCounter(counterId);
-  }
-
-  @Override
   public long getLimitForCounter(String counterId) throws IOException {
     return datastoreStorage.getLimitForCounter(counterId);
-  }
-
-  @Override
-  public void storeResource(Resource resource) throws IOException {
-    datastoreStorage.postResource(resource);
   }
 
   @Override
@@ -266,15 +261,5 @@ public class AggregateStorage implements Storage {
   @Override
   public <T, E extends Exception> T runInTransaction(TransactionFunction<T, E> f) throws IOException, E {
     return datastoreStorage.runInTransaction(f);
-  }
-
-  @Override
-  public void deleteLimitForCounter(String counterId) throws IOException {
-    datastoreStorage.deleteLimitForCounter(counterId);
-  }
-
-  @Override
-  public void updateLimitForCounter(String counterId, long limit) throws IOException {
-    datastoreStorage.updateLimitForCounter(counterId, limit);
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -768,7 +768,10 @@ public class DatastoreStorage implements Closeable {
         .build(), entity -> shards.add(entity.getKey()));
 
     for (List<Key> batch : Lists.partition(shards, MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH_WRITE)) {
-      datastore.delete(batch.toArray(new Key[0]));
+      storeWithRetries(() -> {
+        datastore.delete(batch.toArray(new Key[0]));
+        return null;
+      });
     }
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -732,7 +732,7 @@ public class DatastoreStorage implements Closeable {
     return Optional.of(entityToResource(entity));
   }
 
-  void postResource(Resource resource) throws IOException {
+  void storeResource(Resource resource) throws IOException {
     storeWithRetries(() -> runInTransaction(transaction -> {
       transaction.store(resource);
       return null;

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -754,10 +754,10 @@ public class DatastoreStorage implements Closeable {
    * deletion of shards is done in batches of 25 shards.
    */
   void deleteResource(String id) throws IOException {
-    storeWithRetries(() -> runInTransaction(tx -> {
-      tx.deleteCounterLimit(id);
+    storeWithRetries(() -> {
+      datastore.delete(datastore.newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(id));
       return null;
-    }));
+    });
     deleteShardsForCounter(id);
   }
 
@@ -769,10 +769,7 @@ public class DatastoreStorage implements Closeable {
         .build(), entity -> shards.add(entity.getKey()));
 
     for (List<Key> batch : Lists.partition(shards, MAX_NUMBER_OF_ENTITY_GROUPS_IN_ONE_TRANSACTION)) {
-      storeWithRetries(() -> runInTransaction(transaction -> {
-        datastore.delete(batch.toArray(new Key[0]));
-        return null;
-      }));
+      datastore.delete(batch.toArray(new Key[0]));
     }
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -180,7 +180,6 @@ public class DatastoreStorage implements Closeable {
   public static final int MAX_RETRIES = 100;
   public static final int MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH_READ = 1000;
   public static final int MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH_WRITE = 500;
-  private static final int MAX_NUMBER_OF_ENTITY_GROUPS_IN_ONE_TRANSACTION = 25;
 
   private static final int REQUEST_CONCURRENCY = 32;
 
@@ -768,7 +767,7 @@ public class DatastoreStorage implements Closeable {
         .setFilter(PropertyFilter.eq(PROPERTY_COUNTER_ID, counterId))
         .build(), entity -> shards.add(entity.getKey()));
 
-    for (List<Key> batch : Lists.partition(shards, MAX_NUMBER_OF_ENTITY_GROUPS_IN_ONE_TRANSACTION)) {
+    for (List<Key> batch : Lists.partition(shards, MAX_NUMBER_OF_ENTITIES_IN_ONE_BATCH_WRITE)) {
       datastore.delete(batch.toArray(new Key[0]));
     }
   }

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
@@ -21,7 +21,6 @@
 package com.spotify.styx.storage;
 
 import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
-import static com.spotify.styx.storage.DatastoreStorage.KIND_RESOURCE;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_ALL_TRIGGERED;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_COMPONENT;
 import static com.spotify.styx.storage.DatastoreStorage.PROPERTY_CONCURRENCY;
@@ -146,9 +145,9 @@ public class DatastoreStorageTransaction implements StorageTransaction {
   }
 
   private Entity resourceToEntity(CheckedDatastore datastore, Resource resource) {
-    final Key key = datastore.newKeyFactory().setKind(KIND_RESOURCE).newKey(resource.id());
+    final Key key = datastore.newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(resource.id());
     return Entity.newBuilder(key)
-        .set(PROPERTY_CONCURRENCY, resource.concurrency())
+        .set(PROPERTY_LIMIT, resource.concurrency())
         .build();
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
@@ -139,11 +139,6 @@ public class DatastoreStorageTransaction implements StorageTransaction {
     tx.put(resourceToEntity(tx.getDatastore(), resource));
   }
 
-  @Override
-  public void deleteCounterLimit(String counterId) throws IOException {
-    tx.delete(tx.getDatastore().newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(counterId));
-  }
-
   private Entity resourceToEntity(CheckedDatastore datastore, Resource resource) {
     final Key key = datastore.newKeyFactory().setKind(KIND_COUNTER_LIMIT).newKey(resource.id());
     return Entity.newBuilder(key)

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -282,11 +282,6 @@ public class InMemStorage implements Storage {
   }
 
   @Override
-  public void deleteShardsForCounter(String counterId) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public long getLimitForCounter(String counterId) {
     throw new UnsupportedOperationException();
   }
@@ -295,16 +290,6 @@ public class InMemStorage implements Storage {
   public <T, E extends Exception> T runInTransaction(TransactionFunction<T, E> f)
       throws IOException, E {
     throw new UnsupportedOperationException("Unsupported Operation!");
-  }
-
-  @Override
-  public void deleteLimitForCounter(String counterId) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateLimitForCounter(String counterId, long limit) throws IOException {
-    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -285,8 +285,6 @@ public interface Storage extends Closeable {
 
   Map<Integer, Long> shardsForCounter(String counterId) throws IOException;
 
-  void deleteShardsForCounter(String counterId) throws IOException;
-
   long getLimitForCounter(String counterId) throws IOException;
 
   /**
@@ -295,8 +293,4 @@ public interface Storage extends Closeable {
    */
   <T, E extends Exception> T runInTransaction(TransactionFunction<T, E> f)
       throws IOException, E;
-
-  void deleteLimitForCounter(String counterId) throws IOException;
-
-  void updateLimitForCounter(String counterId, long limit) throws IOException;
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/StorageTransaction.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/StorageTransaction.java
@@ -163,9 +163,4 @@ public interface StorageTransaction {
    * Stores a resource
    */
   void store(Resource resource) throws IOException;
-
-  /**
-   * Deletes the limit configured for the given counter
-   */
-  void deleteCounterLimit(String counterId) throws IOException;
 }

--- a/styx-common/src/main/java/com/spotify/styx/util/ShardedCounter.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ShardedCounter.java
@@ -316,21 +316,4 @@ public class ShardedCounter {
   public long getCounter(String counterId) throws IOException {
     return getCounterSnapshot(counterId).getTotalUsage();
   }
-
-  /**
-   * Delete counter by counterId. Deletes both counter shards and counter limit if it exists.
-   *
-   * <p>Due to Datastore limitations (modify max 25 entity groups per transaction),
-   * deletion of shards is done in batches of 25 shards.
-   *
-   * <p>Behaviour is best-effort and non-determined if other instances try to access the same counter in the meantime.
-   * Best results are achieved if all usages of the given resource - which the counter is associated with -
-   * are removed before calling deleteCounter. This is so, in order to avoid a scenario where one instance
-   * is trying to delete all shards, while another is creating/updating shards in between the
-   * multiple transactions made by this method.
-   */
-  public void deleteCounter(String counterId) throws IOException {
-    storage.deleteShardsForCounter(counterId);
-    storage.deleteLimitForCounter(counterId);
-  }
 }

--- a/styx-common/src/main/java/com/spotify/styx/util/ShardedCounter.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ShardedCounter.java
@@ -67,7 +67,6 @@ public class ShardedCounter {
   public static final String PROPERTY_SHARD_INDEX = "index";
   public static final String PROPERTY_COUNTER_ID = "counterId";
 
-  private final Storage storage;
   private final Stats stats;
   /**
    * A weakly consistent view of the state in Datastore, refreshed by ShardedCounter on demand.
@@ -175,8 +174,7 @@ public class ShardedCounter {
     }
   }
 
-  public ShardedCounter(Storage storage, Stats stats, CounterSnapshotFactory counterSnapshotFactory) {
-    this.storage = Objects.requireNonNull(storage);
+  public ShardedCounter(Stats stats, CounterSnapshotFactory counterSnapshotFactory) {
     this.stats = Objects.requireNonNull(stats);
     this.counterSnapshotFactory = Objects.requireNonNull(counterSnapshotFactory);
   }

--- a/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterSnapshotFactoryTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterSnapshotFactoryTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import com.spotify.styx.model.Resource;
 import com.spotify.styx.storage.AggregateStorage;
 import com.spotify.styx.storage.Storage;
 import java.io.IOException;
@@ -84,7 +85,7 @@ public class ShardedCounterSnapshotFactoryTest {
   @Before
   public void setUp() throws IOException {
     counterSnapshotFactory = spy(new ShardedCounterSnapshotFactory(storage));
-    storage.updateLimitForCounter(RESOURCE_ID, 10L);
+    storage.storeResource(Resource.create(RESOURCE_ID, 10L));
   }
 
   @After

--- a/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
@@ -53,6 +53,7 @@ import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery.CompositeFilter;
 import com.google.cloud.datastore.StructuredQuery.PropertyFilter;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import com.spotify.styx.model.Resource;
 import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.storage.AggregateStorage;
 import com.spotify.styx.storage.Storage;
@@ -118,8 +119,8 @@ public class ShardedCounterTest {
   public void setUp() throws IOException {
     counterSnapshotFactory = spy(new ShardedCounterSnapshotFactory(storage));
     shardedCounter = new ShardedCounter(storage, stats, counterSnapshotFactory);
-    storage.updateLimitForCounter(COUNTER_ID1, 10L);
-    storage.updateLimitForCounter(COUNTER_ID2, 10L);
+    storage.storeResource(Resource.create(COUNTER_ID1, 10L));
+    storage.storeResource(Resource.create(COUNTER_ID2, 10L));
   }
 
   @After
@@ -481,7 +482,7 @@ public class ShardedCounterTest {
       return null;
     });
 
-    shardedCounter.deleteCounter(COUNTER_ID1);
+    storage.deleteResource(COUNTER_ID1);
 
     QueryResults<Entity> results = getShardsForCounter(COUNTER_ID1);
 
@@ -502,7 +503,7 @@ public class ShardedCounterTest {
       return null;
     });
 
-    shardedCounter.deleteCounter(COUNTER_ID1);
+    storage.deleteResource(COUNTER_ID1);
 
     QueryResults<Entity> shardsCounter1 = getShardsForCounter(COUNTER_ID1);
     QueryResults<Entity> shardsCounter2 = getShardsForCounter(COUNTER_ID2);
@@ -516,7 +517,7 @@ public class ShardedCounterTest {
 
   @Test
   public void shouldPassDeletingNonExistingCounterAndLimit() throws IOException {
-    shardedCounter.deleteCounter(COUNTER_ID1);
+    storage.deleteResource(COUNTER_ID1);
 
     QueryResults<Entity> results = getShardsForCounter(COUNTER_ID1);
     assertFalse(results.hasNext());

--- a/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
@@ -118,7 +118,7 @@ public class ShardedCounterTest {
   @Before
   public void setUp() throws IOException {
     counterSnapshotFactory = spy(new ShardedCounterSnapshotFactory(storage));
-    shardedCounter = new ShardedCounter(storage, stats, counterSnapshotFactory);
+    shardedCounter = new ShardedCounter(stats, counterSnapshotFactory);
     storage.storeResource(Resource.create(COUNTER_ID1, 10L));
     storage.storeResource(Resource.create(COUNTER_ID2, 10L));
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -350,7 +350,7 @@ public class StyxScheduler implements AppInit {
     closer.register(storage);
 
     final CounterSnapshotFactory counterSnapshotFactory = new ShardedCounterSnapshotFactory(storage);
-    final ShardedCounter shardedCounter = new ShardedCounter(storage, stats, counterSnapshotFactory);
+    final ShardedCounter shardedCounter = new ShardedCounter(stats, counterSnapshotFactory);
 
     final Config staleStateTtlConfig = config.getConfig(STYX_STALE_STATE_TTL_CONFIG);
     final TimeoutConfig timeoutConfig = TimeoutConfig.createFromConfig(staleStateTtlConfig);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -289,7 +289,6 @@ public class StyxSchedulerServiceFixture {
 
   void givenResource(Resource resource) throws IOException {
     storage.storeResource(resource);
-    storage.updateLimitForCounter(resource.id(), resource.concurrency());
   }
 
   void givenResourceIdsToDecorateWith(Set<String> resourceIds) throws IOException {


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Rework of #489

Remove `Resource` kind because it is not used by scheduler.

So the idea (or the way I choose to convince myself regarding resource vs. counter) is, resource is the concept we expose to users while counter is only referred internally.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`Resource` kind is not used for controlling resource usage anymore.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

Unit test

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [x] Errors that cannot be handled where they occur are propagated
- [x] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [x] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
