### PR TITLE
Return InstancesReadResult instead of Tuple2<>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,16 @@
 
       <!-- general utility libs -->
       <dependency>
+        <groupId>org.immutables</groupId>
+        <artifactId>value</artifactId>
+        <version>2.7.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.immutables</groupId>
+        <artifactId>builder</artifactId>
+        <version>2.7.4</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>27.0.1-jre</version>

--- a/styx-common/pom.xml
+++ b/styx-common/pom.xml
@@ -45,6 +45,16 @@
       <groupId>com.typesafe</groupId>
       <artifactId>config</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>builder</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.github.sviperll</groupId>

--- a/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -40,8 +40,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.function.Predicate;
-import javaslang.Tuple2;
 import org.apache.hadoop.hbase.client.Connection;
 
 /**
@@ -94,7 +92,7 @@ public class AggregateStorage implements Storage {
   }
 
   @Override
-  public Tuple2<Predicate<WorkflowInstance>, Map<WorkflowInstance, RunState>> readActiveStatesPartial() {
+  public InstancesReadResult readActiveStatesPartial() {
     return datastoreStorage.readActiveStatesPartial();
   }
 

--- a/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -409,7 +409,7 @@ public class DatastoreStorage implements Closeable {
                 .build()))));
 
     // Gather the index shard read results
-    final Map<String, Try<List<Entity>>> shardResults = gatherIO(shardFutures, 60, TimeUnit.SECONDS);
+    final Map<String, Try<List<Entity>>> shardResults = gatherIO(shardFutures, 30, TimeUnit.SECONDS);
 
     // List workflow instance keys from successfully read shards
     final List<Key> keys = shardResults.values().stream()
@@ -437,7 +437,7 @@ public class DatastoreStorage implements Closeable {
     }
 
     // Gather workflow instance read results
-    final Map<Integer, Try<List<RunState>>> batchResults = gatherIO(batchFutures, 60, TimeUnit.SECONDS);
+    final Map<Integer, Try<List<RunState>>> batchResults = gatherIO(batchFutures, 30, TimeUnit.SECONDS);
 
     // List successfully read instances
     final Map<WorkflowInstance, RunState> activeStates = batchResults.values().stream()

--- a/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InMemStorage.java
@@ -46,11 +46,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javaslang.Tuple;
-import javaslang.Tuple2;
 
 /**
  * A Storage implementation with state stored in memory. For testing.
@@ -333,7 +330,7 @@ public class InMemStorage implements Storage {
   }
 
   @Override
-  public Map<WorkflowInstance, RunState> readActiveStates() throws IOException {
+  public Map<WorkflowInstance, RunState> readActiveStates() {
     return activeStatesMap;
   }
 
@@ -359,12 +356,7 @@ public class InMemStorage implements Storage {
   }
 
   @Override
-  public Tuple2<Predicate<WorkflowInstance>, Map<WorkflowInstance, RunState>> readActiveStatesPartial() {
-    try {
-      var activeStates = readActiveStates();
-      return Tuple.of(wfi -> false, activeStates);
-    } catch (IOException e) {
-      return Tuple.of(wfi -> true, Map.of());
-    }
+  public InstancesReadResult readActiveStatesPartial() {
+    return InstancesReadResult.ofSuccess(activeStatesMap);
   }
 }

--- a/styx-common/src/main/java/com/spotify/styx/storage/InstancesReadResult.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/InstancesReadResult.java
@@ -1,0 +1,148 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.storage;
+
+import static com.spotify.styx.storage.DatastoreStorage.activeWorkflowInstanceIndexShardName;
+
+import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.state.RunState;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.immutables.builder.Builder;
+import org.immutables.value.Value;
+
+
+/**
+ * A result of reading workflow instances from storage. Reads can be partially successful and the
+ * {@link #instanceUnavailable(WorkflowInstance)} can be called to check whether an instance (or would have)
+ * failed to be read from storage.
+ */
+public class InstancesReadResult {
+
+  public enum Status {
+    SUCCESS, // All instances were successfully read, no failures
+    PARTIAL, // Some instances were successfully read, partial failure
+    FAILURE  // No instances were successfully read, complete failure
+  }
+
+  private final Status status;
+  private final Map<WorkflowInstance, RunState> instances;
+  private final ReadInfo readInfo;
+
+  @Builder.Constructor
+  InstancesReadResult(
+      Map<WorkflowInstance, RunState> instances,
+      ReadInfo readInfo) {
+    this.instances = Map.copyOf(instances);
+    this.status = readInfo.status();
+    this.readInfo = Objects.requireNonNull(readInfo);
+  }
+
+  /**
+   * Get the read success level.
+   */
+  public Status status() {
+    return status;
+  }
+
+  /**
+   * Get all the workflow instances that were read. Might be a partial set in case of partial failures.
+   */
+  public Map<WorkflowInstance, RunState> instances() {
+    return instances;
+  }
+
+  /**
+   * Check whether a {@link WorkflowInstance} failed to be read (or would have if it existed). Note that this method
+   * can return true also for instances that do not exist at all.
+   */
+  public boolean instanceUnavailable(WorkflowInstance instance) {
+    return readInfo.instanceUnavailable(instance);
+  }
+
+  public static InstancesReadResult ofSuccess(Map<WorkflowInstance, RunState> instances) {
+    return builder()
+        .instances(instances)
+        .readInfo(SuccessReadInfo.of())
+        .build();
+  }
+
+  public static InstancesReadResultBuilder builder() {
+    return new InstancesReadResultBuilder();
+  }
+
+  interface ReadInfo {
+    Status status();
+    boolean instanceUnavailable(WorkflowInstance instance);
+  }
+
+  interface SuccessReadInfo extends ReadInfo {
+
+    @Override
+    default Status status() {
+      return Status.SUCCESS;
+    }
+
+    @Override
+    default boolean instanceUnavailable(WorkflowInstance instance) {
+      return false;
+    }
+
+    static SuccessReadInfo of() {
+      return new SuccessReadInfo() {};
+    }
+  }
+
+  @Value.Immutable
+  public interface DatastoreReadInfo extends ReadInfo {
+
+    int shardCount();
+    Set<String> unavailableShards();
+    int instanceCount();
+    Set<WorkflowInstance> unavailableInstances();
+
+    @Override
+    default Status status() {
+      if (unavailableShards().isEmpty() && unavailableInstances().isEmpty()) {
+        return InstancesReadResult.Status.SUCCESS;
+      } else if (unavailableShards().size() == shardCount() ||
+                 unavailableInstances().size() == instanceCount()) {
+        return InstancesReadResult.Status.FAILURE;
+      } else {
+        return InstancesReadResult.Status.PARTIAL;
+      }
+    }
+
+    @Override
+    default boolean instanceUnavailable(WorkflowInstance instance) {
+      return
+          // Did the workflow instance read fail?
+          unavailableInstances().contains(instance) ||
+          // Did we fail to read the shard of the workflow instance?
+          unavailableShards().contains(activeWorkflowInstanceIndexShardName(instance.toKey()));
+    }
+
+    static ImmutableDatastoreReadInfo.Builder builder() {
+      return ImmutableDatastoreReadInfo.builder();
+    }
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -38,8 +38,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.function.Predicate;
-import javaslang.Tuple2;
 
 /**
  * The interface to the persistence layer.
@@ -167,7 +165,7 @@ public interface Storage extends Closeable {
    * A version of {@link #readActiveStates()} that allows for partial success. The return predicate can be used
    * to query whether a WorkflowInstance is unavailable and should be ignored.
    */
-  Tuple2<Predicate<WorkflowInstance>, Map<WorkflowInstance, RunState>> readActiveStatesPartial();
+  InstancesReadResult readActiveStatesPartial();
 
   /**
    * Return a map of all active {@link WorkflowInstance}s to their {@link RunState},

--- a/styx-common/src/main/java/com/spotify/styx/util/FutureUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/FutureUtil.java
@@ -34,12 +34,6 @@ public class FutureUtil {
     throw new UnsupportedOperationException();
   }
 
-  public static <T> CompletableFuture<T> exceptionallyCompletedFuture(final Throwable t) {
-    CompletableFuture<T> future = new CompletableFuture<>();
-    future.completeExceptionally(t);
-    return future;
-  }
-
   /**
    * Gathers results from futures that may fail or time out.
    * @param timeout A global timeout. All futures must have completed before this future completes. Any future

--- a/styx-common/src/main/java/com/spotify/styx/util/FutureUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/FutureUtil.java
@@ -20,11 +20,12 @@
 
 package com.spotify.styx.util;
 
-import com.google.common.collect.ImmutableMap;
+import static java.util.stream.Collectors.toMap;
+
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeoutException;
 import javaslang.control.Try;
 
 public class FutureUtil {
@@ -40,15 +41,17 @@ public class FutureUtil {
   }
 
   /**
-   * Gathers results from futures that may fail.
+   * Gathers results from futures that may fail or time out.
+   * @param timeout A global timeout. All futures must have completed before this future completes. Any future
+   *                not yet completed will be cancelled.
    * @return The values or failures of all futures.
    */
   public static <K, T> Map<K, Try<T>> gatherIO(
-      final Map<K, ? extends Future<T>> futures, long timeout, TimeUnit timeUnit) {
-    final ImmutableMap.Builder<K, Try<T>> results = ImmutableMap.builder();
-    for (Map.Entry<K, ? extends Future<T>> entry : futures.entrySet()) {
-      results.put(entry.getKey(), Try.of(() -> entry.getValue().get(timeout, timeUnit)));
-    }
-    return results.build();
+      final Map<K, ? extends CompletableFuture<T>> futures, CompletionStage<Void> timeout) {
+    return futures.entrySet().stream()
+        // Apply timeout
+        .peek(e -> timeout.thenRun(() -> e.getValue().completeExceptionally(new TimeoutException())))
+        // Collect results
+        .collect(toMap(Map.Entry::getKey, e -> Try.of(() -> e.getValue().get())));
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -453,11 +453,11 @@ public class DatastoreStorageTest {
     doThrow(cause) // Fail first shard read
         .doReturn(List.of()) // Succeed all other reads
         .when(datastore).query(any());
-    var results = storage.readActiveStatesPartial();
+    var result = storage.readActiveStatesPartial();
     // 80 maps to first shard
     final WorkflowInstance unavailableInstance = WorkflowInstance.create(WorkflowId.create("foo", "bar"), "80");
-    assertThat(results._1.test(unavailableInstance), is(true));
-    assertThat(results._1.test(WORKFLOW_INSTANCE1), is(false));
+    assertThat(result.instanceUnavailable(unavailableInstance), is(true));
+    assertThat(result.instanceUnavailable(WORKFLOW_INSTANCE1), is(false));
   }
 
   @Test

--- a/styx-common/src/test/java/com/spotify/styx/storage/InstancesReadResultTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/storage/InstancesReadResultTest.java
@@ -1,0 +1,133 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.storage;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.spotify.styx.model.WorkflowId;
+import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.state.RunState;
+import com.spotify.styx.storage.InstancesReadResult.Status;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public class InstancesReadResultTest {
+
+  private static final Instant NOW = Instant.now();
+  private static final WorkflowId WORKFLOW_ID = WorkflowId.create("foo", "bar");
+  private static final WorkflowInstance WORKFLOW_INSTANCE_1 = WorkflowInstance.create(WORKFLOW_ID, "1");
+  private static final WorkflowInstance WORKFLOW_INSTANCE_2 = WorkflowInstance.create(WORKFLOW_ID, "2");
+
+  private static final RunState RUN_STATE_1 = RunState.create(WORKFLOW_INSTANCE_1, RunState.State.RUNNING, NOW);
+  private static final RunState RUN_STATE_2 = RunState.create(WORKFLOW_INSTANCE_2, RunState.State.RUNNING, NOW);
+
+  @Test
+  public void shouldIndicateSuccess() {
+    assertThat(InstancesReadResult.ofSuccess(Map.of()).status(), is(Status.SUCCESS));
+  }
+
+  @Test
+  public void shouldIndicateSuccessWhenAllShardsAreAvailableButNoInstancesRead() {
+    var result = InstancesReadResult.builder()
+        .instances(Map.of())
+        .readInfo(InstancesReadResult.DatastoreReadInfo.builder()
+            .shardCount(128)
+            .unavailableShards(Set.of())
+            .instanceCount(0)
+            .unavailableInstances(Set.of())
+            .build())
+        .build();
+    assertThat(result.status(), is(Status.SUCCESS));
+  }
+
+  @Test
+  public void shouldIndicateSuccessWhenAllShardsAreAvailableAndAllInstancesAvailable() {
+    var result = InstancesReadResult.builder()
+        .instances(Map.of(WORKFLOW_INSTANCE_1, RUN_STATE_1, WORKFLOW_INSTANCE_2, RUN_STATE_2))
+        .readInfo(InstancesReadResult.DatastoreReadInfo.builder()
+            .shardCount(128)
+            .unavailableShards(Set.of())
+            .instanceCount(2)
+            .unavailableInstances(Set.of())
+            .build())
+        .build();
+    assertThat(result.status(), is(Status.SUCCESS));
+  }
+
+  @Test
+  public void shouldIndicatePartialFailureWhenShardsAreUnavailable() {
+    var result = InstancesReadResult.builder()
+        .instances(Map.of(WORKFLOW_INSTANCE_1, RUN_STATE_1, WORKFLOW_INSTANCE_2, RUN_STATE_2))
+        .readInfo(InstancesReadResult.DatastoreReadInfo.builder()
+            .shardCount(128)
+            .unavailableShards(Set.of("shard-1", "shard-85"))
+            .instanceCount(2)
+            .unavailableInstances(Set.of())
+            .build())
+        .build();
+    assertThat(result.status(), is(Status.PARTIAL));
+  }
+
+  @Test
+  public void shouldIndicateCompleteFailureWhenAllShardsAreUnavailable() {
+    var result = InstancesReadResult.builder()
+        .instances(Map.of())
+        .readInfo(InstancesReadResult.DatastoreReadInfo.builder()
+            .shardCount(2)
+            .addUnavailableShards("shard-1", "shard-85")
+            .instanceCount(0)
+            .unavailableInstances(Set.of())
+            .build())
+        .build();
+    assertThat(result.status(), is(Status.FAILURE));
+  }
+
+  @Test
+  public void shouldIndicatePartialFailureWhenInstancesAreUnavailable() {
+    var result = InstancesReadResult.builder()
+        .instances(Map.of(WORKFLOW_INSTANCE_1, RUN_STATE_1))
+        .readInfo(InstancesReadResult.DatastoreReadInfo.builder()
+            .shardCount(128)
+            .unavailableShards(Set.of())
+            .instanceCount(2)
+            .unavailableInstances(Set.of(WORKFLOW_INSTANCE_2))
+            .build())
+        .build();
+    assertThat(result.status(), is(Status.PARTIAL));
+  }
+
+  @Test
+  public void shouldIndicateCompleteFailureWhenAllInstancesAreUnavailable() {
+    var result = InstancesReadResult.builder()
+        .instances(Map.of())
+        .readInfo(InstancesReadResult.DatastoreReadInfo.builder()
+            .shardCount(128)
+            .unavailableShards(Set.of())
+            .instanceCount(2)
+            .unavailableInstances(Set.of(WORKFLOW_INSTANCE_1, WORKFLOW_INSTANCE_2))
+            .build())
+        .build();
+    assertThat(result.status(), is(Status.FAILURE));
+  }
+}

--- a/styx-common/src/test/java/com/spotify/styx/util/FutureUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/FutureUtilTest.java
@@ -20,8 +20,6 @@
 
 package com.spotify.styx.util;
 
-import static com.spotify.styx.util.FutureUtil.exceptionallyCompletedFuture;
-import static com.spotify.styx.util.FutureUtil.gatherIO;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.delayedExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -57,7 +55,7 @@ public class FutureUtilTest {
   @Test
   public void testExceptionallyCompletedFuture() throws ExecutionException, InterruptedException {
     final IOException cause = new IOException("foo");
-    final CompletableFuture<Object> future = exceptionallyCompletedFuture(cause);
+    final CompletableFuture<Object> future = CompletableFuture.failedFuture(cause);
     exception.expect(ExecutionException.class);
     exception.expectCause(is(cause));
     future.get();
@@ -103,7 +101,7 @@ public class FutureUtilTest {
     var start = System.nanoTime();
     // Give enough time for ~ 20 futures to complete
     var timeout = CompletableFuture.runAsync(() -> {}, delayedExecutor(200, MILLISECONDS));
-    var results = gatherIO(futures, timeout);
+    var results = FutureUtil.gatherIO(futures, timeout);
     var end = System.nanoTime();
     var elapsed = Duration.ofNanos(end - start);
     // Verify that the timeout of 200 ms was properly applied in a non-blocking fashion by checking that the execution

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StateInitializingTrigger.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StateInitializingTrigger.java
@@ -20,7 +20,6 @@
 
 package com.spotify.styx;
 
-import static com.spotify.styx.util.FutureUtil.exceptionallyCompletedFuture;
 import static com.spotify.styx.util.ParameterUtil.toParameter;
 
 import com.spotify.styx.model.TriggerParameters;
@@ -66,7 +65,7 @@ final class StateInitializingTrigger implements TriggerListener {
     } catch (IsClosedException isClosedException) {
       LOG.warn("State receiver is closed when processing workflow {} for trigger {} at {}",
                workflow, trigger, instant, isClosedException);
-      return exceptionallyCompletedFuture(isClosedException);
+      return CompletableFuture.failedFuture(isClosedException);
     }
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/QueuedStateManager.java
@@ -34,6 +34,7 @@ import com.spotify.styx.model.TriggerParameters;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.RunState.State;
+import com.spotify.styx.storage.InstancesReadResult;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.storage.StorageTransaction;
 import com.spotify.styx.storage.TransactionException;
@@ -55,7 +56,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.BiConsumer;
-import java.util.function.Predicate;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.control.Try;
@@ -375,7 +375,7 @@ public class QueuedStateManager implements StateManager {
   }
 
   @Override
-  public Tuple2<Predicate<WorkflowInstance>, Map<WorkflowInstance, RunState>> getActiveStatesPartial() {
+  public InstancesReadResult getActiveStatesPartial() {
     return storage.readActiveStatesPartial();
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/StateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/StateManager.java
@@ -23,13 +23,12 @@ package com.spotify.styx.state;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.TriggerParameters;
 import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.storage.InstancesReadResult;
 import com.spotify.styx.util.IsClosedException;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
-import java.util.function.Predicate;
-import javaslang.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,7 +107,7 @@ public interface StateManager extends Closeable {
    * Get a partial map of all active {@link WorkflowInstance} states with a predicate that indicates if a workflow
    * instance is unavailable.
    */
-  Tuple2<Predicate<WorkflowInstance>, Map<WorkflowInstance, RunState>> getActiveStatesPartial();
+  InstancesReadResult getActiveStatesPartial();
 
   /**
    * Get the current {@link RunState} of a {@link WorkflowInstance}.

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
@@ -39,7 +39,6 @@ import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.AlreadyInitializedException;
-import com.spotify.styx.util.FutureUtil;
 import com.spotify.styx.util.Time;
 import com.spotify.styx.util.TriggerInstantSpec;
 import java.io.IOException;
@@ -108,8 +107,7 @@ public class TriggerManagerTest {
   public void shouldNotUpdateNextNaturalTriggerIfTriggerExecutionFails() throws Exception {
     setupWithNextNaturalTrigger(true, parse("2016-10-01T00:00:00Z"));
     when(triggerListener.event(any(), any(), any(), any()))
-        .thenReturn(FutureUtil.exceptionallyCompletedFuture(
-            new RuntimeException("trigger execution failure!")));
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("trigger execution failure!")));
     triggerManager.tick();
     verify(triggerListener).event(WORKFLOW_DAILY, NATURAL_TRIGGER, parse("2016-10-01T00:00:00Z"),
         TriggerParameters.zero());

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -36,6 +36,7 @@ import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
+import com.spotify.styx.storage.InstancesReadResult;
 import com.spotify.styx.testdata.TestData;
 import com.spotify.styx.util.Debug;
 import io.fabric8.kubernetes.api.model.ContainerState;
@@ -54,7 +55,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javaslang.Tuple;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -115,7 +115,7 @@ public class KubernetesDockerRunnerPodPollerTest {
     podList.setMetadata(new ListMeta());
     podList.getMetadata().setResourceVersion("4711");
 
-    when(stateManager.getActiveStatesPartial()).thenReturn(Tuple.of(wfi -> false, Map.of()));
+    when(stateManager.getActiveStatesPartial()).thenReturn(InstancesReadResult.ofSuccess(Map.of()));
   }
 
   @Test
@@ -283,7 +283,7 @@ public class KubernetesDockerRunnerPodPollerTest {
     RunState runState2 = RunState.create(WORKFLOW_INSTANCE_2, state, stateData2);
     map.put(WORKFLOW_INSTANCE, runState);
     map.put(WORKFLOW_INSTANCE_2, runState2);
-    when(stateManager.getActiveStatesPartial()).thenReturn(Tuple.of(wfi -> false, map));
+    when(stateManager.getActiveStatesPartial()).thenReturn(InstancesReadResult.ofSuccess(map));
   }
 
   private void verifyPodNeverDeleted(PodResource<Pod, DoneablePod> pod) {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -57,6 +57,7 @@ import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
+import com.spotify.styx.storage.InstancesReadResult;
 import com.spotify.styx.testdata.TestData;
 import com.spotify.styx.util.Debug;
 import com.spotify.styx.util.Time;
@@ -97,7 +98,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import javaslang.Tuple;
 import javaslang.control.Try;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -226,7 +226,8 @@ public class KubernetesDockerRunnerTest {
     StateData stateData = StateData.newBuilder().executionId(POD_NAME).build();
     RunState runState = RunState.create(WORKFLOW_INSTANCE, State.SUBMITTED, stateData);
 
-    when(stateManager.getActiveStatesPartial()).thenReturn(Tuple.of(wfi -> false, Map.of(WORKFLOW_INSTANCE, runState)));
+    when(stateManager.getActiveStatesPartial()).thenReturn(
+        InstancesReadResult.ofSuccess(Map.of(WORKFLOW_INSTANCE, runState)));
     when(stateManager.getActiveState(WORKFLOW_INSTANCE)).thenReturn(Optional.of(runState));
   }
 
@@ -398,7 +399,7 @@ public class KubernetesDockerRunnerTest {
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(List.of(containerStatus, keepaliveContainerStatus));
 
-    when(stateManager.getActiveStatesPartial()).thenReturn(Tuple.of(wfi -> false, Map.of()));
+    when(stateManager.getActiveStatesPartial()).thenReturn(InstancesReadResult.ofSuccess(Map.of()));
 
     kdr.tryPollPods();
 
@@ -417,7 +418,7 @@ public class KubernetesDockerRunnerTest {
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(List.of(containerStatus, keepaliveContainerStatus));
 
-    when(stateManager.getActiveStatesPartial()).thenReturn(Tuple.of(wfi -> false, Map.of()));
+    when(stateManager.getActiveStatesPartial()).thenReturn(InstancesReadResult.ofSuccess(Map.of()));
 
     kdr.tryPollPods();
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Return `InstancesReadResult` instead of `Tuple2<>` from `readActiveStatesPartial`.

## Motivation and Context
Make the api a little more maintainable and introspectible.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
