### PR TITLE
authz: principal blacklist

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
@@ -99,6 +99,7 @@ public class StatusResource {
     final TestServiceAccountUsageAuthorizationResponse response =
         new TestServiceAccountUsageAuthorizationResponseBuilder()
             .authorized(result.authorized())
+            .blacklisted(result.blacklisted())
             .serviceAccount(request.serviceAccount())
             .principal(request.principal())
             .message(result.message())

--- a/styx-common/src/main/java/com/spotify/styx/api/ServiceAccountUsageAuthorizer.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/ServiceAccountUsageAuthorizer.java
@@ -497,7 +497,8 @@ public interface ServiceAccountUsageAuthorizer {
                                               String gsuiteUserEmail,
                                               String serviceName,
                                               String message,
-                                              List<String> administrators, List<String> blacklist) {
+                                              List<String> administrators,
+                                              List<String> blacklist) {
 
     final HttpTransport httpTransport;
     try {

--- a/styx-common/src/main/java/com/spotify/styx/api/TestServiceAccountUsageAuthorizationResponse.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/TestServiceAccountUsageAuthorizationResponse.java
@@ -32,6 +32,11 @@ public interface TestServiceAccountUsageAuthorizationResponse {
   boolean authorized();
 
   /**
+   * Blacklisted?
+   */
+  boolean blacklisted();
+
+  /**
    * A message describing the authorization or denial reason.
    */
   Optional<String> message();

--- a/styx-standalone-service/src/main/resources/styx-standalone.conf
+++ b/styx-standalone-service/src/main/resources/styx-standalone.conf
@@ -60,6 +60,14 @@ styx.authentication.resource-whitelist = [
 #   "group:styx-admins@example.com"
 # ]
 
+# A list of principals that should not be authorized to manipulate any workflows nor use any service accounts,
+# even if authorized to do so by users.
+# styx.authorization.blacklist = [
+#   "user:shared-unsecure-user@example.com",
+#   "serviceAccount:shared-build-agent@example.gserviceaccount.com",
+#   "group:undesirables@example.com"
+# ]
+
 # The role that a principal should have either on the workflow service account or in the
 # gcp project of the workflow service account in order to be allowed to create/modify a workflow using it.
 # If unset, authenticated users can use any service account in their workflows.


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Allow blacklisting specific undesirable principals from authorizing.

## Motivation and Context
Protect against users granting authorization access to principals like e.g. a global default CI/CD service account.

Those workflows would otherwise be modifiable by (more or less) _any_ user, which is not intended.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
