### PR TITLE
Add running_timeout check before submitting

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/model/ExecutionDescription.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/ExecutionDescription.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.model;
 
 import io.norberg.automatter.AutoMatter;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,6 +36,7 @@ public interface ExecutionDescription {
   Optional<String> serviceAccount();
   Optional<String> commitSha();
   Map<String, String> env();
+  Optional<Duration> runningTimeout();
 
   static ExecutionDescriptionBuilder builder() {
     return new ExecutionDescriptionBuilder();

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -386,7 +386,7 @@ public class StyxScheduler implements AppInit {
         new TerminationHandler(retryUtil, stateManager),
         new MonitoringHandler(stats),
         new PublisherHandler(publisher, stats),
-        new ExecutionDescriptionHandler(storage, stateManager, new WorkflowValidator(new DockerImageValidator()))));
+        new ExecutionDescriptionHandler(timeoutConfig, storage, stateManager, new WorkflowValidator(new DockerImageValidator()))));
 
     final TriggerListener trigger =
         new StateInitializingTrigger(stateManager);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
@@ -44,6 +44,7 @@ import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
+import com.spotify.styx.state.TimeoutConfig;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.WorkflowValidator;
 import java.io.IOException;
@@ -79,13 +80,15 @@ public class ExecutionDescriptionHandlerTest {
   @Captor ArgumentCaptor<Event> eventCaptor;
 
   @Mock WorkflowValidator workflowValidator;
+  @Mock TimeoutConfig timeouts;
 
   @Before
   public void setUp() throws Exception {
     when(workflowValidator.validateWorkflow(any())).thenReturn(Collections.emptyList());
+    when(timeouts.ttlOf(any())).thenReturn(Duration.ofHours(24));
 
     when(stateManager.receive(any())).thenReturn(CompletableFuture.completedFuture(null));
-    toTest = new ExecutionDescriptionHandler(storage, stateManager, workflowValidator);
+    toTest = new ExecutionDescriptionHandler(timeouts, storage, stateManager, workflowValidator);
   }
 
   @Test


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->

Early halt workflow instances that have a timeout larger than the running state ttl.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We can't do upperlimit validation of the running_timeout in the api without having to talk to the scheduler. If a user configures a running_timeout larger than the configured ttl for the running state, we wouldn't check this until the workflow has timed-out.  Therefore this PR adds an early check and halts the workflow before it even tries to execute, in the case when running_timeout is too large.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit test

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
