### PR TITLE
remove workflow id tag from exit code meter

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
+++ b/styx-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
@@ -22,7 +22,6 @@ package com.spotify.styx.monitoring;
 
 import com.codahale.metrics.Gauge;
 import com.spotify.styx.model.SequenceEvent;
-import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.state.RunState;
 
 final class NoopStats implements Stats {
@@ -74,7 +73,7 @@ final class NoopStats implements Stats {
   }
 
   @Override
-  public void recordExitCode(WorkflowId workflowId, int exitCode) {
+  public void recordExitCode(int exitCode) {
     // nop
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/monitoring/Stats.java
+++ b/styx-common/src/main/java/com/spotify/styx/monitoring/Stats.java
@@ -22,7 +22,6 @@ package com.spotify.styx.monitoring;
 
 import com.codahale.metrics.Gauge;
 import com.spotify.styx.model.SequenceEvent;
-import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.state.RunState;
 
 /**
@@ -50,7 +49,7 @@ public interface Stats {
 
   void recordRunning(String executionId);
 
-  void recordExitCode(WorkflowId workflowId, int exitCode);
+  void recordExitCode(int exitCode);
 
   void recordPullImageError();
 

--- a/styx-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
@@ -175,10 +175,7 @@ public class MetricsStatsTest {
   @Test
   public void shouldRecordExitCode() {
     WorkflowId workflowId = WorkflowId.create("component", "workflow");
-    when(registry.meter(EXIT_CODE_RATE.tagged(
-        "component-id", workflowId.componentId(),
-        "workflow-id", workflowId.id(),
-        "exit-code", "0"))).thenReturn(meter);
+    when(registry.meter(EXIT_CODE_RATE.tagged("exit-code", "0"))).thenReturn(meter);
     stats.recordExitCode(0);
     verify(meter).mark();
   }

--- a/styx-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
@@ -179,7 +179,7 @@ public class MetricsStatsTest {
         "component-id", workflowId.componentId(),
         "workflow-id", workflowId.id(),
         "exit-code", "0"))).thenReturn(meter);
-    stats.recordExitCode(workflowId, 0);
+    stats.recordExitCode(0);
     verify(meter).mark();
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/MonitoringHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/monitoring/MonitoringHandler.java
@@ -25,8 +25,7 @@ import com.spotify.styx.state.RunState;
 import java.util.Objects;
 
 /**
- * An {@link OutputHandler} handler that reports execution elapsed time between submitted and
- * running {@link RunState} to FastForward.
+ * An {@link OutputHandler} handler that reports workflow exit codes.
  */
 public class MonitoringHandler implements OutputHandler {
 
@@ -41,7 +40,7 @@ public class MonitoringHandler implements OutputHandler {
     switch (state.state()) {
       case TERMINATED:
         if (state.data().lastExit().isPresent()) {
-          stats.recordExitCode(state.workflowInstance().workflowId(), state.data().lastExit().get());
+          stats.recordExitCode(state.data().lastExit().get());
         }
         break;
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/MonitoringHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/MonitoringHandlerTest.java
@@ -20,12 +20,10 @@
 
 package com.spotify.styx.state.handlers;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.MonitoringHandler;
 import com.spotify.styx.monitoring.Stats;
@@ -63,7 +61,7 @@ public class MonitoringHandlerTest {
 
     monitoringHandler.transitionInto(state);
 
-    verify(stats).recordExitCode(state.workflowInstance().workflowId(), 20);
+    verify(stats).recordExitCode(20);
   }
 
   @Test
@@ -72,6 +70,6 @@ public class MonitoringHandlerTest {
 
     monitoringHandler.transitionInto(state);
 
-    verify(stats, never()).recordExitCode(any(WorkflowId.class), anyInt());
+    verify(stats, never()).recordExitCode(anyInt());
   }
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
remove workflow id tag from exit code meter

## Motivation and Context
Stop punishing our metrics system with high-cardinality time series.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
