### PR TITLE
client: auth: GCE default credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -542,6 +542,16 @@
         <artifactId>checker-qual</artifactId>
         <version>2.6.0</version>
       </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>3.11.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.stefanbirkner</groupId>
+        <artifactId>system-rules</artifactId>
+        <version>1.19.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/styx-client/pom.xml
+++ b/styx-client/pom.xml
@@ -35,6 +35,10 @@
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-iam</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.spotify</groupId>
@@ -60,6 +64,16 @@
     <dependency>
       <groupId>pl.pragmatists</groupId>
       <artifactId>JUnitParams</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/styx-client/src/test/java/com/spotify/styx/client/auth/GoogleIdTokenAuthTest.java
+++ b/styx-client/src/test/java/com/spotify/styx/client/auth/GoogleIdTokenAuthTest.java
@@ -1,0 +1,84 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Client
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.client.auth;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Optional;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+public class GoogleIdTokenAuthTest {
+
+  private static final String TEST_ID_TOKEN = "foobar";
+
+  @Rule public final MockWebServer metadataServer = new MockWebServer();
+  @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+  @Before
+  public void setUp() throws Exception {
+    metadataServer.setDispatcher(new Dispatcher() {
+      @Override
+      public MockResponse dispatch(RecordedRequest request) {
+        final MockResponse response = new MockResponse()
+            .setHeader("Metadata-Flavor", "Google");
+        if (request.getPath().equals("/")) {
+          return response;
+        }
+        if (!"Google".equals(request.getHeader("Metadata-Flavor"))) {
+          return response.setResponseCode(404);
+        }
+        if (request.getPath().startsWith("/computeMetadata/v1/instance/service-accounts/default/identity?")) {
+          return response
+              .setBody(TEST_ID_TOKEN)
+              .setHeader("Metadata-Flavor", "Google");
+        }
+        return response.setResponseCode(404);
+      }
+    });
+    environmentVariables.set("GCE_METADATA_HOST", "127.0.0.1:" + metadataServer.getPort());
+  }
+
+  @Test
+  public void testGCEMetadataToken() throws IOException, GeneralSecurityException, InterruptedException {
+    environmentVariables.set("GOOGLE_APPLICATION_CREDENTIALS", "");
+    environmentVariables.set("CLOUDSDK_CONFIG", "/non/existent/path");
+    final GoogleIdTokenAuth idTokenAuth = GoogleIdTokenAuth.ofDefaultCredential();
+    assertThat(idTokenAuth.isGCE(), is(true));
+    final Optional<String> token = idTokenAuth.getToken("http://styx.foo.bar");
+    assertThat(token, is(Optional.of(TEST_ID_TOKEN)));
+    final RecordedRequest detectionRequest = metadataServer.takeRequest();
+    assertThat(detectionRequest.getPath(), is("/"));
+    final RecordedRequest tokenRequest = metadataServer.takeRequest();
+    assertThat(tokenRequest.getPath(), is("/computeMetadata/v1/instance/service-accounts/default/identity"
+                                          + "?audience=http://styx.foo.bar&format=full"));
+    assertThat(tokenRequest.getHeader("Metadata-Flavor"), is("Google"));
+  }
+}


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Add support to styx client for authenticating using GCE default credentials.

## Motivation and Context
When using default credentials, `GoogleIdTokenAuth` will check if using GCE credentials and in that case fetch id tokens from the GCE instance metadata server.

This is so that users using GCE default credentials can use the styx client lib / cli without needing to provision service account keys.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
