### PR TITLE
Tolerate failures if not enforcing authorization

### DIFF
--- a/styx-api-service/src/test/java/com/spotify/styx/api/ServiceAccountUsageAuthorizerTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/ServiceAccountUsageAuthorizerTest.java
@@ -198,6 +198,15 @@ public class ServiceAccountUsageAuthorizerTest {
 
   @Parameters({SERVICE_ACCOUNT, MANAGED_SERVICE_ACCOUNT})
   @Test
+  public void shouldAllowAccessOnFailureIfNotEnforcingAuthorizationPolicy(String serviceAccount) throws IOException {
+    final Throwable cause = new AssertionError();
+    when((Object) crm.projects().getIamPolicy(any(), any()).execute()).thenThrow(cause);
+    when(authorizationPolicy.shouldEnforceAuthorization(any(), any(), any())).thenReturn(false);
+    sut.authorizeServiceAccountUsage(WORKFLOW_ID, serviceAccount, idToken);
+  }
+
+  @Parameters({SERVICE_ACCOUNT, MANAGED_SERVICE_ACCOUNT})
+  @Test
   public void shouldAllowAccessIfNotEnforcingAuthorizationPolicy(String serviceAccount) {
     when(authorizationPolicy.shouldEnforceAuthorization(any(), any(), any())).thenReturn(false);
     sut.authorizeServiceAccountUsage(WORKFLOW_ID, serviceAccount, idToken);


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Tolerate failures if not enforcing authorization

## Motivation and Context
Make rolling out authorization in production less risky.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
