### PR TITLE
Some CLI workflow formatting fixes

### DIFF
--- a/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
@@ -124,7 +124,7 @@ class PlainCliOutput implements CliOutput {
   public void printWorkflow(Workflow wf, WorkflowState state) {
     System.out.println(Joiner.on(' ').join(
         wf.componentId(),
-        wf.id().id(),
+        wf.workflowId(),
         wf.configuration().schedule(),
         wf.configuration().offset().orElse(""),
         wf.configuration().dockerImage().orElse(""),

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PlainCliOutput.java
@@ -143,7 +143,7 @@ class PlainCliOutput implements CliOutput {
 
   @Override
   public void printWorkflows(List<Workflow> workflows) {
-    workflows.forEach(wf -> System.out.println(wf.id().toKey()));
+    workflows.forEach(wf -> System.out.println(wf.componentId() + " " + wf.workflowId()));
   }
 
   @Override

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -264,22 +264,22 @@ class PrettyCliOutput implements CliOutput {
 
   @Override
   public void printWorkflow(Workflow wf, WorkflowState state) {
-    System.out.println("Component: " + wf.componentId());
-    System.out.println(" Workflow: " + wf.workflowId());
-    System.out.println(" Schedule: " + wf.configuration().schedule());
-    System.out.println("   Offset: " + wf.configuration().offset().orElse(""));
-    System.out.println("    Image: " + wf.configuration().dockerImage().orElse(""));
-    System.out.println("     Args: " + wf.configuration().dockerArgs().orElse(Collections.emptyList()));
-    System.out.println("  TermLog: " + wf.configuration().dockerTerminationLogging());
-    System.out.println("   Secret: " + wf.configuration().secret().map(s -> s.name() + ':' + s.mountPath()).orElse(""));
-    System.out.println(" Svc Acct: " + wf.configuration().serviceAccount().orElse(""));
-    System.out.println("Resources: " + wf.configuration().resources());
-    System.out.println("      Env: " + Joiner.on(' ').withKeyValueSeparator('=').join(wf.configuration().env()));
-    System.out.println("  Timeout: " + wf.configuration().runningTimeout().map(Duration::toString).orElse(""));
-    System.out.println("   Commit: " + wf.configuration().commitSha().orElse(""));
-    System.out.println("  Enabled: " + state.enabled().map(Object::toString).orElse(""));
-    System.out.println("     Trig: " + state.nextNaturalTrigger().map(Object::toString).orElse(""));
-    System.out.println("Ofst Trig: " + state.nextNaturalOffsetTrigger().map(Object::toString).orElse(""));
+    System.out.println("Component:           " + wf.componentId());
+    System.out.println("Workflow:            " + wf.workflowId());
+    System.out.println("Schedule:            " + wf.configuration().schedule());
+    System.out.println("Offset:              " + wf.configuration().offset().orElse(""));
+    System.out.println("Docker Image:        " + wf.configuration().dockerImage().orElse(""));
+    System.out.println("Docker Arguments:    " + wf.configuration().dockerArgs().orElse(Collections.emptyList()));
+    System.out.println("Termination Logging: " + wf.configuration().dockerTerminationLogging());
+    System.out.println("Secret:              " + wf.configuration().secret().map(s -> s.name() + ':' + s.mountPath()).orElse(""));
+    System.out.println("Service Account:     " + wf.configuration().serviceAccount().orElse(""));
+    System.out.println("Resources:           " + wf.configuration().resources());
+    System.out.println("Environment:         " + Joiner.on(' ').withKeyValueSeparator('=').join(wf.configuration().env()));
+    System.out.println("Timeout:             " + wf.configuration().runningTimeout().map(Duration::toString).orElse(""));
+    System.out.println("Commit:              " + wf.configuration().commitSha().orElse(""));
+    System.out.println("Enabled:             " + state.enabled().map(Object::toString).orElse(""));
+    System.out.println("Trigger:             " + state.nextNaturalTrigger().map(Object::toString).orElse(""));
+    System.out.println("Trigger (offset):    " + state.nextNaturalOffsetTrigger().map(Object::toString).orElse(""));
   }
 
   @Override

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -265,7 +265,7 @@ class PrettyCliOutput implements CliOutput {
   @Override
   public void printWorkflow(Workflow wf, WorkflowState state) {
     System.out.println("Component: " + wf.componentId());
-    System.out.println(" Workflow: " + wf.id().id());
+    System.out.println(" Workflow: " + wf.workflowId());
     System.out.println(" Schedule: " + wf.configuration().schedule());
     System.out.println("   Offset: " + wf.configuration().offset().orElse(""));
     System.out.println("    Image: " + wf.configuration().dockerImage().orElse(""));

--- a/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/PrettyCliOutput.java
@@ -264,22 +264,22 @@ class PrettyCliOutput implements CliOutput {
 
   @Override
   public void printWorkflow(Workflow wf, WorkflowState state) {
-    System.out.println("Component:           " + wf.componentId());
-    System.out.println("Workflow:            " + wf.workflowId());
-    System.out.println("Schedule:            " + wf.configuration().schedule());
-    System.out.println("Offset:              " + wf.configuration().offset().orElse(""));
-    System.out.println("Docker Image:        " + wf.configuration().dockerImage().orElse(""));
-    System.out.println("Docker Arguments:    " + wf.configuration().dockerArgs().orElse(Collections.emptyList()));
-    System.out.println("Termination Logging: " + wf.configuration().dockerTerminationLogging());
-    System.out.println("Secret:              " + wf.configuration().secret().map(s -> s.name() + ':' + s.mountPath()).orElse(""));
-    System.out.println("Service Account:     " + wf.configuration().serviceAccount().orElse(""));
-    System.out.println("Resources:           " + wf.configuration().resources());
-    System.out.println("Environment:         " + Joiner.on(' ').withKeyValueSeparator('=').join(wf.configuration().env()));
-    System.out.println("Timeout:             " + wf.configuration().runningTimeout().map(Duration::toString).orElse(""));
-    System.out.println("Commit:              " + wf.configuration().commitSha().orElse(""));
-    System.out.println("Enabled:             " + state.enabled().map(Object::toString).orElse(""));
-    System.out.println("Trigger:             " + state.nextNaturalTrigger().map(Object::toString).orElse(""));
-    System.out.println("Trigger (offset):    " + state.nextNaturalOffsetTrigger().map(Object::toString).orElse(""));
+    System.out.println("Component:             " + wf.componentId());
+    System.out.println("Workflow:              " + wf.workflowId());
+    System.out.println("Schedule:              " + wf.configuration().schedule());
+    System.out.println("Offset:                " + wf.configuration().offset().orElse(""));
+    System.out.println("Docker Image:          " + wf.configuration().dockerImage().orElse(""));
+    System.out.println("Docker Arguments:      " + wf.configuration().dockerArgs().orElse(Collections.emptyList()));
+    System.out.println("Termination Logging:   " + wf.configuration().dockerTerminationLogging());
+    System.out.println("Secret:                " + wf.configuration().secret().map(s -> s.name() + ':' + s.mountPath()).orElse(""));
+    System.out.println("Service Account:       " + wf.configuration().serviceAccount().orElse(""));
+    System.out.println("Resources:             " + wf.configuration().resources());
+    System.out.println("Environment:           " + Joiner.on(' ').withKeyValueSeparator('=').join(wf.configuration().env()));
+    System.out.println("Timeout:               " + wf.configuration().runningTimeout().map(Duration::toString).orElse(""));
+    System.out.println("Commit:                " + wf.configuration().commitSha().orElse(""));
+    System.out.println("Enabled:               " + state.enabled().map(Object::toString).orElse(""));
+    System.out.println("Next Trigger:          " + state.nextNaturalTrigger().map(Object::toString).orElse(""));
+    System.out.println("Next Trigger (offset): " + state.nextNaturalOffsetTrigger().map(Object::toString).orElse(""));
   }
 
   @Override

--- a/styx-cli/src/test/java/com/spotify/styx/cli/PlainCliOutputTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/PlainCliOutputTest.java
@@ -113,7 +113,7 @@ public class PlainCliOutputTest {
         .schedule(Schedule.DAYS)
         .build());
     cliOutput.printWorkflows(List.of(foo1, foo2));
-    assertThat(outContent.toString(), is(String.format("foo1#bar1%nfoo2#bar2%n")));
+    assertThat(outContent.toString(), is(String.format("foo1 bar1%nfoo2 bar2%n")));
   }
 
   @Test

--- a/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
@@ -293,22 +293,22 @@ public class PrettyCliOutputTest {
         .build();
     cliOutput.printWorkflow(workflow, state);
     assertThat(outContent.toString(), is(
-              "Component: foo1\n"
-            + " Workflow: bar1\n"
-            + " Schedule: DAYS\n"
-            + "   Offset: 6h\n"
-            + "    Image: foo/bar:baz\n"
-            + "     Args: [foo, the, bar]\n"
-            + "  TermLog: true\n"
-            + "   Secret: secret-foo:/foo-secret\n"
-            + " Svc Acct: foo@bar.baz\n"
-            + "Resources: [r1, r2]\n"
-            + "      Env: BAR=bar FOO=foo\n"
-            + "  Timeout: PT23H\n"
-            + "   Commit: deadbeef\n"
-            + "  Enabled: true\n"
-            + "     Trig: 2018-01-02T03:04:05.000000006Z\n"
-            + "Ofst Trig: 2018-01-02T09:04:05.000000006Z\n"));
+              "Component:           foo1\n"
+            + "Workflow:            bar1\n"
+            + "Schedule:            DAYS\n"
+            + "Offset:              6h\n"
+            + "Docker Image:        foo/bar:baz\n"
+            + "Docker Arguments:    [foo, the, bar]\n"
+            + "Termination Logging: true\n"
+            + "Secret:              secret-foo:/foo-secret\n"
+            + "Service Account:     foo@bar.baz\n"
+            + "Resources:           [r1, r2]\n"
+            + "Environment:         BAR=bar FOO=foo\n"
+            + "Timeout:             PT23H\n"
+            + "Commit:              deadbeef\n"
+            + "Enabled:             true\n"
+            + "Trigger:             2018-01-02T03:04:05.000000006Z\n"
+            + "Trigger (offset):    2018-01-02T09:04:05.000000006Z\n"));
 
   }
 }

--- a/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/PrettyCliOutputTest.java
@@ -293,22 +293,22 @@ public class PrettyCliOutputTest {
         .build();
     cliOutput.printWorkflow(workflow, state);
     assertThat(outContent.toString(), is(
-              "Component:           foo1\n"
-            + "Workflow:            bar1\n"
-            + "Schedule:            DAYS\n"
-            + "Offset:              6h\n"
-            + "Docker Image:        foo/bar:baz\n"
-            + "Docker Arguments:    [foo, the, bar]\n"
-            + "Termination Logging: true\n"
-            + "Secret:              secret-foo:/foo-secret\n"
-            + "Service Account:     foo@bar.baz\n"
-            + "Resources:           [r1, r2]\n"
-            + "Environment:         BAR=bar FOO=foo\n"
-            + "Timeout:             PT23H\n"
-            + "Commit:              deadbeef\n"
-            + "Enabled:             true\n"
-            + "Trigger:             2018-01-02T03:04:05.000000006Z\n"
-            + "Trigger (offset):    2018-01-02T09:04:05.000000006Z\n"));
+              "Component:             foo1\n"
+            + "Workflow:              bar1\n"
+            + "Schedule:              DAYS\n"
+            + "Offset:                6h\n"
+            + "Docker Image:          foo/bar:baz\n"
+            + "Docker Arguments:      [foo, the, bar]\n"
+            + "Termination Logging:   true\n"
+            + "Secret:                secret-foo:/foo-secret\n"
+            + "Service Account:       foo@bar.baz\n"
+            + "Resources:             [r1, r2]\n"
+            + "Environment:           BAR=bar FOO=foo\n"
+            + "Timeout:               PT23H\n"
+            + "Commit:                deadbeef\n"
+            + "Enabled:               true\n"
+            + "Next Trigger:          2018-01-02T03:04:05.000000006Z\n"
+            + "Next Trigger (offset): 2018-01-02T09:04:05.000000006Z\n"));
 
   }
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Original output of cli was hard to parse with shell script because of `#` separator rather than standard ` ` (space).

I also found some of the contractions in the pretty workflow show output a bit cryptic so they were extended and also left-aligned (because I find it easier to read, but I guess that's subjective).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
