### PR TITLE
aggregate resource demand instead of metering

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
+++ b/styx-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
@@ -193,7 +193,7 @@ public final class MetricsStats implements Stats {
   private final ConcurrentMap<Tuple3<String, String, Integer>, Meter> dockerOperationErrorMeters;
   private final ConcurrentMap<String, Histogram> resourceConfiguredHistograms;
   private final ConcurrentMap<String, Histogram> resourceUsedHistograms;
-  private final ConcurrentMap<String, Histogram> resourceDemandedMeters;
+  private final ConcurrentMap<String, Histogram> resourceDemandedHistograms;
   private final ConcurrentMap<String, Meter> eventConsumerErrorMeters;
   private final ConcurrentMap<String, Meter> eventConsumerMeters;
   private final ConcurrentMap<String, Meter> publishingMeters;
@@ -230,7 +230,7 @@ public final class MetricsStats implements Stats {
     this.dockerOperationErrorMeters = new ConcurrentHashMap<>();
     this.resourceConfiguredHistograms = new ConcurrentHashMap<>();
     this.resourceUsedHistograms = new ConcurrentHashMap<>();
-    this.resourceDemandedMeters = new ConcurrentHashMap<>();
+    this.resourceDemandedHistograms = new ConcurrentHashMap<>();
     this.eventConsumerErrorMeters = new ConcurrentHashMap<>();
     this.eventConsumerMeters = new ConcurrentHashMap<>();
     this.publishingMeters = new ConcurrentHashMap<>();
@@ -457,7 +457,7 @@ public final class MetricsStats implements Stats {
   }
 
   private Histogram resourceDemandedHistogram(String resource) {
-    return resourceDemandedMeters.computeIfAbsent(
+    return resourceDemandedHistograms.computeIfAbsent(
         resource, (op) -> registry.getOrAdd(RESOURCE_DEMANDED.tagged("resource", resource), HISTOGRAM));
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
+++ b/styx-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
@@ -336,7 +336,7 @@ public final class MetricsStats implements Stats {
 
   @Override
   public void recordResourceDemanded(String resource, long demanded) {
-    resourceDemandedMeter(resource).update(demanded);
+    resourceDemandedHistogram(resource).update(demanded);
   }
 
   @Override
@@ -456,7 +456,7 @@ public final class MetricsStats implements Stats {
         resource, (op) -> registry.getOrAdd(RESOURCE_USED.tagged("resource", resource), HISTOGRAM));
   }
 
-  private Histogram resourceDemandedMeter(String resource) {
+  private Histogram resourceDemandedHistogram(String resource) {
     return resourceDemandedMeters.computeIfAbsent(
         resource, (op) -> registry.getOrAdd(RESOURCE_DEMANDED.tagged("resource", resource), HISTOGRAM));
   }

--- a/styx-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
+++ b/styx-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
@@ -193,7 +193,7 @@ public final class MetricsStats implements Stats {
   private final ConcurrentMap<Tuple3<String, String, Integer>, Meter> dockerOperationErrorMeters;
   private final ConcurrentMap<String, Histogram> resourceConfiguredHistograms;
   private final ConcurrentMap<String, Histogram> resourceUsedHistograms;
-  private final ConcurrentMap<String, Meter> resourceDemandedMeters;
+  private final ConcurrentMap<String, Histogram> resourceDemandedMeters;
   private final ConcurrentMap<String, Meter> eventConsumerErrorMeters;
   private final ConcurrentMap<String, Meter> eventConsumerMeters;
   private final ConcurrentMap<String, Meter> publishingMeters;
@@ -335,8 +335,8 @@ public final class MetricsStats implements Stats {
   }
 
   @Override
-  public void recordResourceDemanded(String resource) {
-    resourceDemandedMeter(resource).mark();
+  public void recordResourceDemanded(String resource, long demanded) {
+    resourceDemandedMeter(resource).update(demanded);
   }
 
   @Override
@@ -456,9 +456,9 @@ public final class MetricsStats implements Stats {
         resource, (op) -> registry.getOrAdd(RESOURCE_USED.tagged("resource", resource), HISTOGRAM));
   }
 
-  private Meter resourceDemandedMeter(String resource) {
+  private Histogram resourceDemandedMeter(String resource) {
     return resourceDemandedMeters.computeIfAbsent(
-        resource, (op) -> registry.meter(RESOURCE_DEMANDED.tagged("resource", resource)));
+        resource, (op) -> registry.getOrAdd(RESOURCE_DEMANDED.tagged("resource", resource), HISTOGRAM));
   }
 
   private Meter eventConsumerMeter(SequenceEvent sequenceEvent) {

--- a/styx-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
+++ b/styx-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
@@ -114,7 +114,7 @@ final class NoopStats implements Stats {
   }
 
   @Override
-  public void recordResourceDemanded(String resource) {
+  public void recordResourceDemanded(String resource, long demanded) {
     // nop
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/monitoring/Stats.java
+++ b/styx-common/src/main/java/com/spotify/styx/monitoring/Stats.java
@@ -66,7 +66,7 @@ public interface Stats {
 
   void recordResourceUsed(String resource, long used);
 
-  void recordResourceDemanded(String resource);
+  void recordResourceDemanded(String resource, long demanded);
 
   void recordEventConsumer(SequenceEvent event);
 

--- a/styx-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
@@ -240,9 +240,9 @@ public class MetricsStatsTest {
   @Test
   public void shouldRecordResourceDemanded() {
     String resource = "resource";
-    when(registry.meter(RESOURCE_DEMANDED.tagged("resource", resource))).thenReturn(meter);
-    stats.recordResourceDemanded(resource);
-    verify(meter).mark();
+    when(registry.getOrAdd(RESOURCE_DEMANDED.tagged("resource", resource), HISTOGRAM)).thenReturn(histogram);
+    stats.recordResourceDemanded(resource, 17);
+    verify(histogram).update(17L);
   }
 
   @Test


### PR DESCRIPTION


# Hey, I just made a Pull Request!

## Description
Emit aggregate resource demand counts instead of metering in order to produce more meaningful values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
