### PR TITLE
datastore: fix readActiveStatesPartial timeouts

### DIFF
--- a/styx-common/src/test/java/com/spotify/styx/util/FutureUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/FutureUtilTest.java
@@ -20,18 +20,27 @@
 
 package com.spotify.styx.util;
 
-import static com.spotify.styx.util.FutureUtil.exceptionallyCompletedFuture;
+import static com.spotify.styx.util.FutureUtil.gatherIO;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.delayedExecutor;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toMap;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
 import javaslang.control.Try;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,7 +56,7 @@ public class FutureUtilTest {
   @Test
   public void testExceptionallyCompletedFuture() throws ExecutionException, InterruptedException {
     final IOException cause = new IOException("foo");
-    final CompletableFuture<Object> future = exceptionallyCompletedFuture(cause);
+    final CompletableFuture<Object> future = CompletableFuture.failedFuture(cause);
     exception.expect(ExecutionException.class);
     exception.expectCause(is(cause));
     future.get();
@@ -55,10 +64,11 @@ public class FutureUtilTest {
 
   @Test
   public void gatherIOShouldReturnValues() {
+    var timeout = CompletableFuture.runAsync(() -> {}, delayedExecutor(30, SECONDS));
     var futures = Map.of(
         "foo", completedFuture("foo"),
         "bar", completedFuture("bar"));
-    var results = FutureUtil.gatherIO(futures, 30, TimeUnit.SECONDS);
+    var results = FutureUtil.gatherIO(futures, timeout);
     assertThat(results, is(Map.of(
         "foo", Try.success("foo"),
         "bar", Try.success("bar"))));
@@ -66,14 +76,48 @@ public class FutureUtilTest {
 
   @Test
   public void gatherIOShouldPropagateException() {
+    var timeout = CompletableFuture.runAsync(() -> {}, delayedExecutor(30, SECONDS));
     var cause = new Exception("foo");
     var futures = Map.of(
         "foo", completedFuture("foo"),
         "bar", CompletableFuture.<String>failedFuture(cause));
-    var results = FutureUtil.gatherIO(futures, 30, TimeUnit.SECONDS);
+    var results = FutureUtil.gatherIO(futures, timeout);
     assertThat(results.size(), is(2));
     assertThat(results, hasEntry("foo", Try.success("foo")));
     assertThat(results.get("bar").getCause(), instanceOf(ExecutionException.class));
     assertThat(results.get("bar").getCause().getCause(), is(cause));
+  }
+
+  @Test
+  public void gatherIOShouldApplyTimeouts() {
+    var executor = Executors.newSingleThreadExecutor();
+    // Total execution time for these futures running sequentially is 10 seconds
+    var futures = IntStream.range(0, 1000).boxed()
+        .collect(toMap(
+            i -> i,
+            i -> CompletableFuture.supplyAsync(() -> {
+              sleepMillis(10);
+              return i;
+            }, executor)));
+    var start = System.nanoTime();
+    // Give enough time for ~ 20 futures to complete
+    var timeout = CompletableFuture.runAsync(() -> {}, delayedExecutor(200, MILLISECONDS));
+    var results = gatherIO(futures, timeout);
+    var end = System.nanoTime();
+    var elapsed = Duration.ofNanos(end - start);
+    // Verify that the timeout of 200 ms was properly applied in a non-blocking fashion by checking that the execution
+    // duration is well below the expected total of 10 seconds.
+    assertThat(elapsed.getSeconds(), is(lessThan(1L)));
+    // Verify that the expected number of futures succeeded
+    var successCount = results.values().stream().filter(Try::isSuccess).count();
+    assertThat(successCount, is(both(greaterThan(10L)).and(lessThan(30L))));
+  }
+
+  private void sleepMillis(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StateInitializingTrigger.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StateInitializingTrigger.java
@@ -20,7 +20,6 @@
 
 package com.spotify.styx;
 
-import static com.spotify.styx.util.FutureUtil.exceptionallyCompletedFuture;
 import static com.spotify.styx.util.ParameterUtil.toParameter;
 
 import com.spotify.styx.model.TriggerParameters;
@@ -66,7 +65,7 @@ final class StateInitializingTrigger implements TriggerListener {
     } catch (IsClosedException isClosedException) {
       LOG.warn("State receiver is closed when processing workflow {} for trigger {} at {}",
                workflow, trigger, instant, isClosedException);
-      return exceptionallyCompletedFuture(isClosedException);
+      return CompletableFuture.failedFuture(isClosedException);
     }
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
@@ -39,7 +39,6 @@ import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.AlreadyInitializedException;
-import com.spotify.styx.util.FutureUtil;
 import com.spotify.styx.util.Time;
 import com.spotify.styx.util.TriggerInstantSpec;
 import java.io.IOException;
@@ -108,8 +107,7 @@ public class TriggerManagerTest {
   public void shouldNotUpdateNextNaturalTriggerIfTriggerExecutionFails() throws Exception {
     setupWithNextNaturalTrigger(true, parse("2016-10-01T00:00:00Z"));
     when(triggerListener.event(any(), any(), any(), any()))
-        .thenReturn(FutureUtil.exceptionallyCompletedFuture(
-            new RuntimeException("trigger execution failure!")));
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("trigger execution failure!")));
     triggerManager.tick();
     verify(triggerListener).event(WORKFLOW_DAILY, NATURAL_TRIGGER, parse("2016-10-01T00:00:00Z"),
         TriggerParameters.zero());

--- a/styx-service-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -31,6 +31,8 @@ import static com.spotify.styx.util.ShardedCounter.PROPERTY_COUNTER_ID;
 import static com.spotify.styx.util.ShardedCounter.PROPERTY_LIMIT;
 import static com.spotify.styx.util.ShardedCounter.PROPERTY_SHARD_INDEX;
 import static com.spotify.styx.util.ShardedCounter.PROPERTY_SHARD_VALUE;
+import static java.util.concurrent.CompletableFuture.delayedExecutor;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
@@ -100,7 +102,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
@@ -400,6 +401,8 @@ public class DatastoreStorage implements Closeable {
    * Strongly consistently read all active states
    */
   Tuple2<Predicate<WorkflowInstance>, Map<WorkflowInstance, RunState>> readActiveStatesPartial() {
+    var timeout = CompletableFuture.runAsync(() -> {}, delayedExecutor(30, SECONDS));
+
     // Read all index shards in parallel
     final Map<String, CompletableFuture<List<Entity>>> shardFutures =
         activeWorkflowInstanceIndexShardKeys(datastore.newKeyFactory()).stream()
@@ -409,7 +412,7 @@ public class DatastoreStorage implements Closeable {
                 .build()))));
 
     // Gather the index shard read results
-    final Map<String, Try<List<Entity>>> shardResults = gatherIO(shardFutures, 60, TimeUnit.SECONDS);
+    final Map<String, Try<List<Entity>>> shardResults = gatherIO(shardFutures, timeout);
 
     // List workflow instance keys from successfully read shards
     final List<Key> keys = shardResults.values().stream()
@@ -437,7 +440,7 @@ public class DatastoreStorage implements Closeable {
     }
 
     // Gather workflow instance read results
-    final Map<Integer, Try<List<RunState>>> batchResults = gatherIO(batchFutures, 60, TimeUnit.SECONDS);
+    final Map<Integer, Try<List<RunState>>> batchResults = gatherIO(batchFutures, timeout);
 
     // List successfully read instances
     final Map<WorkflowInstance, RunState> activeStates = batchResults.values().stream()
@@ -462,6 +465,8 @@ public class DatastoreStorage implements Closeable {
         unavailableInstances.contains(wfi) ||
         // Did we fail to read the shard of the workflow instance?
         unavailableShards.contains(activeWorkflowInstanceIndexShardName(wfi.toKey()));
+
+    timeout.cancel(true);
 
     return Tuple.of(unavailableInstance, activeStates);
   }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
datastore: fix readActiveStatesPartial timeouts

## Motivation and Context
Instead of applying a fixed timeout to a single future at a time,
which might add up to a significantly longer execution time than
expected, enforce a "global" timeout for the `readActiveStatesPartial`
method and apply it to all the IO futures, cancelling all uncompleted
futures when timing out.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
