### PR TITLE
skip at most once handlers

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/state/AtMostOnceOutputHandler.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/AtMostOnceOutputHandler.java
@@ -1,0 +1,28 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.state;
+
+/**
+ * Output handler that should be invoked at most once.
+ */
+@FunctionalInterface
+public interface AtMostOnceOutputHandler extends OutputHandler {
+}

--- a/styx-common/src/main/java/com/spotify/styx/state/OutputHandler.java
+++ b/styx-common/src/main/java/com/spotify/styx/state/OutputHandler.java
@@ -34,6 +34,10 @@ public interface OutputHandler {
 
   void transitionInto(RunState state);
 
+  default void tryTransitionInto(RunState state) {
+    transitionInto(state);
+  }
+
   static OutputHandler fanOutput(OutputHandler... outputHandlers) {
     return new FanOutputHandler(ImmutableList.copyOf(outputHandlers));
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -377,10 +377,8 @@ public class StyxScheduler implements AppInit {
     // TODO: hack to get around circular reference. Change OutputHandler.transitionInto() to
     //       take StateManager as argument instead?
     final List<OutputHandler> outputHandlers = new ArrayList<>();
-    final BiConsumer<SequenceEvent, RunState> eventConsumer = eventConsumerFactory.apply(environment, stats);
-    final PublisherHandler publisherHandler = new PublisherHandler(publisher, stats);
     final QueuedStateManager queuedStateManager = closer.register(new QueuedStateManager(time, eventProcessingExecutor,
-        storage, fanoutEventConsumer(eventConsumer, publisherHandler), eventConsumerExecutor, fanOutput(outputHandlers),
+        storage, eventConsumerFactory.apply(environment, stats), eventConsumerExecutor, fanOutput(outputHandlers),
         shardedCounter));
     final StateManager stateManager = TracingProxy.instrument(StateManager.class, queuedStateManager);
 
@@ -406,6 +404,7 @@ public class StyxScheduler implements AppInit {
             dockerRunner, stateManager),
         new TerminationHandler(retryUtil, stateManager),
         new MonitoringHandler(stats),
+        new PublisherHandler(publisher, stats),
         new ExecutionDescriptionHandler(storage, stateManager, workflowValidator)));
 
     final TriggerListener trigger =
@@ -458,16 +457,6 @@ public class StyxScheduler implements AppInit {
     this.scheduler = scheduler;
     this.triggerManager = triggerManager;
     this.backfillTriggerManager = backfillTriggerManager;
-  }
-
-  @SafeVarargs
-  private BiConsumer<SequenceEvent, RunState> fanoutEventConsumer(
-      BiConsumer<SequenceEvent, RunState>... eventConsumers) {
-    return (event, runState) -> {
-      for (final BiConsumer<SequenceEvent, RunState> eventConsumer : eventConsumers) {
-        runGuarded(() -> eventConsumer.accept(event, runState));
-      }
-    };
   }
 
   @VisibleForTesting

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -125,8 +125,8 @@ public class QueuedStateManager implements StateManager {
   @Override
   public void tick() {
     var states = getActiveStates();
-    for (final RunState runState : states.values()) {
-      outputHandler.transitionInto(runState);
+    for (var runState : states.values()) {
+      outputHandler.tryTransitionInto(runState);
     }
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -123,6 +123,14 @@ public class QueuedStateManager implements StateManager {
   }
 
   @Override
+  public void tick() {
+    var states = getActiveStates();
+    for (final RunState runState : states.values()) {
+      outputHandler.transitionInto(runState);
+    }
+  }
+
+  @Override
   public CompletionStage<Void> trigger(WorkflowInstance workflowInstance, Trigger trigger, TriggerParameters parameters)
       throws IsClosedException {
     ensureRunning();

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/StateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/StateManager.java
@@ -39,6 +39,12 @@ public interface StateManager extends Closeable {
   Logger LOG = LoggerFactory.getLogger(StateManager.class);
 
   /**
+   * Drive all active instances forward by re-invoking output handlers. Should be called regularly to
+   * ensure instances do not get stuck due to ephemeral output handler failure.
+   */
+  void tick();
+
+  /**
    * Triggers a workflow instance to run.
    *
    * @throws IsClosedException if the state receiver is closed and can not handle events

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/PublisherHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/PublisherHandler.java
@@ -26,22 +26,23 @@ import static com.spotify.styx.state.RunState.State.SUBMITTED;
 import com.cronutils.utils.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.spotify.styx.model.ExecutionDescription;
+import com.spotify.styx.model.SequenceEvent;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.publisher.Publisher;
-import com.spotify.styx.state.OutputHandler;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.util.Retrier;
 import com.spotify.styx.util.RunnableWithException;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An {@link OutputHandler} that integrates {@link RunState.State} values with a {@link Publisher}.
+ * An event consumer that integrates {@link RunState.State} values with a {@link Publisher}.
  */
-public class PublisherHandler implements OutputHandler {
+public class PublisherHandler implements BiConsumer<SequenceEvent, RunState> {
 
   private static final Logger LOG = LoggerFactory.getLogger(PublisherHandler.class);
 
@@ -71,7 +72,7 @@ public class PublisherHandler implements OutputHandler {
   }
 
   @Override
-  public void transitionInto(RunState state) {
+  public void accept(SequenceEvent sequenceEvent, RunState state) {
     final WorkflowInstance workflowInstance = state.workflowInstance();
     switch (state.state()) {
       case SUBMITTED:

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.spotify.styx.QuietDeterministicScheduler;
@@ -80,6 +81,7 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.SecretList;
 import io.fabric8.kubernetes.api.model.SecretVolumeSource;
 import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
@@ -232,6 +234,13 @@ public class KubernetesDockerRunnerTest {
   @After
   public void tearDown() throws Exception {
     kdr.close();
+  }
+
+  @Test
+  public void shouldToleratePodAlreadyCreated() throws IOException {
+    when(pods.create(any(Pod.class))).thenThrow(new KubernetesClientException("Already created", 409, null));
+    kdr.start(WORKFLOW_INSTANCE, RUN_SPEC);
+    verifyZeroInteractions(stateManager);
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/QueuedStateManagerTest.java
@@ -149,6 +149,23 @@ public class QueuedStateManagerTest {
   }
 
   @Test
+  public void tickShouldCallOutputHandlers() throws IOException {
+    var instance1 = WorkflowInstance.create(TestData.WORKFLOW_ID, "2016-05-01");
+    var instance2 = WorkflowInstance.create(TestData.WORKFLOW_ID, "2016-05-02");
+    var runState1 = RunState.create(instance1, State.SUBMITTING, StateData.zero(), NOW.minusMillis(2), 17);
+    var runState2 = RunState.create(instance2, State.TERMINATED, StateData.zero(), NOW.minusMillis(1), 4711);
+
+    when(storage.readActiveStates()).thenReturn(Map.of(
+        instance1, runState1,
+        instance2, runState2));
+
+    stateManager.tick();
+
+    verify(outputHandler).transitionInto(runState1);
+    verify(outputHandler).transitionInto(runState2);
+  }
+
+  @Test
   public void shouldInitializeAndTriggerWFInstance() throws Exception {
     final RunState instanceStateFresh =
         RunState.create(INSTANCE, State.NEW, StateData.zero(), NOW, -1);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.collect.ImmutableList;
 import com.spotify.styx.docker.DockerRunner;
@@ -161,25 +162,16 @@ public class DockerRunnerHandlerTest {
 
     dockerRunnerHandler.transitionInto(runState);
 
-    // Verify that the state manager receives two events:
-    // 1. submitted
-    // 2. runError
-    verify(stateManager, timeout(60_000).times(2))
-        .receive(eventCaptor.capture(), counterCaptor.capture());
+    verify(stateManager).receive(eventCaptor.capture(), counterCaptor.capture());
 
-    Event event1 = eventCaptor.getAllValues().get(0);
-    Event event2 = eventCaptor.getAllValues().get(1);
-    
-    long counter1 = counterCaptor.getAllValues().get(0);
-    long counter2 = counterCaptor.getAllValues().get(1);
+    Event event = eventCaptor.getAllValues().get(0);
+    long counter = counterCaptor.getAllValues().get(0);
 
-    event1.accept(eventVisitor);
-    verify(eventVisitor).submitted(workflowInstance, TEST_EXECUTION_ID);
-    assertThat(counter1, is(runState.counter()));
-
-    event2.accept(eventVisitor);
+    event.accept(eventVisitor);
     verify(eventVisitor).runError(workflowInstance, throwable.getMessage());
-    assertThat(counter2, is(runState.counter() + 1));
+    assertThat(counter, is(runState.counter() + 1));
+
+    verifyNoMoreInteractions(stateManager);
   }
 
   @Test

--- a/styx-standalone-service/src/main/resources/styx-standalone.conf
+++ b/styx-standalone-service/src/main/resources/styx-standalone.conf
@@ -2,12 +2,12 @@ styx.mode = "production"
 
 # ttls for stale states in ISO-8601 duration format
 styx.stale-state-ttls = {
-  new            = "PT1M"
-  creating       = "PT1M"
+  new            = "PT30M"
+  creating       = "PT30M"
   submitted      = "PT10M"
   running        = "PT24H"
-  terminated     = "PT1M"
-  failed         = "PT1M"
+  terminated     = "PT30M"
+  failed         = "PT30M"
   awaiting_retry = "PT8H"
 
   # applies to all other states


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Introducing `AtMostOnceOutputHandler` so we can skip when trying to transition.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
