### PR TITLE
record demanded resource count

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
+++ b/styx-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
@@ -84,6 +84,9 @@ public final class MetricsStats implements Stats {
   static final MetricId RESOURCE_USED = BASE
       .tagged("what", "resource-used");
 
+  static final MetricId RESOURCE_DEMANDED = BASE
+      .tagged("what", "resource-demanded");
+
   static final MetricId EXIT_CODE_RATE = BASE
       .tagged("what", "exit-code-rate");
 
@@ -190,6 +193,7 @@ public final class MetricsStats implements Stats {
   private final ConcurrentMap<Tuple3<String, String, Integer>, Meter> dockerOperationErrorMeters;
   private final ConcurrentMap<String, Histogram> resourceConfiguredHistograms;
   private final ConcurrentMap<String, Histogram> resourceUsedHistograms;
+  private final ConcurrentMap<String, Meter> resourceDemandedMeters;
   private final ConcurrentMap<String, Meter> eventConsumerErrorMeters;
   private final ConcurrentMap<String, Meter> eventConsumerMeters;
   private final ConcurrentMap<String, Meter> publishingMeters;
@@ -226,6 +230,7 @@ public final class MetricsStats implements Stats {
     this.dockerOperationErrorMeters = new ConcurrentHashMap<>();
     this.resourceConfiguredHistograms = new ConcurrentHashMap<>();
     this.resourceUsedHistograms = new ConcurrentHashMap<>();
+    this.resourceDemandedMeters = new ConcurrentHashMap<>();
     this.eventConsumerErrorMeters = new ConcurrentHashMap<>();
     this.eventConsumerMeters = new ConcurrentHashMap<>();
     this.publishingMeters = new ConcurrentHashMap<>();
@@ -327,6 +332,11 @@ public final class MetricsStats implements Stats {
   @Override
   public void recordResourceUsed(String resource, long used) {
     resourceUsedHistogram(resource).update(used);
+  }
+
+  @Override
+  public void recordResourceDemanded(String resource) {
+    resourceDemandedMeter(resource).mark();
   }
 
   @Override
@@ -444,6 +454,11 @@ public final class MetricsStats implements Stats {
   private Histogram resourceUsedHistogram(String resource) {
     return resourceUsedHistograms.computeIfAbsent(
         resource, (op) -> registry.getOrAdd(RESOURCE_USED.tagged("resource", resource), HISTOGRAM));
+  }
+
+  private Meter resourceDemandedMeter(String resource) {
+    return resourceDemandedMeters.computeIfAbsent(
+        resource, (op) -> registry.meter(RESOURCE_DEMANDED.tagged("resource", resource)));
   }
 
   private Meter eventConsumerMeter(SequenceEvent sequenceEvent) {

--- a/styx-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
+++ b/styx-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
@@ -114,6 +114,11 @@ final class NoopStats implements Stats {
   }
 
   @Override
+  public void recordResourceDemanded(String resource) {
+    // nop
+  }
+
+  @Override
   public void recordEventConsumer(SequenceEvent event) {
     // nop
   }

--- a/styx-common/src/main/java/com/spotify/styx/monitoring/Stats.java
+++ b/styx-common/src/main/java/com/spotify/styx/monitoring/Stats.java
@@ -66,6 +66,8 @@ public interface Stats {
 
   void recordResourceUsed(String resource, long used);
 
+  void recordResourceDemanded(String resource);
+
   void recordEventConsumer(SequenceEvent event);
 
   void recordEventConsumerError(SequenceEvent event);

--- a/styx-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
@@ -37,6 +37,7 @@ import static com.spotify.styx.monitoring.MetricsStats.PUBLISHING_RATE;
 import static com.spotify.styx.monitoring.MetricsStats.PULL_IMAGE_ERROR_RATE;
 import static com.spotify.styx.monitoring.MetricsStats.QUEUED_EVENTS;
 import static com.spotify.styx.monitoring.MetricsStats.RESOURCE_CONFIGURED;
+import static com.spotify.styx.monitoring.MetricsStats.RESOURCE_DEMANDED;
 import static com.spotify.styx.monitoring.MetricsStats.RESOURCE_USED;
 import static com.spotify.styx.monitoring.MetricsStats.STORAGE_DURATION;
 import static com.spotify.styx.monitoring.MetricsStats.STORAGE_RATE;
@@ -234,6 +235,14 @@ public class MetricsStatsTest {
     when(registry.getOrAdd(RESOURCE_USED.tagged("resource", resource), HISTOGRAM)).thenReturn(histogram);
     stats.recordResourceUsed(resource, 100L);
     verify(histogram).update(100L);
+  }
+
+  @Test
+  public void shouldRecordResourceDemanded() {
+    String resource = "resource";
+    when(registry.meter(RESOURCE_DEMANDED.tagged("resource", resource))).thenReturn(meter);
+    stats.recordResourceDemanded(resource);
+    verify(meter).mark();
   }
 
   @Test

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -282,6 +282,8 @@ public class Scheduler {
       return;
     }
 
+    instanceResourceRefs.forEach(stats::recordResourceDemanded);
+
     // Check resource limits. This is racy and can give false positives but the transactional
     // checking happens later. This is just intended to avoid spinning on exhausted resources.
     final List<String> depletedResources = instanceResourceRefs.stream()

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -422,6 +422,7 @@ public class SchedulerTest {
 
     scheduler.tick();
 
+    verify(stats).recordResourceDemanded("r1");
     verify(stats).recordResourceUsed("r1", 2L);
   }
 
@@ -450,6 +451,7 @@ public class SchedulerTest {
     verify(shardedCounter, times(1)).counterHasSpareCapacity("r1");
     assertThat(eventCaptor.getAllValues().stream()
         .anyMatch(e -> EventUtil.name(e).equals("dequeue")), is(false));
+    verify(stats).recordResourceDemanded("r1");
     verify(stats).recordResourceUsed("r1", 3L);
 
     scheduler.tick();
@@ -458,6 +460,7 @@ public class SchedulerTest {
     verify(shardedCounter, times(2)).counterHasSpareCapacity("r1");
     assertThat(eventCaptor.getAllValues().stream()
         .anyMatch(e -> EventUtil.name(e).equals("dequeue")), is(false));
+    verify(stats, times(2)).recordResourceDemanded("r1");
     verify(stats, times(2)).recordResourceUsed("r1", 3L);
   }
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
After resource reference validation, record the demand of using.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To be able to understand when out of resource, roughly how bad the situation is in terms
of queuing WFI.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit test

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
