### PR TITLE
cli: global options

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -77,8 +77,10 @@ import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.ArgumentAction;
+import net.sourceforge.argparse4j.inf.ArgumentGroup;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.FeatureControl;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.Subparsers;
@@ -144,7 +146,7 @@ public final class CliMain {
 
     try {
       namespace = parser.parser.parseArgs(args.toArray(new String[0]));
-      apiHost = namespace.getString(parser.host.getDest());
+      apiHost = namespace.getString(parser.globalOptions.host.getDest());
       if (apiHost == null) {
         throw new ArgumentParserException("Styx API host not set", parser.parser);
       }
@@ -155,8 +157,8 @@ public final class CliMain {
       throw CliExitException.of(ExitStatus.ArgumentError);
     }
 
-    final boolean plainOutput = namespace.getBoolean(parser.plain.getDest());
-    final boolean jsonOutput = namespace.getBoolean(parser.json.getDest());
+    final boolean plainOutput = Objects.equals(namespace.getBoolean(parser.globalOptions.plain.getDest()), true);
+    final boolean jsonOutput = Objects.equals(namespace.getBoolean(parser.globalOptions.json.getDest()), true);
     final CliOutput cliOutput;
     if (jsonOutput) {
       cliOutput = cliContext.output(Output.JSON);
@@ -166,7 +168,7 @@ public final class CliMain {
       cliOutput = cliContext.output(Output.PRETTY);
     }
 
-    final boolean debug = namespace.getBoolean(parser.debug.getDest());
+    final boolean debug = Objects.equals(namespace.getBoolean(parser.globalOptions.debug.getDest()), true);
 
     new CliMain(parser, namespace, apiHost, cliOutput, cliContext, debug).run();
   }
@@ -628,7 +630,15 @@ public final class CliMain {
                            + "` to check active workflow instances.");
   }
 
-  private static class StyxCliParser {
+  private static class ParserBase {
+    final CliContext cliContext;
+
+    protected ParserBase(CliContext cliContext) {
+      this.cliContext = cliContext;
+    }
+  }
+
+  private static class StyxCliParser extends ParserBase {
 
     final ArgumentParser parser = ArgumentParsers.newArgumentParser("styx")
         .description("Styx CLI")
@@ -639,10 +649,10 @@ public final class CliMain {
     final Subparsers subCommands = parser.addSubparsers().title("commands").metavar(" ");
 
     final Subparsers backfillParser =
-        Command.BACKFILL.parser(subCommands)
+        Command.BACKFILL.parser(subCommands, cliContext)
             .addSubparsers().title("commands").metavar(" ");
 
-    final Subparser backfillShow = BackfillCommand.SHOW.parser(backfillParser);
+    final Subparser backfillShow = BackfillCommand.SHOW.parser(backfillParser, cliContext);
     final Argument backfillShowId =
         backfillShow.addArgument("backfill").help("Backfill ID");
     final Argument backfillShowNoTruncate = backfillShow
@@ -651,18 +661,18 @@ public final class CliMain {
         .action(Arguments.storeTrue())
         .help("don't truncate output (only for pretty printing)");
 
-    final Subparser backfillEdit = BackfillCommand.EDIT.parser(backfillParser);
+    final Subparser backfillEdit = BackfillCommand.EDIT.parser(backfillParser, cliContext);
     final Argument backfillEditId =
         backfillEdit.addArgument("backfill").help("Backfill ID");
     final Argument backfillEditConcurrency =
         backfillEdit.addArgument("--concurrency").help("set the concurrency value for the backfill")
             .type(Integer.class);
 
-    final Subparser backfillHalt = BackfillCommand.HALT.parser(backfillParser);
+    final Subparser backfillHalt = BackfillCommand.HALT.parser(backfillParser, cliContext);
     final Argument backfillHaltId =
         backfillHalt.addArgument("backfill").help("Backfill ID");
 
-    final Subparser backfillList = BackfillCommand.LIST.parser(backfillParser);
+    final Subparser backfillList = BackfillCommand.LIST.parser(backfillParser, cliContext);
     final Argument backfillListWorkflow =
         backfillList.addArgument("-w", "--workflow").help("only show backfills for WORKFLOW");
     final Argument backfillListComponent =
@@ -678,7 +688,7 @@ public final class CliMain {
             .action(Arguments.storeTrue())
             .help("don't truncate output (only for pretty printing)");
 
-    final Subparser backfillCreate = BackfillCommand.CREATE.parser(backfillParser);
+    final Subparser backfillCreate = BackfillCommand.CREATE.parser(backfillParser, cliContext);
     final Argument backfillCreateComponent =
         backfillCreate.addArgument("component").help("Component ID");
     final Argument backfillCreateWorkflow =
@@ -704,14 +714,14 @@ public final class CliMain {
         .action(Arguments.storeTrue());
 
     final Subparsers resourceParser =
-        Command.RESOURCE.parser(subCommands)
+        Command.RESOURCE.parser(subCommands, cliContext)
             .addSubparsers().title("commands").metavar(" ");
 
-    final Subparser resourceShow = ResourceCommand.SHOW.parser(resourceParser);
+    final Subparser resourceShow = ResourceCommand.SHOW.parser(resourceParser, cliContext);
     final Argument resourceShowId =
         resourceShow.addArgument("id").help("Resource ID");
 
-    final Subparser resourceEdit = ResourceCommand.EDIT.parser(resourceParser);
+    final Subparser resourceEdit = ResourceCommand.EDIT.parser(resourceParser, cliContext);
     final Argument resourceEditId =
         resourceEdit.addArgument("id").help("Resource ID");
     final Argument resourceEditConcurrency =
@@ -719,9 +729,9 @@ public final class CliMain {
             .help("set the concurrency value for the resource")
             .type(Integer.class);
 
-    final Subparser resourceList = ResourceCommand.LIST.parser(resourceParser);
+    final Subparser resourceList = ResourceCommand.LIST.parser(resourceParser, cliContext);
 
-    final Subparser resourceCreate = ResourceCommand.CREATE.parser(resourceParser);
+    final Subparser resourceCreate = ResourceCommand.CREATE.parser(resourceParser, cliContext);
     final Argument resourceCreateId =
         resourceCreate.addArgument("id").help("Resource ID");
     final Argument resourceCreateConcurrency =
@@ -730,18 +740,18 @@ public final class CliMain {
             .type(Integer.class);
 
     final Subparsers workflowParser =
-        Command.WORKFLOW.parser(subCommands)
+        Command.WORKFLOW.parser(subCommands, cliContext)
             .addSubparsers().title("commands").metavar(" ");
 
-    final Subparser workflowList = WorkflowCommand.LIST.parser(workflowParser);
+    final Subparser workflowList = WorkflowCommand.LIST.parser(workflowParser, cliContext);
 
-    final Subparser workflowShow = WorkflowCommand.SHOW.parser(workflowParser);
+    final Subparser workflowShow = WorkflowCommand.SHOW.parser(workflowParser, cliContext);
     final Argument workflowShowComponentId =
         workflowShow.addArgument("component").help("Component ID");
     final Argument workflowShowWorkflowId =
         workflowShow.addArgument("workflow").help("Workflow ID");
 
-    final Subparser workflowCreate = WorkflowCommand.CREATE.parser(workflowParser);
+    final Subparser workflowCreate = WorkflowCommand.CREATE.parser(workflowParser, cliContext);
     final Argument workflowCreateComponentId =
         workflowCreate.addArgument("component").help("Component ID");
     final Argument workflowCreateFile =
@@ -749,7 +759,7 @@ public final class CliMain {
             .type(fileType().acceptSystemIn().verifyCanRead())
             .help("Workflow configuration file");
 
-    final Subparser workflowDelete = WorkflowCommand.DELETE.parser(workflowParser);
+    final Subparser workflowDelete = WorkflowCommand.DELETE.parser(workflowParser, cliContext);
     final Argument workflowDeleteComponentId =
         workflowDelete.addArgument("component").help("Component ID");
     final Argument workflowDeleteWorkflowId =
@@ -760,56 +770,39 @@ public final class CliMain {
             .setDefault(false)
             .action(Arguments.storeTrue());
 
-    final Subparser workflowEnable = WorkflowCommand.ENABLE.parser(workflowParser);
+    final Subparser workflowEnable = WorkflowCommand.ENABLE.parser(workflowParser, cliContext);
     final Argument workflowEnableComponentId =
         workflowEnable.addArgument("component").help("Component ID");
     final Argument workflowEnableWorkflowId =
         workflowEnable.addArgument("workflow").nargs("+").help("Workflow IDs");
 
-    final Subparser workflowDisable = WorkflowCommand.DISABLE.parser(workflowParser);
+    final Subparser workflowDisable = WorkflowCommand.DISABLE.parser(workflowParser, cliContext);
     final Argument workflowDisableComponentId =
         workflowDisable.addArgument("component").help("Component ID");
     final Argument workflowDisableWorkflowId =
         workflowDisable.addArgument("workflow").nargs("+").help("Workflow IDs");
 
-    final Subparser list = Command.LIST.parser(subCommands);
+    final Subparser list = Command.LIST.parser(subCommands, cliContext);
     final Argument listComponent = list.addArgument("-c", "--component")
         .help("only show instances for COMPONENT");
 
-    final Subparser events = addWorkflowInstanceArguments(Command.EVENTS.parser(subCommands));
-    final Subparser trigger = addWorkflowInstanceArguments(Command.TRIGGER.parser(subCommands));
+    final Subparser events = addWorkflowInstanceArguments(Command.EVENTS.parser(subCommands, cliContext));
+    final Subparser trigger = addWorkflowInstanceArguments(Command.TRIGGER.parser(subCommands, cliContext));
     final Argument triggerEnv = addEnvVarArgument(trigger, "-e", "--env");
     final Argument triggerAllowFuture = addEnvVarArgument(trigger, "--allow-future")
         .help("Allow triggering future partition")
         .setDefault(false)
         .action(Arguments.storeTrue());
 
-    final Subparser halt = addWorkflowInstanceArguments(Command.HALT.parser(subCommands));
-    final Subparser retry = addWorkflowInstanceArguments(Command.RETRY.parser(subCommands));
+    final Subparser halt = addWorkflowInstanceArguments(Command.HALT.parser(subCommands, cliContext));
+    final Subparser retry = addWorkflowInstanceArguments(Command.RETRY.parser(subCommands, cliContext));
 
-    final Argument host = parser.addArgument("-H", "--host")
-        .help("Styx API host (can also be set with environment variable " + ENV_VAR_PREFIX + "_HOST)")
-        .action(Arguments.store());
-
-    final Argument json = parser.addArgument("--json")
-        .help("json output")
-        .setDefault(false)
-        .action(Arguments.storeTrue());
-
-    final Argument plain = parser.addArgument("-p", "--plain")
-        .help("plain output")
-        .setDefault(false)
-        .action(Arguments.storeTrue());
-
-    final Argument debug = parser.addArgument("--debug")
-        .help("debug output")
-        .setDefault(false)
-        .action(Arguments.storeTrue());
+    final GlobalOptions globalOptions = GlobalOptions.add(parser, cliContext, false);
 
     final Argument version = parser.addArgument("--version").action(Arguments.version());
 
     private StyxCliParser(CliContext cliContext) {
-      host.setDefault(cliContext.env().get(ENV_VAR_PREFIX + "_HOST"));
+      super(cliContext);
     }
 
     private static Subparser addWorkflowInstanceArguments(Subparser subparser) {
@@ -857,9 +850,8 @@ public final class CliMain {
       this.description = description;
     }
 
-    public Subparser parser(Subparsers subCommands) {
-      Subparser subparser = subCommands
-          .addParser(name().toLowerCase())
+    public Subparser parser(Subparsers subCommands, CliContext cliContext) {
+      Subparser subparser = addSubparser(subCommands, name().toLowerCase(), cliContext)
           .setDefault(COMMAND_DEST, this)
           .description(description)
           .help(description);
@@ -869,6 +861,47 @@ public final class CliMain {
       }
 
       return subparser;
+    }
+
+  }
+
+  private static Subparser addSubparser(Subparsers subCommands, String name, CliContext cliContext) {
+    final Subparser parser = subCommands.addParser(name);
+    GlobalOptions.add(parser, cliContext, true);
+    return parser;
+  }
+
+  private static class GlobalOptions {
+
+    final Argument host;
+    final Argument json;
+    final Argument plain;
+    final Argument debug;
+    final ArgumentGroup options;
+
+    private GlobalOptions(ArgumentParser parser, CliContext cliContext, boolean subCommand) {
+      this.options = parser.addArgumentGroup("global options");
+      this.host = options.addArgument("-H", "--host")
+          .help("Styx API host (can also be set with environment variable " + ENV_VAR_PREFIX + "_HOST)")
+          .setDefault(subCommand ? FeatureControl.SUPPRESS : null)
+          .setDefault(cliContext.env().get(ENV_VAR_PREFIX + "_HOST"))
+          .action(Arguments.store());
+      this.json = options.addArgument("--json")
+          .help("json output")
+          .setDefault(subCommand ? FeatureControl.SUPPRESS : null)
+          .action(Arguments.storeTrue());
+      this.plain = options.addArgument("-p", "--plain")
+          .help("plain output")
+          .setDefault(subCommand ? FeatureControl.SUPPRESS : null)
+          .action(Arguments.storeTrue());
+      this.debug = options.addArgument("--debug")
+          .help("debug output")
+          .setDefault(subCommand ? FeatureControl.SUPPRESS : null)
+          .action(Arguments.storeTrue());
+    }
+
+    static GlobalOptions add(ArgumentParser parser, CliContext cliContext, boolean subCommand) {
+      return new GlobalOptions(parser, cliContext, subCommand);
     }
   }
 
@@ -887,9 +920,8 @@ public final class CliMain {
       this.description = description;
     }
 
-    public Subparser parser(Subparsers subCommands) {
-      final Subparser subparser = subCommands
-          .addParser(name().toLowerCase())
+    public Subparser parser(Subparsers subCommands, CliContext cliContext) {
+      final Subparser subparser = addSubparser(subCommands, name().toLowerCase(), cliContext)
           .setDefault(SUBCOMMAND_DEST, this)
           .description(description)
           .help(description);
@@ -916,9 +948,8 @@ public final class CliMain {
       this.description = description;
     }
 
-    public Subparser parser(Subparsers subCommands) {
-      final Subparser subparser = subCommands
-          .addParser(name().toLowerCase())
+    public Subparser parser(Subparsers subCommands, CliContext cliContext) {
+      final Subparser subparser = addSubparser(subCommands, name().toLowerCase(), cliContext)
           .setDefault(SUBCOMMAND_DEST, this)
           .description(description)
           .help(description);
@@ -947,9 +978,8 @@ public final class CliMain {
       this.description = description;
     }
 
-    public Subparser parser(Subparsers subCommands) {
-      final Subparser subparser = subCommands
-          .addParser(name().toLowerCase())
+    public Subparser parser(Subparsers subCommands, CliContext cliContext) {
+      final Subparser subparser = addSubparser(subCommands, name().toLowerCase(), cliContext)
           .setDefault(SUBCOMMAND_DEST, this)
           .description(description)
           .help(description);


### PR DESCRIPTION

# Hey, I just made a Pull Request!

## Description
Make it possible to specify `--json`, `--plain`, `--debug` and `-H/--host` anywhere on the command line, not just in the beginning.

## Motivation and Context
Improve styx cli ease of use.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
