### PR TITLE
handle null pod annotations

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -539,10 +539,10 @@ class KubernetesDockerRunner implements DockerRunner {
         runState.state().equals(RUNNING) && runState.data().executionId().isPresent());
 
     final Set<WorkflowInstance> workflowInstancesForPods = podList.getItems().stream()
-        .filter(pod -> pod.getMetadata().getAnnotations()
-            .containsKey(STYX_WORKFLOW_INSTANCE_ANNOTATION))
-        .map(pod -> WorkflowInstance
-            .parseKey(pod.getMetadata().getAnnotations().get(STYX_WORKFLOW_INSTANCE_ANNOTATION)))
+        .map(pod -> pod.getMetadata().getAnnotations())
+        .filter(Objects::nonNull)
+        .filter(annotations -> annotations.containsKey(STYX_WORKFLOW_INSTANCE_ANNOTATION))
+        .map(annotations -> WorkflowInstance.parseKey(annotations.get(STYX_WORKFLOW_INSTANCE_ANNOTATION)))
         .collect(toSet());
 
     // Emit errors for workflow instances that seem to be missing its pod
@@ -609,7 +609,7 @@ class KubernetesDockerRunner implements DockerRunner {
   private static Optional<WorkflowInstance> readPodWorkflowInstance(Pod pod) {
     final Map<String, String> annotations = pod.getMetadata().getAnnotations();
     final String podName = pod.getMetadata().getName();
-    if (!annotations.containsKey(KubernetesDockerRunner.STYX_WORKFLOW_INSTANCE_ANNOTATION)) {
+    if (annotations == null || !annotations.containsKey(KubernetesDockerRunner.STYX_WORKFLOW_INSTANCE_ANNOTATION)) {
       LOG.warn("[AUDIT] Got pod without workflow instance annotation {}", podName);
       return Optional.empty();
     }
@@ -674,8 +674,9 @@ class KubernetesDockerRunner implements DockerRunner {
   private void logEvent(Watcher.Action action, Pod pod, String resourceVersion,
                         boolean polled) {
     final String podName = pod.getMetadata().getName();
-    final String workflowInstance = pod.getMetadata().getAnnotations()
-        .getOrDefault(KubernetesDockerRunner.STYX_WORKFLOW_INSTANCE_ANNOTATION, "N/A");
+    final String workflowInstance = Optional.ofNullable(pod.getMetadata().getAnnotations())
+        .map(annotations -> annotations.get(STYX_WORKFLOW_INSTANCE_ANNOTATION))
+        .orElse("N/A");
     final String status = readStatus(pod);
 
     LOG.info("{}Pod event for {} ({}) at resource version {}, action: {}, workflow instance: {}, status: {}",

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesPodEventTranslator.java
@@ -69,7 +69,9 @@ final class KubernetesPodEventTranslator {
     final ContainerStateTerminated terminated = status.getState().getTerminated();
 
     // Check termination log exit code, if available
-    if ("true".equals(pod.getMetadata().getAnnotations().get(DOCKER_TERMINATION_LOGGING_ANNOTATION))) {
+    if (Optional.ofNullable(pod.getMetadata().getAnnotations())
+        .map(annotations -> "true".equals(annotations.get(DOCKER_TERMINATION_LOGGING_ANNOTATION)))
+        .orElse(false)) {
       if (terminated.getMessage() == null) {
         LOG.warn("Missing termination log message for workflow instance {} container {}",
                  workflowInstance, status.getContainerID());


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
handle null pod annotations

## Motivation and Context
A single pod with no annotations currently causes pod polling to break.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
