### PR TITLE
scheduler: remove the startup restore step

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/CachedSupplier.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/CachedSupplier.java
@@ -63,7 +63,7 @@ public class CachedSupplier<T> implements Supplier<T> {
 
   @Override
   public T get() {
-    T value = cachedValue.get();
+    var value = cachedValue.get();
 
     if (value != null && !timedOut()) {
       return value;
@@ -79,12 +79,12 @@ public class CachedSupplier<T> implements Supplier<T> {
    */
   private T getSynchronized() {
     synchronized (lock) {
-      final T value = cachedValue.get();
+      var value = cachedValue.get();
       if (value != null && !timedOut()) {
         return value;
       }
       try {
-        final T newValue = delegate.get();
+        var newValue = delegate.get();
         cachedValue.set(newValue);
         cacheTime = time.get().toEpochMilli();
         return newValue;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -351,10 +351,4 @@ public class Scheduler {
     var dequeue = Event.dequeue(workflowInstance, resourceIds);
     stateManager.receiveIgnoreClosed(dequeue, state.counter());
   }
-
-  private void sendTimeout(WorkflowInstance workflowInstance, RunState runState) {
-    LOG.info("Found stale state {} since {} for workflow {}; Issuing a timeout",
-        runState.state(), Instant.ofEpochMilli(runState.timestamp()), workflowInstance);
-    stateManager.receiveIgnoreClosed(Event.timeout(workflowInstance), runState.counter());
-  }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -414,7 +414,7 @@ public class StyxScheduler implements AppInit {
         // an extended downtime, many k8s pods will be completed and would transition the instance into done.
         // However, many of those instances would _also_ technically have timed out according to wall clock and
         // the TimeoutHandler would fail them if allowed to run first.
-        new TimeoutHandler(timeoutConfig, time, stateManager, storage)));
+        new TimeoutHandler(timeoutConfig, time, stateManager, workflowCache)));
 
     final TriggerListener trigger =
         new StateInitializingTrigger(stateManager);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -24,6 +24,7 @@ import com.spotify.styx.ServiceAccountKeyManager;
 import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
+import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.util.Debug;
@@ -48,17 +49,18 @@ public interface DockerRunner extends Closeable {
   Logger LOG = LoggerFactory.getLogger(DockerRunner.class);
 
   /**
-   * Fetch workflow instance state from execution engine and emit events as needed. For use when
-   * when booting in order to recover executions that completed while styx was offline.
-   */
-  void restore();
-
-  /**
    * Starts a workflow instance asynchronously.
    * @param workflowInstance The workflow instance that the run belongs to
    * @param runSpec          Specification of what to run
    */
   void start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException;
+
+  /**
+   * Check the status of a workflow instance execution.
+   *
+   * @param runState         The run state of the instance.
+   */
+  void poll(RunState runState);
 
   /**
    * Perform cleanup for resources such as secrets etc. Resources that are not in use by any currently live workflows

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -547,8 +547,8 @@ class KubernetesDockerRunner implements DockerRunner {
     }
     var runState = stateManager.getActiveState(workflowInstance.orElseThrow());
     var shouldDelete = runState.isPresent() && isPodRunState(pod, runState.orElseThrow())
-                       ? shouldDeletePodWithRunState(workflowInstance.get(), pod, runState.orElseThrow())
-                       : shouldDeletePodWithoutRunState(workflowInstance.get(), pod);
+                       ? shouldDeletePodWithRunState(workflowInstance.orElseThrow(), pod, runState.orElseThrow())
+                       : shouldDeletePodWithoutRunState(workflowInstance.orElseThrow(), pod);
     if (shouldDelete) {
       client.pods().delete(pod);
     }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -126,7 +126,7 @@ class KubernetesDockerRunner implements DockerRunner {
   private static final int DEFAULT_POD_CLEANUP_INTERVAL_SECONDS = 60;
   private static final int DEFAULT_POD_DELETION_DELAY_SECONDS = 120;
   private static final Duration PROCESS_POD_UPDATE_INTERVAL = Duration.ofSeconds(5);
-  private static final int K8S_EVENT_PROCESSING_THREADS = 32;
+  private static final int K8S_POD_PROCESSING_THREADS = 32;
   private static final Time DEFAULT_TIME = Instant::now;
   static final String STYX_WORKFLOW_SA_ENV_VARIABLE = "GOOGLE_APPLICATION_CREDENTIALS";
   static final String STYX_WORKFLOW_SA_SECRET_NAME = "styx-wf-sa-keys";
@@ -143,7 +143,7 @@ class KubernetesDockerRunner implements DockerRunner {
 
   private final Closer closer = Closer.create();
 
-  private final ScheduledExecutorService executor;
+  private final ScheduledExecutorService scheduledExecutor;
 
   private final KubernetesClient client;
   private final StateManager stateManager;
@@ -154,7 +154,7 @@ class KubernetesDockerRunner implements DockerRunner {
   private final Duration cleanupPodsInterval;
   private final Duration podDeletionDelay;
   private final Time time;
-  private final ExecutorService eventExecutor;
+  private final ExecutorService executor;
 
   private Watch watch;
 
@@ -162,7 +162,7 @@ class KubernetesDockerRunner implements DockerRunner {
                          KubernetesGCPServiceAccountSecretManager serviceAccountSecretManager,
                          Debug debug, String styxEnvironment,
                          int cleanupPodsIntervalSeconds, int podDeletionDelaySeconds,
-                         Time time, ScheduledExecutorService executor) {
+                         Time time, ScheduledExecutorService scheduledExecutor) {
     this.stateManager = Objects.requireNonNull(stateManager);
     this.client = Objects.requireNonNull(client);
     this.stats = Objects.requireNonNull(stats);
@@ -172,9 +172,10 @@ class KubernetesDockerRunner implements DockerRunner {
     this.cleanupPodsInterval = Duration.ofSeconds(cleanupPodsIntervalSeconds);
     this.podDeletionDelay = Duration.ofSeconds(podDeletionDelaySeconds);
     this.time = Objects.requireNonNull(time);
-    this.executor = register(closer, Objects.requireNonNull(executor), "kubernetes-poll");
-    this.eventExecutor = currentContextExecutorService(
-        register(closer, new ForkJoinPool(K8S_EVENT_PROCESSING_THREADS), "kubernetes-event"));
+    this.scheduledExecutor =
+        register(closer, Objects.requireNonNull(scheduledExecutor), "kubernetes-scheduled-executor");
+    this.executor = currentContextExecutorService(
+        register(closer, new ForkJoinPool(K8S_POD_PROCESSING_THREADS), "kubernetes-executor"));
   }
 
   KubernetesDockerRunner(NamespacedKubernetesClient client, StateManager stateManager, Stats stats,
@@ -508,10 +509,10 @@ class KubernetesDockerRunner implements DockerRunner {
   }
 
   public void init() {
-    scheduleWithJitter(this::cleanupPods, executor, cleanupPodsInterval);
+    scheduleWithJitter(this::cleanupPods, scheduledExecutor, cleanupPodsInterval);
 
     final PodWatcher watcher = new PodWatcher();
-    scheduleWithJitter(watcher::processPodUpdates, executor, PROCESS_POD_UPDATE_INTERVAL);
+    scheduleWithJitter(watcher::processPodUpdates, scheduledExecutor, PROCESS_POD_UPDATE_INTERVAL);
 
     watch = client.pods().watch(watcher);
   }
@@ -535,7 +536,7 @@ class KubernetesDockerRunner implements DockerRunner {
   @VisibleForTesting
   void tryCleanupPods() {
     client.pods().list().getItems().stream()
-        .map(pod -> runAsync(guard(() -> tryCleanupPod(pod)), eventExecutor))
+        .map(pod -> runAsync(guard(() -> tryCleanupPod(pod)), executor))
         .collect(toList())
         .forEach(CompletableFuture::join);
   }
@@ -686,7 +687,7 @@ class KubernetesDockerRunner implements DockerRunner {
           .map(podName -> {
             // Remove from change set before processing in order to not lose updates
             final WorkflowInstance instance = podUpdates.remove(podName);
-            return runAsync(() -> processPodUpdate(podName, instance), eventExecutor);
+            return runAsync(() -> processPodUpdate(podName, instance), executor);
           })
           .collect(toList())
           .forEach(CompletableFuture::join);
@@ -721,7 +722,7 @@ class KubernetesDockerRunner implements DockerRunner {
     }
 
     private void scheduleReconnect() {
-      executor.schedule(this::reconnect, RECONNECT_DELAY_SECONDS, TimeUnit.SECONDS);
+      scheduledExecutor.schedule(this::reconnect, RECONNECT_DELAY_SECONDS, TimeUnit.SECONDS);
     }
 
     @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -25,22 +25,12 @@ import static com.spotify.styx.docker.KubernetesPodEventTranslator.imageError;
 import static com.spotify.styx.docker.KubernetesPodEventTranslator.isTerminated;
 import static com.spotify.styx.docker.KubernetesPodEventTranslator.translate;
 import static com.spotify.styx.serialization.Json.OBJECT_MAPPER;
-import static com.spotify.styx.state.RunState.State.RUNNING;
 import static com.spotify.styx.util.CloserUtil.register;
 import static com.spotify.styx.util.GrpcContextUtil.currentContextExecutorService;
-import static com.spotify.styx.util.GuardedRunnable.runGuarded;
-import static java.util.stream.Collectors.toSet;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.github.rholder.retry.Attempt;
-import com.github.rholder.retry.RetryException;
-import com.github.rholder.retry.Retryer;
-import com.github.rholder.retry.RetryerBuilder;
-import com.github.rholder.retry.StopStrategies;
-import com.github.rholder.retry.WaitStrategies;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.spotify.styx.model.Event;
@@ -67,7 +57,6 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.QuantityBuilder;
@@ -93,7 +82,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +91,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
@@ -134,7 +121,7 @@ class KubernetesDockerRunner implements DockerRunner {
   static final String TRIGGER_TYPE = "STYX_TRIGGER_TYPE";
   static final String ENVIRONMENT = "STYX_ENVIRONMENT";
   static final String LOGGING = "STYX_LOGGING";
-  private static final int DEFAULT_POLL_PODS_INTERVAL_SECONDS = 60;
+  private static final int DEFAULT_POD_CLEANUP_INTERVAL_SECONDS = 60;
   private static final int DEFAULT_POD_DELETION_DELAY_SECONDS = 120;
   private static final Duration PROCESS_POD_UPDATE_INTERVAL = Duration.ofSeconds(5);
   private static final int K8S_EVENT_PROCESSING_THREADS = 32;
@@ -162,7 +149,7 @@ class KubernetesDockerRunner implements DockerRunner {
   private final KubernetesGCPServiceAccountSecretManager serviceAccountSecretManager;
   private final Debug debug;
   private final String styxEnvironment;
-  private final Duration pollPodsInterval;
+  private final Duration cleanupPodsInterval;
   private final Duration podDeletionDelay;
   private final Time time;
   private final ExecutorService eventExecutor;
@@ -172,7 +159,7 @@ class KubernetesDockerRunner implements DockerRunner {
   KubernetesDockerRunner(NamespacedKubernetesClient client, StateManager stateManager, Stats stats,
                          KubernetesGCPServiceAccountSecretManager serviceAccountSecretManager,
                          Debug debug, String styxEnvironment,
-                         int pollPodsIntervalSeconds, int podDeletionDelaySeconds,
+                         int cleanupPodsIntervalSeconds, int podDeletionDelaySeconds,
                          Time time, ScheduledExecutorService executor) {
     this.stateManager = Objects.requireNonNull(stateManager);
     this.client = Objects.requireNonNull(client);
@@ -180,7 +167,7 @@ class KubernetesDockerRunner implements DockerRunner {
     this.serviceAccountSecretManager = Objects.requireNonNull(serviceAccountSecretManager);
     this.debug = debug;
     this.styxEnvironment = styxEnvironment;
-    this.pollPodsInterval = Duration.ofSeconds(pollPodsIntervalSeconds);
+    this.cleanupPodsInterval = Duration.ofSeconds(cleanupPodsIntervalSeconds);
     this.podDeletionDelay = Duration.ofSeconds(podDeletionDelaySeconds);
     this.time = Objects.requireNonNull(time);
     this.executor = register(closer, Objects.requireNonNull(executor), "kubernetes-poll");
@@ -192,7 +179,7 @@ class KubernetesDockerRunner implements DockerRunner {
                          KubernetesGCPServiceAccountSecretManager serviceAccountSecretManager,
                          Debug debug, String styxEnvironment) {
     this(client, stateManager, stats, serviceAccountSecretManager, debug, styxEnvironment,
-        DEFAULT_POLL_PODS_INTERVAL_SECONDS, DEFAULT_POD_DELETION_DELAY_SECONDS, DEFAULT_TIME,
+        DEFAULT_POD_CLEANUP_INTERVAL_SECONDS, DEFAULT_POD_DELETION_DELAY_SECONDS, DEFAULT_TIME,
         Executors.newSingleThreadScheduledExecutor(THREAD_FACTORY));
   }
 
@@ -210,6 +197,20 @@ class KubernetesDockerRunner implements DockerRunner {
         throw new IOException("Failed to create Kubernetes pod", kce);
       }
     }
+  }
+
+  @Override
+  public void poll(RunState runState) {
+    var executionId = runState.data().executionId().orElseThrow(IllegalArgumentException::new);
+    var pod = client.pods().withName(executionId).get();
+    if (pod == null) {
+      // No pod found. Emit an error guarded by the state counter we are basing the error conclusion on.
+      stateManager.receiveIgnoreClosed(
+          Event.runError(runState.workflowInstance(), "No pod associated with this instance"), runState.counter());
+      return;
+    }
+    logEvent(Watcher.Action.MODIFIED, pod, pod.getMetadata().getResourceVersion(), true);
+    emitPodEvents(pod, runState);
   }
 
   @Override
@@ -504,32 +505,8 @@ class KubernetesDockerRunner implements DockerRunner {
     closer.close();
   }
 
-  @Override
-  public void restore() {
-    // Failing here means restarting the styx scheduler and replaying all events again. This is
-    // quite time consuming and distressing when deploying, so try hard.
-    final Retryer<Object> retryer = RetryerBuilder.newBuilder()
-        .retryIfException()
-        .withWaitStrategy(WaitStrategies.exponentialWait(10, TimeUnit.SECONDS))
-        .withStopStrategy(StopStrategies.stopAfterAttempt(10))
-        .withRetryListener(this::onRestorePollPodsAttempt)
-        .build();
-
-    try {
-      retryer.call(Executors.callable(this::tryPollPods));
-    } catch (ExecutionException | RetryException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private <V> void onRestorePollPodsAttempt(Attempt<V> attempt) {
-    if (attempt.hasException()) {
-      LOG.warn("restore: failed polling pods, attempt = {}", attempt.getAttemptNumber(), attempt.getExceptionCause());
-    }
-  }
-
   public void init() {
-    scheduleWithJitter(this::pollPods, executor, pollPodsInterval);
+    scheduleWithJitter(this::cleanupPods, executor, cleanupPodsInterval);
 
     final PodWatcher watcher = new PodWatcher();
     scheduleWithJitter(watcher::processPodUpdates, executor, PROCESS_POD_UPDATE_INTERVAL);
@@ -537,91 +514,42 @@ class KubernetesDockerRunner implements DockerRunner {
     watch = client.pods().watch(watcher);
   }
 
-  private void examineRunningWFISandAssociatedPods(Map<WorkflowInstance, RunState> activeStates,
-                                                   PodList podList) {
-
-    final Map<WorkflowInstance, RunState> runningWorkflowInstances = Maps.filterValues(activeStates, runState ->
-        runState.state().equals(RUNNING) && runState.data().executionId().isPresent());
-
-    final Set<WorkflowInstance> workflowInstancesForPods = podList.getItems().stream()
-        .map(pod -> pod.getMetadata().getAnnotations())
-        .filter(Objects::nonNull)
-        .map(annotations -> annotations.get(STYX_WORKFLOW_INSTANCE_ANNOTATION))
-        .filter(Objects::nonNull)
-        .map(WorkflowInstance::parseKey)
-        .collect(toSet());
-
-    // Emit errors for workflow instances that seem to be missing its pod
-    runningWorkflowInstances.forEach((workflowInstance, runState) -> {
-
-      // Is there a matching pod in the list? Bail.
-      if (workflowInstancesForPods.contains(workflowInstance)) {
-        return;
-      }
-
-      // The pod list might be stale so explicitly look for a pod using the execution ID.
-      final String executionId = runState.data().executionId().get();
-      final Pod pod = client.pods().withName(executionId).get();
-
-      // We found a pod? Bail.
-      if (pod != null) {
-        return;
-      }
-
-      // No pod found. Emit an error guarded by the state counter we are basing the error conclusion on.
-      stateManager.receiveIgnoreClosed(
-          Event.runError(workflowInstance, "No pod associated with this instance"), runState.counter());
-    });
-  }
-
-  private void pollPods() {
+  private void cleanupPods() {
     try {
-      try (Scope ss = tracer.spanBuilder("Styx.KubernetesDockerRunner.pollPods")
+      try (Scope ss = tracer.spanBuilder("Styx.KubernetesDockerRunner.cleanupPods")
           .setRecordEvents(true)
           .setSampler(Samplers.alwaysSample())
           .startScopedSpan()) {
-        tryPollPods();
+        tryCleanupPods();
       }
     } catch (Throwable t) {
-      LOG.warn("Error while polling pods", t);
+      LOG.warn("Error while cleaning pods", t);
     }
   }
 
+  /**
+   * Deletes stale workflow instance execution pods.
+   */
   @VisibleForTesting
-  synchronized void tryPollPods() {
-    // Fetch pods _before_ fetching all active states
-    final PodList list = client.pods().list();
-    final Map<WorkflowInstance, RunState> activeStates = stateManager.getActiveStates();
-      
-    // Note: Avoid blocking during the processing of the above fetched run states in order to prevent them
-    //       from going stale and losing races due to concurrent processing with other schedulers.
-      
-    examineRunningWFISandAssociatedPods(activeStates, list);
+  void tryCleanupPods() {
+    var pods = client.pods().list().getItems();
 
-    var podsToDelete = new ArrayList<String>();
-    for (Pod pod : list.getItems()) {
-      logEvent(Watcher.Action.MODIFIED, pod, list.getMetadata().getResourceVersion(), true);
-      final Optional<WorkflowInstance> workflowInstance = readPodWorkflowInstance(pod);
-      if (!workflowInstance.isPresent()) {
+    for (var pod : pods) {
+      var workflowInstance = readPodWorkflowInstance(pod);
+      if (workflowInstance.isEmpty()) {
         continue;
       }
 
-      final RunState runState = activeStates.get(workflowInstance.get());
-      final boolean shouldDeletePod;
-      if (runState != null && isPodRunState(pod, runState)) {
-        emitPodEvents(pod, runState);
-        shouldDeletePod = shouldDeletePodWithRunState(workflowInstance.get(), pod, runState);
-      } else {
-        // The pod is stale as we fetched the active states _after_ listing all pods.
-        shouldDeletePod = shouldDeletePodWithoutRunState(workflowInstance.get(), pod);
-      }
-      if (shouldDeletePod) {
-        podsToDelete.add(pod.getMetadata().getName());
+      var runState = stateManager.getActiveState(workflowInstance.orElseThrow());
+
+      var shouldDelete = runState.isPresent() && isPodRunState(pod, runState.orElseThrow())
+                         ? shouldDeletePodWithRunState(workflowInstance.get(), pod, runState.orElseThrow())
+                         : shouldDeletePodWithoutRunState(workflowInstance.get(), pod);
+
+      if (shouldDelete) {
+        client.pods().delete(pod);
       }
     }
-
-    // Do blocking pod deletion after emitting events in order to avoid run states going stale. See note above.
-    podsToDelete.forEach(name -> runGuarded(() -> client.pods().withName(name).delete()));
   }
 
   private static Optional<WorkflowInstance> readPodWorkflowInstance(Pod pod) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LocalDockerRunner.java
@@ -32,6 +32,7 @@ import com.spotify.docker.client.messages.ContainerInfo;
 import com.spotify.docker.client.messages.Image;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
 import java.io.IOException;
 import java.util.Map;
@@ -73,13 +74,6 @@ class LocalDockerRunner implements DockerRunner {
   }
 
   @Override
-  public void restore() {
-    // TODO: a meaningful implementation of this method needs LocalDockerRunner to list the
-    //       local docker containers using the docker api and emit events for them similar to
-    //       KubernetesDockerRunner.
-  }
-
-  @Override
   public void start(WorkflowInstance workflowInstance, RunSpec runSpec) {
     final String imageTag = runSpec.imageName().contains(":")
         ? runSpec.imageName()
@@ -108,6 +102,11 @@ class LocalDockerRunner implements DockerRunner {
 
     inFlight.put(creation.id(), workflowInstance);
     LOG.info("Started container with id " + creation.id() + " and name " + runSpec.executionId());
+  }
+
+  @Override
+  public void poll(RunState runState) {
+    // TODO
   }
 
   @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
@@ -23,6 +23,7 @@ package com.spotify.styx.docker;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.state.RunState;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
@@ -47,13 +48,13 @@ class RoutingDockerRunner implements DockerRunner {
   }
 
   @Override
-  public void restore() {
-    runner().restore();
+  public void start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException {
+    runner().start(workflowInstance, runSpec);
   }
 
   @Override
-  public void start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException {
-    runner().start(workflowInstance, runSpec);
+  public void poll(RunState runState) {
+    runner().poll(runState);
   }
 
   @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -96,6 +96,11 @@ public class DockerRunnerHandler implements OutputHandler {
         }
         break;
 
+      case SUBMITTED:
+      case RUNNING:
+        dockerRunner.poll(state);
+        break;
+
       case TERMINATED:
       case FAILED:
       case ERROR:

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -98,6 +98,8 @@ public class DockerRunnerHandler implements OutputHandler {
 
       case SUBMITTED:
       case RUNNING:
+        // This handler will be invoked regularly as long as the workflow instance is active, so while it is in the
+        // SUBMITTED and RUNNING states, we poll the runner to check the status and health of the container.
         dockerRunner.poll(state);
         break;
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TimeoutHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TimeoutHandler.java
@@ -1,0 +1,85 @@
+/*-
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.state.handlers;
+
+import static com.spotify.styx.state.StateUtil.hasTimedOut;
+
+import com.spotify.styx.model.Event;
+import com.spotify.styx.model.Workflow;
+import com.spotify.styx.model.WorkflowConfiguration;
+import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.state.OutputHandler;
+import com.spotify.styx.state.RunState;
+import com.spotify.styx.state.StateManager;
+import com.spotify.styx.state.TimeoutConfig;
+import com.spotify.styx.storage.Storage;
+import com.spotify.styx.util.Time;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link OutputHandler} that issues {@code timeout} events for instances that have timed out according to the
+ * {@link TimeoutConfig} and the {@link WorkflowConfiguration#runningTimeout()}.
+ */
+public class TimeoutHandler implements OutputHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(TimeoutHandler.class);
+
+  private final TimeoutConfig ttls;
+  private final Time time;
+  private final StateManager stateManager;
+  private final Storage storage;
+
+  public TimeoutHandler(TimeoutConfig ttls, Time time, StateManager stateManager,
+                        Storage storage) {
+    this.ttls = Objects.requireNonNull(ttls, "ttls");
+    this.time = Objects.requireNonNull(time, "time");
+    this.stateManager = Objects.requireNonNull(stateManager, "stateManager");
+    this.storage = Objects.requireNonNull(storage, "storage");
+  }
+
+  @Override
+  public void transitionInto(RunState runState) {
+    // TODO: cache the workflow ttl configuration
+    var workflowOpt = getWorkflow(runState);
+    if (hasTimedOut(workflowOpt, runState, time.get(), ttls.ttlOf(runState.state()))) {
+      sendTimeout(runState.workflowInstance(), runState);
+    }
+  }
+
+  private Optional<Workflow> getWorkflow(RunState runState) {
+    try {
+      return storage.workflow(runState.workflowInstance().workflowId());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void sendTimeout(WorkflowInstance workflowInstance, RunState runState) {
+    log.info("Found stale state {} since {} for workflow {}; Issuing a timeout",
+        runState.state(), Instant.ofEpochMilli(runState.timestamp()), workflowInstance);
+    stateManager.receiveIgnoreClosed(Event.timeout(workflowInstance), runState.counter());
+  }
+}

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -73,7 +73,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import javaslang.Tuple;
 import javaslang.Tuple2;
@@ -111,7 +110,7 @@ public class StyxSchedulerServiceFixture {
   // captured fields from fakes
   Queue<Tuple2<WorkflowInstance, DockerRunner.RunSpec>> dockerRuns = new ConcurrentLinkedQueue();
   Queue<String> dockerCleans = new ConcurrentLinkedQueue();
-  AtomicInteger dockerRestores = new AtomicInteger();
+  Queue<RunState> dockerPolls = new ConcurrentLinkedQueue();
 
   // service and helper
   private StyxScheduler styxScheduler;
@@ -422,14 +421,15 @@ public class StyxSchedulerServiceFixture {
 
   private DockerRunner fakeDockerRunner() {
     return new DockerRunner() {
-      @Override
-      public void restore() {
-        dockerRestores.incrementAndGet();
-      }
 
       @Override
       public void start(WorkflowInstance workflowInstance, RunSpec runSpec) {
         dockerRuns.add(Tuple.of(workflowInstance, runSpec));
+      }
+
+      @Override
+      public void poll(RunState runState) {
+        dockerPolls.add(runState);
       }
 
       @Override

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SystemTest.java
@@ -27,6 +27,7 @@ import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -702,10 +703,11 @@ public class SystemTest extends StyxSchedulerServiceFixture {
   }
   }
 
+  // TODO: rewrite
   @RunWith(JUnitParamsRunner.class)
-  public static class RestoresContainerStateWhenStartingTest extends SystemTest {
+  public static class PollsPodStateWhenStartingTest extends SystemTest {
   @Test
-  public void restoresContainerStateWhenStarting() throws Exception {
+  public void pollsPodStateWhenStarting() throws Exception {
     WorkflowInstance workflowInstance = create(HOURLY_WORKFLOW.id(), "2016-03-14T14");
 
     givenTheTimeIs("2016-03-14T15:17:45Z");
@@ -719,8 +721,10 @@ public class SystemTest extends StyxSchedulerServiceFixture {
 
     styxStarts();
 
-    // Verify that styx tells the runner to restore container state
-    assertThat(dockerRestores.get(), is(1));
+    timePasses(1, MINUTES);
+
+    // Verify that styx polled for execution status
+    assertThat(dockerPolls.size(), is(greaterThanOrEqualTo(1)));
 
     // Simulate the runner emitting a successful termination event
     injectEvent(Event.terminate(workflowInstance, Optional.of(0)));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/RoutingDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/RoutingDockerRunnerTest.java
@@ -30,13 +30,18 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Maps;
 import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.state.RunState;
 import com.spotify.styx.testdata.TestData;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class RoutingDockerRunnerTest {
 
   static final WorkflowInstance WORKFLOW_INSTANCE = WorkflowInstance.create(
@@ -50,6 +55,7 @@ public class RoutingDockerRunnerTest {
   Supplier<String> dockerId = mock(Supplier.class);
 
   DockerRunner dockerRunner;
+  @Mock private RunState runState;
 
   @Before
   public void setUp() throws Exception {
@@ -63,6 +69,15 @@ public class RoutingDockerRunnerTest {
 
     assertThat(createdRunners, hasKey("default"));
     verify(createdRunners.get("default")).start(WORKFLOW_INSTANCE, RUN_SPEC);
+  }
+
+  @Test
+  public void testUsesCreatesRunnerOnPoll() throws Exception {
+    when(dockerId.get()).thenReturn("default");
+    dockerRunner.poll(runState);
+
+    assertThat(createdRunners, hasKey("default"));
+    verify(createdRunners.get("default")).poll(runState);
   }
 
   @Test
@@ -81,15 +96,6 @@ public class RoutingDockerRunnerTest {
 
     assertThat(createdRunners, hasKey("default"));
     verify(createdRunners.get("default")).cleanup();
-  }
-
-  @Test
-  public void testUsesDefaultRunnerOnRestore() throws Exception {
-    when(dockerId.get()).thenReturn("default");
-    dockerRunner.restore();
-
-    assertThat(createdRunners, hasKey("default"));
-    verify(createdRunners.get("default")).restore();
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/DockerRunnerHandlerTest.java
@@ -222,7 +222,7 @@ public class DockerRunnerHandlerTest {
 
   @Parameters({"SUBMITTED", "RUNNING"})
   @Test
-  public void shouldPollWhenRunning(State state) {
+  public void shouldPollWhenStarted(State state) {
     WorkflowConfiguration workflowConfiguration = configuration("--date", "{}", "--bar");
     Workflow workflow = Workflow.create("id", workflowConfiguration);
     WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/TimeoutHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/TimeoutHandlerTest.java
@@ -33,15 +33,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.spotify.styx.model.Event;
+import com.spotify.styx.model.Workflow;
+import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.RunState.State;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.TimeoutConfig;
-import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.Time;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Optional;
+import java.util.Map;
+import java.util.function.Supplier;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
@@ -58,19 +60,19 @@ public class TimeoutHandlerTest {
   private long counter = 17;
 
   @Mock private StateManager stateManager;
-  @Mock private Storage storage;
+  @Mock private Supplier<Map<WorkflowId, Workflow>> workflows;
 
   private TimeoutHandler timeoutHandler;
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    when(storage.workflow(WORKFLOW_ID)).thenReturn(Optional.of(WORKFLOW_WITH_RESOURCES));
+    when(workflows.get()).thenReturn(Map.of(WORKFLOW_ID, WORKFLOW_WITH_RESOURCES));
   }
 
   private void setUpWithTimeoutSeconds(int timeoutSeconds) {
     TimeoutConfig timeoutConfig = createWithDefaultTtl(ofSeconds(timeoutSeconds));
-    timeoutHandler = new TimeoutHandler(timeoutConfig, time, stateManager, storage);
+    timeoutHandler = new TimeoutHandler(timeoutConfig, time, stateManager, workflows);
   }
 
   @Parameters(source = State.class)

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/TimeoutHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/TimeoutHandlerTest.java
@@ -1,0 +1,106 @@
+/*-
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.state.handlers;
+
+import static com.spotify.styx.state.TimeoutConfig.createWithDefaultTtl;
+import static com.spotify.styx.testdata.TestData.WORKFLOW_ID;
+import static com.spotify.styx.testdata.TestData.WORKFLOW_INSTANCE;
+import static com.spotify.styx.testdata.TestData.WORKFLOW_WITH_RESOURCES;
+import static java.time.Duration.ofSeconds;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.spotify.styx.model.Event;
+import com.spotify.styx.state.RunState;
+import com.spotify.styx.state.RunState.State;
+import com.spotify.styx.state.StateManager;
+import com.spotify.styx.state.TimeoutConfig;
+import com.spotify.styx.storage.Storage;
+import com.spotify.styx.util.Time;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnitParamsRunner.class)
+public class TimeoutHandlerTest {
+
+  private Instant now = Instant.parse("2016-12-02T22:00:00Z");
+  private Time time = () -> now;
+  private long counter = 17;
+
+  @Mock private StateManager stateManager;
+  @Mock private Storage storage;
+
+  private TimeoutHandler timeoutHandler;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    when(storage.workflow(WORKFLOW_ID)).thenReturn(Optional.of(WORKFLOW_WITH_RESOURCES));
+  }
+
+  private void setUpWithTimeoutSeconds(int timeoutSeconds) {
+    TimeoutConfig timeoutConfig = createWithDefaultTtl(ofSeconds(timeoutSeconds));
+    timeoutHandler = new TimeoutHandler(timeoutConfig, time, stateManager, storage);
+  }
+
+  @Parameters(source = State.class)
+  @Test
+  public void shouldTimeoutActiveState(State state) throws Exception {
+    assumeFalse(state.isTerminal());
+    setUpWithTimeoutSeconds(5);
+    var runState = RunState.create(WORKFLOW_INSTANCE, state, now, counter);
+    now = now.plus(5, ChronoUnit.SECONDS);
+    timeoutHandler.transitionInto(runState);
+    verify(stateManager).receiveIgnoreClosed(Event.timeout(WORKFLOW_INSTANCE), counter);
+  }
+
+  @Parameters(source = State.class)
+  @Test
+  public void shouldNotTimeoutTerminalState(State state) throws Exception {
+    assumeTrue(state.isTerminal());
+    setUpWithTimeoutSeconds(0);
+    now = now.plus(5, ChronoUnit.SECONDS);
+    var runState = RunState.create(WORKFLOW_INSTANCE, state, now, counter);
+    timeoutHandler.transitionInto(runState);
+    verify(stateManager, never()).receiveIgnoreClosed(any());
+  }
+
+  @Parameters(source = State.class)
+  @Test
+  public void shouldNotTransitionIfNotTimedOut(State state) throws Exception {
+    setUpWithTimeoutSeconds(20);
+    var runState = RunState.create(WORKFLOW_INSTANCE, State.RUNNING, now, counter);
+    timeoutHandler.transitionInto(runState);
+    verify(stateManager, never()).receiveIgnoreClosed(any());
+  }
+}


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Remove the `restore` step that block scheduler startup.

## Motivation and Context
* Make `DockerRunnerHandler` poll for execution status and emit events.
* Move timeout handling out of the scheduler and into a dedicated
  `TimeoutHandler` that runs last.

This allows us to remove the `restore` method and stop blocking on it
during startup as timeouts are now issued _after_ checking if the
pod is done.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [x] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
