### PR TITLE
do not create p12 sa keys

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
@@ -43,11 +43,6 @@ public class ServiceAccountKeyManager {
         .setPrivateKeyType("TYPE_GOOGLE_CREDENTIALS_FILE"));
   }
 
-  public ServiceAccountKey createP12Key(String serviceAccount) throws IOException {
-    return createKey(serviceAccount, new CreateServiceAccountKeyRequest()
-        .setPrivateKeyType("TYPE_PKCS12_FILE"));
-  }
-
   public boolean serviceAccountExists(String serviceAccount) throws IOException {
     try {
       iam.projects().serviceAccounts().get("projects/-/serviceAccounts/" + serviceAccount)


### PR DESCRIPTION

# Hey, I just made a Pull Request!

## Description
Do not create p12 SA keys.

## Motivation and Context
* I believe nobody uses p12 keys (re-verify)
* One step towards not having keys at all (!)

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
