### PR TITLE
avoid GCP API interaction if not necessary

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/api/ServiceAccountUsageAuthorizer.java
+++ b/styx-common/src/main/java/com/spotify/styx/api/ServiceAccountUsageAuthorizer.java
@@ -220,11 +220,7 @@ public interface ServiceAccountUsageAuthorizer {
       return checkIsPrincipalBlacklisted(principalEmail)
           .or(() -> checkIsPrincipalAdmin(principalEmail))
           .or(() -> checkRole(serviceAccount, principalEmail, projectIdSupplier))
-          .orElseGet(() -> ServiceAccountUsageAuthorizationResult.builder()
-              .serviceAccountProjectId(projectIdSupplier.get())
-              .authorized(false)
-              .message(denialMessage(serviceAccount, principalEmail, projectIdSupplier.get()))
-              .build());
+          .orElseGet(() -> deny(serviceAccount, principalEmail, projectIdSupplier));
     }
 
     private Optional<ServiceAccountUsageAuthorizationResult> checkIsPrincipalBlacklisted(String principalEmail) {
@@ -267,6 +263,16 @@ public interface ServiceAccountUsageAuthorizer {
                   .message(accessMessage)
                   .build()
           );
+    }
+
+    private ServiceAccountUsageAuthorizationResult deny(String serviceAccount,
+                                                        String principalEmail,
+                                                        Supplier<String> projectIdSupplier) {
+      return ServiceAccountUsageAuthorizationResult.builder()
+          .serviceAccountProjectId(projectIdSupplier.get())
+          .authorized(false)
+          .message(denialMessage(serviceAccount, principalEmail, projectIdSupplier.get()))
+          .build();
     }
 
     private ResponseException denialResponseException(String message) {

--- a/styx-common/src/test/java/com/spotify/styx/api/ServiceAccountUsageAuthorizerTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/api/ServiceAccountUsageAuthorizerTest.java
@@ -194,7 +194,6 @@ public class ServiceAccountUsageAuthorizerTest {
         .authorized(false)
         .blacklisted(true)
         .message(blacklistedMessage(BLACKLISTED_SA_EMAIL))
-        .serviceAccountProjectId(SERVICE_ACCOUNT_PROJECT)
         .build();
     var result = sut.checkServiceAccountUsageAuthorization(SERVICE_ACCOUNT, BLACKLISTED_SA_EMAIL);
     assertThat(result, is(expectedResult));


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Apply blacklist and admin check before making any GCP API interaction.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are cases that getting service account would fail due to non-exist GCP project or non-exist
service account:

```
API error: 500 Internal Server Error (Request ID: 63671a603b6d4bd5a08487c505f4731b): UncheckedExecutionException: java.lang.RuntimeException: java.util.concurrent.ExecutionException: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden {   "code" : 403,   "errors" : [ {     "domain" : "global",     "message" : "Permission iam.serviceAccounts.get is required to perform this operation on service account projects/-/serviceAccounts/...",     "reason" : "forbidden"   } ],   "message" : "Permission iam.serviceAccounts.get is required to perform this operation on service account projects/-/serviceAccounts/...",   "status" : "PERMISSION_DENIED" }: GoogleJsonResponseException: 403 Forbidden {   "code" : 403,   "errors" : [ {     "domain" : "global",     "message" : "Permission iam.serviceAccounts.get is required to perform this operation on service account projects/-/serviceAccounts/....",     "reason" : "forbidden"   } ],   "message" : "Permission iam.serviceAccounts.get is required to perform this operation on service account projects/-/serviceAccounts/....",   "status" : "PERMISSION_DENIED" }
```
When this happens, neither user or admins would be able to delete the dangling workflow. With this change, at least admins will be able to force taking any action without depending on GCP.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
