### PR TITLE
restore old behaviour when modifying workflow

### DIFF
--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -21,7 +21,7 @@
 package com.spotify.styx;
 
 import static com.spotify.styx.model.WorkflowState.patchEnabled;
-import static com.spotify.styx.util.TimeUtil.nextInstant;
+import static com.spotify.styx.util.TimeUtil.lastInstant;
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -301,7 +301,7 @@ public class StyxSchedulerServiceFixture {
   }
 
   void workflowChanges(Workflow workflow) throws IOException {
-    final TriggerInstantSpec triggerInstantSpec = initializeNaturalTrigger(workflow);
+    final TriggerInstantSpec triggerInstantSpec = updateNaturalTrigger(workflow);
     storage.storeWorkflow(workflow);
     storage.updateNextNaturalTrigger(workflow.id(), triggerInstantSpec);
   }
@@ -310,12 +310,12 @@ public class StyxSchedulerServiceFixture {
     storage.delete(workflow.id());
   }
 
-  private TriggerInstantSpec initializeNaturalTrigger(Workflow workflow) {
-    // TODO: duplicate of WorkflowInitializer.initializeNaturalTrigger
+  private TriggerInstantSpec updateNaturalTrigger(Workflow workflow) {
+    // TODO: duplicate of WorkflowInitializer.updateNaturalTrigger
     final Instant now = time.get();
-    final Instant offsetNow = workflow.configuration().subtractOffset(now);
+
     final Schedule schedule = workflow.configuration().schedule();
-    final Instant nextTrigger = nextInstant(offsetNow, schedule);
+    final Instant nextTrigger = lastInstant(now, schedule);
     final Instant nextWithOffset = workflow.configuration().addOffset(nextTrigger);
     return TriggerInstantSpec.create(nextTrigger, nextWithOffset);
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -439,18 +439,17 @@ public class SystemTest extends StyxSchedulerServiceFixture {
     assertThat(triggerInstantSpec.offsetInstant(),
                is(Instant.parse("2016-03-14T16:00:00Z")));
 
-    workflowInstance = create(HOURLY_WORKFLOW.id(), "2016-03-14T16");
-    // this should store a new value for nextNaturalTrigger, 2016-03-14T16
+    workflowInstance = create(HOURLY_WORKFLOW.id(), "2016-03-14T15");
     workflowChanges(HOURLY_WORKFLOW_WITH_ZERO_OFFSET);
     workflow = storage.workflow(workflowInstance.workflowId()).get();
 
     triggerInstantSpec = storage.workflowsWithNextNaturalTrigger().get(workflow);
     assertThat(triggerInstantSpec.instant(),
-               is(Instant.parse("2016-03-14T16:00:00Z")));
+               is(Instant.parse("2016-03-14T15:00:00Z")));
     assertThat(triggerInstantSpec.offsetInstant(),
-               is(Instant.parse("2016-03-14T16:00:00Z")));
+               is(Instant.parse("2016-03-14T15:00:00Z")));
 
-    givenTheTimeIs("2016-03-14T16:30:00Z");
+    givenTheTimeIs("2016-03-14T15:30:00Z");
 
     tickTriggerManager();
     awaitWorkflowInstanceState(workflowInstance, RunState.State.QUEUED);
@@ -458,41 +457,13 @@ public class SystemTest extends StyxSchedulerServiceFixture {
     awaitNumberOfDockerRuns(2);
 
     workflowInstance = getDockerRuns().get(1)._1;
-    assertThat(workflowInstance.parameter(), is("2016-03-14T16"));
+    assertThat(workflowInstance.parameter(), is("2016-03-14T15"));
 
     triggerInstantSpec = storage.workflowsWithNextNaturalTrigger().get(workflow);
     assertThat(triggerInstantSpec.instant(),
-               is(Instant.parse("2016-03-14T17:00:00Z")));
+               is(Instant.parse("2016-03-14T16:00:00Z")));
     assertThat(triggerInstantSpec.offsetInstant(),
-               is(Instant.parse("2016-03-14T17:00:00Z")));
-
-    givenTheTimeIs("2016-03-14T17:30:00Z");
-
-    workflowInstance = create(HOURLY_WORKFLOW.id(), "2016-03-14T16");
-    // this should store a the same value for nextNaturalTrigger, 2016-03-14T16
-    workflowChanges(HOURLY_WORKFLOW_WITH_TWO_HOURS_OFFSET);
-    workflow = storage.workflow(workflowInstance.workflowId()).get();
-
-    triggerInstantSpec = storage.workflowsWithNextNaturalTrigger().get(workflow);
-    assertThat(triggerInstantSpec.instant(),
-        is(Instant.parse("2016-03-14T16:00:00Z")));
-    assertThat(triggerInstantSpec.offsetInstant(),
-        is(Instant.parse("2016-03-14T18:00:00Z")));
-
-    givenTheTimeIs("2016-03-14T18:30:00Z");
-
-    tickTriggerManager();
-    // the instance 2016-03-14T16 is still active and should reach SUBMITTED state
-    awaitWorkflowInstanceState(workflowInstance, RunState.State.SUBMITTED);
-
-    workflowInstance = getDockerRuns().get(1)._1;
-    assertThat(workflowInstance.parameter(), is("2016-03-14T16"));
-
-    triggerInstantSpec = storage.workflowsWithNextNaturalTrigger().get(workflow);
-    assertThat(triggerInstantSpec.instant(),
-        is(Instant.parse("2016-03-14T17:00:00Z")));
-    assertThat(triggerInstantSpec.offsetInstant(),
-        is(Instant.parse("2016-03-14T19:00:00Z")));
+               is(Instant.parse("2016-03-14T16:00:00Z")));
   }
   }
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
https://github.com/spotify/styx/pull/651 changed the behaviour and this PR makes that only applicable
to creating new workflows.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
