### PR TITLE
Validate the upper bound of running time configuration

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -83,15 +83,18 @@ public class StyxApi implements AppInit {
 
   public static final String SERVICE_NAME = "styx-api";
 
-  public static final String SCHEDULER_SERVICE_BASE_URL = "styx.scheduler.base-url";
-  public static final String DEFAULT_SCHEDULER_SERVICE_BASE_URL = "http://localhost:8080";
+  static final String SCHEDULER_SERVICE_BASE_URL = "styx.scheduler.base-url";
+  static final String DEFAULT_SCHEDULER_SERVICE_BASE_URL = "http://localhost:8080";
 
-  public static final Duration DEFAULT_RETRY_BASE_DELAY_BT = Duration.ofSeconds(1);
-  public static final String AUTHORIZATION_SERVICE_ACCOUNT_USER_ROLE_CONFIG = "styx.authorization.service-account-user-role";
-  public static final String AUTHORIZATION_GSUITE_USER_CONFIG = "styx.authorization.gsuite-user";
-  public static final String AUTHORIZATION_REQUIRE_ALL_CONFIG = "styx.authorization.require.all";
-  public static final String AUTHORIZATION_REQUIRE_WORKFLOWS = "styx.authorization.require.workflows";
-  public static final String AUTHORIZATION_MESSAGE_CONFIG = "styx.authorization.message";
+  static final Duration DEFAULT_RETRY_BASE_DELAY_BT = Duration.ofSeconds(1);
+  static final String AUTHORIZATION_SERVICE_ACCOUNT_USER_ROLE_CONFIG = "styx.authorization.service-account-user-role";
+  static final String AUTHORIZATION_GSUITE_USER_CONFIG = "styx.authorization.gsuite-user";
+  static final String AUTHORIZATION_REQUIRE_ALL_CONFIG = "styx.authorization.require.all";
+  static final String AUTHORIZATION_REQUIRE_WORKFLOWS = "styx.authorization.require.workflows";
+  static final String AUTHORIZATION_MESSAGE_CONFIG = "styx.authorization.message";
+
+  static final String STYX_RUNNING_STATE_TTL_CONFIG = "styx.running-state-ttl";
+  static final String DEFAULT_STYX_RUNNING_STATE_TTL = "PT24H";
 
   private final String serviceName;
   private final StorageFactory storageFactory;
@@ -168,9 +171,9 @@ public class StyxApi implements AppInit {
   @Override
   public void create(Environment environment) {
     final Config config = environment.config();
-    final String schedulerServiceBaseUrl = config.hasPath(SCHEDULER_SERVICE_BASE_URL)
-                                           ? config.getString(SCHEDULER_SERVICE_BASE_URL)
-                                           : DEFAULT_SCHEDULER_SERVICE_BASE_URL;
+    final String schedulerServiceBaseUrl = getConfigWithDefault(config, SCHEDULER_SERVICE_BASE_URL, DEFAULT_SCHEDULER_SERVICE_BASE_URL);
+    final Duration runningStateTtl = Duration.parse(
+            getConfigWithDefault(config, STYX_RUNNING_STATE_TTL_CONFIG, DEFAULT_STYX_RUNNING_STATE_TTL));
 
     final Stats stats = statsFactory.apply(environment);
     final Storage storage = MeteredStorageProxy.instrument(storageFactory.apply(environment, stats), stats, time);
@@ -186,15 +189,12 @@ public class StyxApi implements AppInit {
     final ServiceAccountUsageAuthorizer authorizer =
         serviceAccountUsageAuthorizer(config, defaultCredential(), serviceName);
 
-    final WorkflowResource workflowResource = new WorkflowResource(storage,
-        new WorkflowValidator(new DockerImageValidator()),
-        new WorkflowInitializer(storage, time),
-        workflowConsumer, authorizer);
+    WorkflowValidator workflowValidator = WorkflowValidator.createWithRunningTimeoutLimit(new DockerImageValidator(), runningStateTtl);
+    final WorkflowResource workflowResource = new WorkflowResource(storage, workflowValidator,
+            new WorkflowInitializer(storage, time), workflowConsumer, authorizer);
 
-    final BackfillResource backfillResource = new BackfillResource(schedulerServiceBaseUrl,
-        storage,
-        new WorkflowValidator(new DockerImageValidator()),
-        time);
+    final BackfillResource backfillResource = new BackfillResource(schedulerServiceBaseUrl, storage,
+            workflowValidator, time);
     environment.closer().register(backfillResource);
 
     final ResourceResource resourceResource = new ResourceResource(storage);
@@ -224,6 +224,10 @@ public class StyxApi implements AppInit {
             requestAuthenticator, serviceName));
   }
 
+  private static String getConfigWithDefault(Config config, String key, String defaultValue) {
+    return config.hasPath(key) ? config.getString(key) : defaultValue;
+  }
+
   @VisibleForTesting
   static ServiceAccountUsageAuthorizer serviceAccountUsageAuthorizer(Config config,
                                                                      GoogleCredential credential,
@@ -235,9 +239,7 @@ public class StyxApi implements AppInit {
     if (config.hasPath(AUTHORIZATION_SERVICE_ACCOUNT_USER_ROLE_CONFIG)) {
       final String role = config.getString(AUTHORIZATION_SERVICE_ACCOUNT_USER_ROLE_CONFIG);
       final String gsuiteUserEmail = config.getString(AUTHORIZATION_GSUITE_USER_CONFIG);
-      final String message = config.hasPath(AUTHORIZATION_MESSAGE_CONFIG)
-                             ? config.getString(AUTHORIZATION_MESSAGE_CONFIG)
-                             : "";
+      final String message = getConfigWithDefault(config, AUTHORIZATION_MESSAGE_CONFIG, "");
       authorizer = ServiceAccountUsageAuthorizer.create(
           role, authorizationPolicy, credential, gsuiteUserEmail, serviceName, message);
     } else {

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -1094,7 +1094,7 @@ public final class CliMain {
 
       @Override
       public WorkflowValidator workflowValidator() {
-        return new WorkflowValidator(new DockerImageValidator());
+        return WorkflowValidator.create(new DockerImageValidator());
       }
     };
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -379,6 +379,9 @@ public class StyxScheduler implements AppInit {
 
     final RateLimiter dequeueRateLimiter = RateLimiter.create(DEFAULT_SUBMISSION_RATE_PER_SEC);
 
+    Duration runningStateTtl = timeoutConfig.ttlOf(State.RUNNING);
+    WorkflowValidator workflowValidator = WorkflowValidator.createWithRunningTimeoutLimit(new DockerImageValidator(), runningStateTtl);
+
     outputHandlers.addAll(ImmutableList.of(
         new TransitionLogger(""),
         new DockerRunnerHandler(
@@ -386,7 +389,7 @@ public class StyxScheduler implements AppInit {
         new TerminationHandler(retryUtil, stateManager),
         new MonitoringHandler(stats),
         new PublisherHandler(publisher, stats),
-        new ExecutionDescriptionHandler(storage, stateManager, new WorkflowValidator(new DockerImageValidator()))));
+        new ExecutionDescriptionHandler(storage, stateManager, workflowValidator)));
 
     final TriggerListener trigger =
         new StateInitializingTrigger(stateManager);
@@ -419,8 +422,7 @@ public class StyxScheduler implements AppInit {
     setupMetrics(queuedStateManager, workflowCache, storage, dequeueRateLimiter, stats, time);
 
     final SchedulerResource schedulerResource =
-        new SchedulerResource(stateManager, trigger, storage, time,
-            new WorkflowValidator(new DockerImageValidator()));
+        new SchedulerResource(stateManager, trigger, storage, time, workflowValidator);
 
     final RequestAuthenticator requestAuthenticator = new RequestAuthenticator(
         authenticatorFactory.apply(AuthenticatorConfiguration.fromConfig(config, serviceName)));


### PR DESCRIPTION
## Description
Somebody could specify an runtime timeout that exceed the implicit
maximum defined in the scheduler.

So to avoid giving false expectations, now an maximum upper value is
defined in the configuration and the workflow validator now enforce that
the value specified does not exceed this limit.

## Have you tested this? If so, how?
I have included unit tests.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
