### PR TITLE
Custom running state timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ the [Service Account] that Styx itself runs as should be granted `Service Accoun
 role for the `service_account` of the workflow. This can be done by following
 [Granting Roles to Service Accounts].
 
+#### `running_timeout` **[string]**
+An [ISO 8601 Duration] specification for timing out container execution. Defaults to 24 hours that also
+serves as the upper boundary.
+
 ### Triggering and executions
 
 Each time a Workflow Schedule is triggered, Styx will treat that trigger as a first class entity.

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -118,6 +118,8 @@ public class WorkflowResourceTest extends VersionedApiTest {
           .commitSha("00000ef508c1cb905e360590ce3e7e9193f6b370")
           .dockerImage("bar-dummy:dummy")
           .serviceAccount(SERVICE_ACCOUNT)
+          .env("FOO", "foo", "BAR", "bar")
+          .runningTimeout(Duration.parse("PT23H"))
           .build();
 
   private static final Workflow WORKFLOW =

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
@@ -34,6 +34,7 @@ import com.spotify.styx.model.WorkflowState;
 import com.spotify.styx.model.data.EventInfo;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.StateData;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.SortedMap;
@@ -133,6 +134,7 @@ class PlainCliOutput implements CliOutput {
         wf.configuration().serviceAccount().map(Object::toString).orElse(""),
         wf.configuration().resources(),
         wf.configuration().env(),
+        wf.configuration().runningTimeout().map(Duration::toString).orElse(""),
         wf.configuration().commitSha().orElse(""),
         state.enabled().map(Object::toString).orElse(""),
         state.nextNaturalTrigger().map(Object::toString).orElse(""),

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -46,6 +46,7 @@ import com.spotify.styx.model.WorkflowState;
 import com.spotify.styx.model.data.EventInfo;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.StateData;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -274,6 +275,7 @@ class PrettyCliOutput implements CliOutput {
     System.out.println(" Svc Acct: " + wf.configuration().serviceAccount().orElse(""));
     System.out.println("Resources: " + wf.configuration().resources());
     System.out.println("      Env: " + Joiner.on(' ').withKeyValueSeparator('=').join(wf.configuration().env()));
+    System.out.println("  Timeout: " + wf.configuration().runningTimeout().map(Duration::toString).orElse(""));
     System.out.println("   Commit: " + wf.configuration().commitSha().orElse(""));
     System.out.println("  Enabled: " + state.enabled().map(Object::toString).orElse(""));
     System.out.println("     Trig: " + state.nextNaturalTrigger().map(Object::toString).orElse(""));

--- a/styx-cli/src/test/java/com/spotify/styx/cli/PlainCliOutputTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/PlainCliOutputTest.java
@@ -36,6 +36,7 @@ import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowState;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -130,6 +131,7 @@ public class PlainCliOutputTest {
         .serviceAccount("foo@bar.baz")
         .resources("r1", "r2")
         .env("FOO", "foo", "BAR", "bar")
+        .runningTimeout(Duration.parse("PT20H"))
         .commitSha("deadbeef")
         .build());
     final WorkflowState state = WorkflowState.builder()
@@ -139,7 +141,8 @@ public class PlainCliOutputTest {
         .build();
     cliOutput.printWorkflow(workflow, state);
     assertThat(outContent.toString(), is(
-        "foo1 bar1 DAYS 6h foo/bar:baz [foo, the, bar] true secret-foo:/foo-secret foo@bar.baz [r1, r2] {BAR=bar, FOO=foo} deadbeef true 2018-01-02T03:04:05.000000006Z 2018-01-02T09:04:05.000000006Z\n"));
+        "foo1 bar1 DAYS 6h foo/bar:baz [foo, the, bar] true secret-foo:/foo-secret foo@bar.baz [r1, r2] {BAR=bar, "
+        + "FOO=foo} PT20H deadbeef true 2018-01-02T03:04:05.000000006Z 2018-01-02T09:04:05.000000006Z\n"));
 
   }
 }

--- a/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
@@ -48,6 +48,7 @@ import com.spotify.styx.state.Message;
 import com.spotify.styx.state.StateData;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -282,6 +283,7 @@ public class PrettyCliOutputTest {
         .serviceAccount("foo@bar.baz")
         .resources("r1", "r2")
         .env("FOO", "foo", "BAR", "bar")
+        .runningTimeout(Duration.parse("PT23H"))
         .commitSha("deadbeef")
         .build());
     final WorkflowState state = WorkflowState.builder()
@@ -302,6 +304,7 @@ public class PrettyCliOutputTest {
             + " Svc Acct: foo@bar.baz\n"
             + "Resources: [r1, r2]\n"
             + "      Env: BAR=bar FOO=foo\n"
+            + "  Timeout: PT23H\n"
             + "   Commit: deadbeef\n"
             + "  Enabled: true\n"
             + "     Trig: 2018-01-02T03:04:05.000000006Z\n"

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
@@ -23,6 +23,7 @@ package com.spotify.styx.model;
 import com.spotify.styx.model.Schedule.WellKnown;
 import com.spotify.styx.util.TimeUtil;
 import io.norberg.automatter.AutoMatter;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -59,6 +60,8 @@ public interface WorkflowConfiguration {
   Optional<Secret> secret();
 
   Optional<String> serviceAccount();
+
+  Optional<Duration> runningTimeout();
 
   List<String> resources();
 

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
@@ -61,11 +61,11 @@ public interface WorkflowConfiguration {
 
   Optional<String> serviceAccount();
 
-  Optional<Duration> runningTimeout();
-
   List<String> resources();
 
   Map<String, String> env();
+
+  Optional<Duration> runningTimeout();
 
   default Instant addOffset(Instant next) {
     final String offset = offset().orElseGet(this::defaultOffset);

--- a/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
+++ b/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
@@ -33,6 +33,7 @@ import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowConfiguration.Secret;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
+import java.time.Duration;
 import java.util.Set;
 
 public final class TestData {
@@ -129,6 +130,16 @@ public final class TestData {
           .serviceAccount("foo@bar.baz.quux")
           .build();
 
+  public static final WorkflowConfiguration HOURLY_WORKFLOW_CONFIGURATION_WITH_RESOURCES_RUNNING_TIMEOUT =
+      WorkflowConfiguration.builder()
+          .id("styx.TestEndpoint")
+          .commitSha(VALID_SHA)
+          .dockerImage("busybox")
+          .schedule(HOURS)
+          .resources(RESOURCE_IDS)
+          .runningTimeout(Duration.ofMillis(2L))
+          .build();
+
   public static final ExecutionDescription EXECUTION_DESCRIPTION =
       ExecutionDescription.builder()
           .dockerImage("busybox:1.1")
@@ -142,6 +153,9 @@ public final class TestData {
 
   public static final Workflow WORKFLOW_WITH_RESOURCES_2 = Workflow.create(WORKFLOW_ID_2.componentId(),
       HOURLY_WORKFLOW_CONFIGURATION_WITH_RESOURCES_2);
+
+  public static final Workflow WORKFLOW_WITH_RESOURCES_RUNNING_TIMEOUT = Workflow.create(WORKFLOW_ID.componentId(),
+      HOURLY_WORKFLOW_CONFIGURATION_WITH_RESOURCES_RUNNING_TIMEOUT);
 
   private TestData() {
     throw new UnsupportedOperationException();

--- a/styx-common/src/main/java/com/spotify/styx/util/WorkflowValidator.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/WorkflowValidator.java
@@ -102,6 +102,8 @@ public class WorkflowValidator {
       e.add("invalid schedule");
     }
 
+    // TODO: validate runningTimeout value? Not trivial due to ttls are configured only for scheduler not api.
+
     return e;
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/util/WorkflowValidator.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/WorkflowValidator.java
@@ -24,6 +24,7 @@ import static java.lang.String.format;
 
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowConfiguration;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -42,6 +43,7 @@ public class WorkflowValidator {
   static final long MAX_SERVICE_ACCOUNT_LENGTH = 256;
   static final long MAX_ENV_VARS = 128;
   static final long MAX_ENV_SIZE = 16 * 1024;
+  static final long MIN_RUNNING_TIMEOUT_SECONDS = 60;
 
   private final DockerImageValidator dockerImageValidator;
 
@@ -59,21 +61,21 @@ public class WorkflowValidator {
 
     // TODO: validate more of the contents
 
-    limit(e, cfg.id().length(),
+    upperLimit(e, cfg.id().length(),
         MAX_ID_LENGTH, "id too long");
-    limit(e, cfg.commitSha().map(String::length).orElse(0),
+    upperLimit(e, cfg.commitSha().map(String::length).orElse(0),
         MAX_COMMIT_SHA_LENGTH, "commitSha too long");
-    limit(e, cfg.secret().map(s -> s.name().length()).orElse(0),
+    upperLimit(e, cfg.secret().map(s -> s.name().length()).orElse(0),
         MAX_SECRET_NAME_LENGTH, "secret name too long");
-    limit(e, cfg.secret().map(s -> s.mountPath().length()).orElse(0),
+    upperLimit(e, cfg.secret().map(s -> s.mountPath().length()).orElse(0),
         MAX_SECRET_MOUNT_PATH_LENGTH, "secret mount path too long");
-    limit(e, cfg.serviceAccount().map(String::length).orElse(0),
+    upperLimit(e, cfg.serviceAccount().map(String::length).orElse(0),
         MAX_SERVICE_ACCOUNT_LENGTH, "service account too long");
-    limit(e, cfg.resources().size(),
+    upperLimit(e, cfg.resources().size(),
         MAX_RESOURCES, "too many resources");
-    limit(e, cfg.env().size(),
+    upperLimit(e, cfg.env().size(),
         MAX_ENV_VARS, "too many env vars");
-    limit(e, cfg.env().entrySet().stream()
+    upperLimit(e, cfg.env().entrySet().stream()
             .mapToLong(entry -> entry.getKey().length() + entry.getValue().length()).sum(),
         MAX_ENV_SIZE, "env too big");
 
@@ -83,9 +85,9 @@ public class WorkflowValidator {
             .forEach(e::add));
 
     cfg.resources().stream().map(String::length).forEach(v ->
-        limit(e, v, MAX_RESOURCE_LENGTH, "resource name too long"));
+        upperLimit(e, v, MAX_RESOURCE_LENGTH, "resource name too long"));
 
-    limit(e, cfg.dockerArgs().map(args -> args.size() + args.stream().mapToLong(String::length).sum()),
+    upperLimit(e, cfg.dockerArgs().map(args -> args.size() + args.stream().mapToLong(String::length).sum()),
         MAX_DOCKER_ARGS_TOTAL, "docker args is too large");
 
     cfg.offset().ifPresent(offset -> {
@@ -103,16 +105,28 @@ public class WorkflowValidator {
     }
 
     // TODO: validate runningTimeout value? Not trivial due to ttls are configured only for scheduler not api.
+    lowerLimit(e, cfg.runningTimeout().map(Duration::getSeconds),
+        MIN_RUNNING_TIMEOUT_SECONDS, "running timeout is too small");
 
     return e;
   }
 
-  private void limit(List<String> errors, Optional<Long> value, long limit, String message) {
-    value.ifPresent(v -> limit(errors, v, limit, message));
+  private void upperLimit(List<String> errors, Optional<Long> value, long limit, String message) {
+    value.ifPresent(v -> upperLimit(errors, v, limit, message));
   }
 
-  private void limit(List<String> errors, long value, long limit, String message) {
+  private void upperLimit(List<String> errors, long value, long limit, String message) {
     if (value > limit) {
+      errors.add(message + ": " + value + ", limit = " + limit);
+    }
+  }
+
+  private void lowerLimit(List<String> errors, Optional<Long> value, long limit, String message) {
+    value.ifPresent(v -> lowerLimit(errors, v, limit, message));
+  }
+
+  private void lowerLimit(List<String> errors, long value, long limit, String message) {
+    if (value < limit) {
       errors.add(message + ": " + value + ", limit = " + limit);
     }
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -156,9 +156,9 @@ public class Scheduler {
     final Map<WorkflowInstance, RunState> activeStatesMap = stateManager.getActiveStates();
     final List<InstanceState> activeStates = getActiveInstanceStates(activeStatesMap);
 
-    final Set<WorkflowInstance> timedOutInstances = getTimedOutInstances(activeStates, time.get(), ttls);
-
     final Map<WorkflowId, Workflow> workflows = getWorkflows(activeStates);
+
+    final Set<WorkflowInstance> timedOutInstances = getTimedOutInstances(workflows, activeStates, time.get(), ttls);
 
     final Map<WorkflowId, Set<String>> workflowResourceReferences =
         activeStates.parallelStream()


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
`runningTimeout` added to workflow configuration to customize timeout value for `running` state.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users want to configure smaller value than the global default one.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit test.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [x] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
