### PR TITLE
Rename: QueuedStateManager -> PersistentStateManager

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -73,7 +73,7 @@ import com.spotify.styx.monitoring.StatsFactory;
 import com.spotify.styx.monitoring.TracingProxy;
 import com.spotify.styx.publisher.Publisher;
 import com.spotify.styx.state.OutputHandler;
-import com.spotify.styx.state.QueuedStateManager;
+import com.spotify.styx.state.PersistentStateManager;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.state.StateManager;
@@ -378,7 +378,7 @@ public class StyxScheduler implements AppInit {
         eventConsumerFactory.apply(environment, stats),
         new PublisherHandler(publisher, stats),
         new TransitionLogger());
-    var queuedStateManager = closer.register(new QueuedStateManager(time, stateProcessingExecutor,
+    var queuedStateManager = closer.register(new PersistentStateManager(time, stateProcessingExecutor,
         storage, eventConsumer, eventConsumerExecutor, fanOutput(outputHandlers),
         shardedCounter));
     final StateManager stateManager = TracingProxy.instrument(StateManager.class, queuedStateManager);
@@ -542,7 +542,7 @@ public class StyxScheduler implements AppInit {
 
   @VisibleForTesting
   static void setupMetrics(
-      QueuedStateManager stateManager,
+      PersistentStateManager stateManager,
       Supplier<Map<WorkflowId, Workflow>> workflowCache,
       Storage storage,
       RateLimiter submissionRateLimiter,

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/PersistentStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/PersistentStateManager.java
@@ -64,8 +64,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An implementation of {@link StateManager} that has an internal queue for all the incoming
- * {@link Event}s that are sent to {@link #receive(Event)}.
+ * An implementation of {@link StateManager} that persists {@link RunState}s and performs transactional
+ * state transitions using {@link Storage}.
  *
  * <p>The events are all processed on an injected {@link Executor}, but sequentially per
  * {@link WorkflowInstance}. This allows event processing to scale across many separate workflow
@@ -74,10 +74,9 @@ import org.slf4j.LoggerFactory;
  * <p>All {@link #outputHandler} transitions are also executed on the injected
  * {@link Executor}.
  */
-// TODO: Remove "Queued" from name as there is no longer any queue \o/
-public class QueuedStateManager implements StateManager {
+public class PersistentStateManager implements StateManager {
 
-  private static final Logger DEFAULT_LOG = LoggerFactory.getLogger(QueuedStateManager.class);
+  private static final Logger DEFAULT_LOG = LoggerFactory.getLogger(PersistentStateManager.class);
   private final Logger log;
 
   private static final long NO_EVENTS_PROCESSED = -1L;
@@ -94,7 +93,7 @@ public class QueuedStateManager implements StateManager {
 
   private volatile boolean running = true;
 
-  public QueuedStateManager(
+  public PersistentStateManager(
       Time time,
       ExecutorService executor,
       Storage storage,
@@ -106,7 +105,7 @@ public class QueuedStateManager implements StateManager {
         DEFAULT_LOG);
   }
 
-  public QueuedStateManager(
+  public PersistentStateManager(
       Time time,
       ExecutorService executor,
       Storage storage,

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
@@ -48,7 +48,7 @@ import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
-import com.spotify.styx.state.QueuedStateManager;
+import com.spotify.styx.state.PersistentStateManager;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.state.StateData;
@@ -92,7 +92,7 @@ public class StyxSchedulerTest {
   @Mock private Container.Projects.Locations.Clusters.Get gkeClusterGet;
   @Mock private Storage storage;
   @Mock private StorageTransaction transaction;
-  @Mock private QueuedStateManager stateManager;
+  @Mock private PersistentStateManager stateManager;
   @Mock private Supplier<Map<WorkflowId, Workflow>> workflowCache;
   @Mock private RateLimiter submissionRateLimiter;
   @Mock private Stats stats;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/PersistentStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/PersistentStateManagerTest.java
@@ -86,7 +86,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
 @RunWith(MockitoJUnitRunner.class)
-public class QueuedStateManagerTest {
+public class PersistentStateManagerTest {
 
   private static final Instant NOW = Instant.parse("2017-01-02T01:02:03Z");
   private static final WorkflowInstance INSTANCE = WorkflowInstance.create(
@@ -108,7 +108,7 @@ public class QueuedStateManagerTest {
   private final ExecutorService eventConsumerExecutor = Executors.newSingleThreadExecutor();
 
 
-  private QueuedStateManager stateManager;
+  private PersistentStateManager stateManager;
 
   @Captor private ArgumentCaptor<RunState> runStateCaptor;
 
@@ -126,7 +126,7 @@ public class QueuedStateManagerTest {
     when(storage.runInTransaction(any())).thenAnswer(
         a -> a.<TransactionFunction>getArgument(0).apply(transaction));
     doNothing().when(outputHandler).transitionInto(runStateCaptor.capture());
-    stateManager = new QueuedStateManager(
+    stateManager = new PersistentStateManager(
         time, executor, storage, eventConsumer,
         eventConsumerExecutor, OutputHandler.fanOutput(outputHandler), shardedCounter, logger);
   }
@@ -315,7 +315,7 @@ public class QueuedStateManagerTest {
   @Test
   public void shouldFailTriggerIfIsClosedOnReceive() throws Exception {
     reset(storage);
-    stateManager = spy(new QueuedStateManager(
+    stateManager = spy(new PersistentStateManager(
         time, executor, storage, eventConsumer,
         eventConsumerExecutor, outputHandler, shardedCounter));
     when(storage.getLatestStoredCounter(any())).thenReturn(Optional.empty());
@@ -332,7 +332,7 @@ public class QueuedStateManagerTest {
   @Test
   public void shouldFailTriggerIfIsClosedOnReceiveAndFailDeleteActiveState() throws Exception {
     reset(storage);
-    stateManager = spy(new QueuedStateManager(
+    stateManager = spy(new PersistentStateManager(
         time, executor, storage, eventConsumer,
         eventConsumerExecutor, outputHandler, shardedCounter));
     when(storage.getLatestStoredCounter(any())).thenReturn(Optional.empty());
@@ -675,7 +675,7 @@ public class QueuedStateManagerTest {
     final Event dequeueEvent = Event.dequeue(INSTANCE, ImmutableSet.copyOf(resourceIds));
     final Event infoEvent = Event.info(INSTANCE,
         Message.info(String.format("Resource limit reached for: %s", resourceIds)));
-    final QueuedStateManager spied = spy(stateManager);
+    final PersistentStateManager spied = spy(stateManager);
     doNothing().when(spied).receiveIgnoreClosed(eq(infoEvent), anyLong());
 
     try {
@@ -703,7 +703,7 @@ public class QueuedStateManagerTest {
 
     final Event dequeueEvent = Event.dequeue(INSTANCE,
         resources.stream().map(Resource::id).collect(toSet()));
-    final QueuedStateManager spied = spy(stateManager);
+    final PersistentStateManager spied = spy(stateManager);
 
     try {
       spied.receive(dequeueEvent);
@@ -728,7 +728,7 @@ public class QueuedStateManagerTest {
         resources.stream().map(Resource::id).collect(toSet()));
     final Event infoEvent = Event.info(INSTANCE,
         Message.info(String.format("Resource limit reached for: %s", resourceIds)));
-    final QueuedStateManager spied = spy(stateManager);
+    final PersistentStateManager spied = spy(stateManager);
 
     try {
       spied.receive(dequeueEvent);
@@ -842,7 +842,7 @@ public class QueuedStateManagerTest {
 
   @Test
   public void shouldReceiveEventIgnoreClosed() throws IOException, IsClosedException {
-    final QueuedStateManager spied = spy(stateManager);
+    final PersistentStateManager spied = spy(stateManager);
     spied.close();
 
     spied.receiveIgnoreClosed(Event.started(INSTANCE));
@@ -852,7 +852,7 @@ public class QueuedStateManagerTest {
 
   @Test
   public void shouldReceiveEventIgnoreClosedWithCounter() throws IOException, IsClosedException {
-    final QueuedStateManager spied = spy(stateManager);
+    final PersistentStateManager spied = spy(stateManager);
     spied.close();
 
     spied.receiveIgnoreClosed(Event.started(INSTANCE), 17);


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Rename `QueuedStateManager` to `PersistentStateManager`.

## Motivation and Context
The state manager implementation no longer has a queue, so name doesn't make any sense. The current defining property of this implementation is that it persists state in storage and performs transactional updates, so change the name to something that reflects that.

Note: Continuation of #704 which should be merged first. Change target to `master` before merging. 

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
