### PR TITLE
Use guava cache

### DIFF
--- a/styx-common/pom.xml
+++ b/styx-common/pom.xml
@@ -121,5 +121,10 @@
       <artifactId>system-rules</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/styx-common/src/main/java/com/spotify/styx/util/CachedSupplier.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/CachedSupplier.java
@@ -44,7 +44,7 @@ public class CachedSupplier<T> implements Supplier<T> {
 
   CachedSupplier(Try.CheckedSupplier<T> delegate, Time time, Duration timeout) {
     this.cache = CacheBuilder.newBuilder()
-        .expireAfterAccess(timeout)
+        .expireAfterWrite(timeout)
         .ticker(new Ticker() {
           @Override
           public long read() {

--- a/styx-common/src/main/java/com/spotify/styx/util/CachedSupplier.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/CachedSupplier.java
@@ -44,7 +44,7 @@ public class CachedSupplier<T> implements Supplier<T> {
 
   CachedSupplier(Try.CheckedSupplier<T> delegate, Time time, Duration timeout) {
     this.cache = CacheBuilder.newBuilder()
-        .expireAfterWrite(timeout)
+        .refreshAfterWrite(timeout)
         .ticker(new Ticker() {
           @Override
           public long read() {

--- a/styx-common/src/main/java/com/spotify/styx/util/CachedSupplier.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/CachedSupplier.java
@@ -25,7 +25,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.time.Duration;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import javaslang.control.Try;
 
@@ -57,10 +56,6 @@ public class CachedSupplier<T> implements Supplier<T> {
 
   @Override
   public T get() {
-    try {
-      return cache.get(Boolean.TRUE);
-    } catch (ExecutionException e) {
-      throw new RuntimeException(e);
-    }
+    return Try.of(() -> cache.get(Boolean.TRUE)).get();
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/util/CachedSupplierTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/CachedSupplierTest.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx.util;
 
+import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -76,12 +77,15 @@ public class CachedSupplierTest {
   public void testCacheTimesOut() throws Throwable {
     int a = sut.get();
     x = 100;
-    instant = Instant.parse("2016-10-17T15:00:11Z");
+    instant = instant.plus(9, SECONDS);
     int b = sut.get();
+    instant = instant.plus(2, SECONDS);
+    int c = sut.get();
 
     verify(delegate, times(2)).get();
     assertThat(a, is(42));
-    assertThat(b, is(100));
+    assertThat(b, is(42));
+    assertThat(c, is(100));
   }
 
   @Test
@@ -119,5 +123,22 @@ public class CachedSupplierTest {
     assertThat(f2.join(), is(17));
 
     verifyNoMoreInteractions(delegate);
+  }
+
+  @Test
+  public void defaultTimeout() throws Throwable {
+    sut = new CachedSupplier<>(delegate, time);
+
+    var a = sut.get();
+    x = 100;
+    instant = instant.plus(29, SECONDS);
+    var b = sut.get();
+    instant = instant.plus(2, SECONDS);
+    var c = sut.get();
+
+    verify(delegate, times(2)).get();
+    assertThat(a, is(42));
+    assertThat(b, is(42));
+    assertThat(c, is(100));
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/util/CachedSupplierTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/CachedSupplierTest.java
@@ -20,10 +20,13 @@
 
 package com.spotify.styx.util;
 
-import static java.time.temporal.ChronoUnit.SECONDS;
+import static com.spotify.styx.util.CachedSupplier.DEFAULT_TIMEOUT;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -37,8 +40,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Supplier;
 import javaslang.control.Try;
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -46,8 +52,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class CachedSupplierTest {
 
-  private volatile Instant instant = Instant.parse("2016-10-17T15:00:00Z");
-  private volatile int x = 42;
+  @Rule public final ExpectedException exception = ExpectedException.none();
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+  private static final int INITIAL_VALUE = 42;
+  private static final int NEW_VALUE = 100;
+
+  private volatile Instant now = Instant.parse("2016-10-17T15:00:00Z");
 
   @Mock private Try.CheckedSupplier<Integer> delegate;
 
@@ -56,64 +67,82 @@ public class CachedSupplierTest {
 
   @Before
   public void setUp() throws Throwable {
-    when(delegate.get()).then(a -> x);
-    when(time.nanoTime()).then(a -> MILLISECONDS.toNanos(instant.toEpochMilli()));
-    sut = new CachedSupplier<>(delegate, time, Duration.ofSeconds(10));
+    when(delegate.get()).thenReturn(INITIAL_VALUE);
+    when(time.nanoTime()).then(a -> MILLISECONDS.toNanos(now.toEpochMilli()));
+    sut = new CachedSupplier<>(delegate, time, TIMEOUT);
   }
 
   @Test
   public void testCachesCalls() throws Throwable {
-    int a = sut.get();
-    x = 100;
-    int b = sut.get();
-
+    // Initial load
+    var a = sut.get();
+    assertThat(a, is(INITIAL_VALUE));
     verify(delegate, times(1)).get();
 
-    assertThat(a, is(42));
-    assertThat(b, is(42));
+    // Make underlying supplier return new value
+    lenient().when(delegate.get()).thenReturn(NEW_VALUE);
+
+    // Should still get initial value here
+    var b = sut.get();
+    assertThat(b, is(INITIAL_VALUE));
+
+    // Verify there were no additional calls to the underlying supplier
+    verifyNoMoreInteractions(delegate);
   }
 
   @Test
   public void testReturnsOldValueIfDelegateFails() throws Throwable {
-    int a = sut.get();
-    instant = instant.plus(20, SECONDS);
-    when(delegate.get()).then(__ -> {
-      throw new RuntimeException("Fail!"); });
-    int b = sut.get();
-    int c = sut.get();
-
-    verify(delegate, times(3)).get();
-
-    assertThat(a, is(42));
-    assertThat(b, is(42));
-    assertThat(c, is(42));
-  }
-
-  @Test
-  public void testCacheTimesOut() throws Throwable {
-    int a = sut.get();
-    x = 100;
-    instant = instant.plus(9, SECONDS);
-    int b = sut.get();
-    instant = instant.plus(2, SECONDS);
-    int c = sut.get();
-
-    verify(delegate, times(2)).get();
-    assertThat(a, is(42));
-    assertThat(b, is(42));
-    assertThat(c, is(100));
-  }
-
-  @Test
-  public void testCacheDoesNotTimeOutWithinTimeout() throws Throwable {
-    int a = sut.get();
-    x = 100;
-    instant = Instant.parse("2016-10-17T15:00:09Z");
-    int b = sut.get();
-
+    // Initial load
+    var a = sut.get();
+    assertThat(a, is(INITIAL_VALUE));
     verify(delegate, times(1)).get();
-    assertThat(a, is(42));
-    assertThat(b, is(42));
+
+    // Make the supplier fail and progress time enough to trigger refresh
+    when(delegate.get()).thenThrow(new RuntimeException("Fail!"));
+    now = now.plus(TIMEOUT).plusSeconds(1);
+
+    // Trigger refresh
+    var b = sut.get();
+    assertThat(b, is(INITIAL_VALUE));
+
+    // Ensure that the old value is still returned (never observe another value)
+    exception.expect(ConditionTimeoutException.class);
+    await().atMost(5, SECONDS).until(() -> sut.get() != INITIAL_VALUE);
+  }
+
+  @Test
+  public void testCacheRefreshes() throws Throwable {
+    // Initial load
+    var a = sut.get();
+    assertThat(a, is(INITIAL_VALUE));
+    verify(delegate, times(1)).get();
+
+    // Make supplier return new value and progress time enough to trigger refresh
+    when(delegate.get()).thenReturn(NEW_VALUE);
+    now = now.plus(TIMEOUT).plusSeconds(1);
+
+    // Eventually observe new value
+    await().until(() -> sut.get() == NEW_VALUE);
+  }
+
+  @Test
+  public void testCacheDoesNotRefreshBeforeTimeout() throws Throwable {
+    // Initial load
+    int a = sut.get();
+    assertThat(a, is(INITIAL_VALUE));
+    verify(delegate, times(1)).get();
+
+    // Make supplier return new value and progress time, but not enough to trigger refresh
+    lenient().when(delegate.get()).thenReturn(NEW_VALUE);
+    now = now.plus(TIMEOUT).minusSeconds(1);
+
+    // Should return initial value and not trigger refresh
+    int b = sut.get();
+    assertThat(b, is(INITIAL_VALUE));
+
+    // Ensure that there is no call to refresh
+    Thread.sleep(5000);
+    verifyNoMoreInteractions(delegate);
   }
 
   @Test
@@ -125,19 +154,17 @@ public class CachedSupplierTest {
     var f1 = CompletableFuture.supplyAsync(sut, executor);
     var f2 = CompletableFuture.supplyAsync(sut, executor);
 
-    // Wait for first thread to call delegate
+    // Wait for first call to the underlying supplier
     verify(delegate, timeout(5000).times(1)).get();
 
-    // Wait for second thread to reach lock
-    Thread.sleep(500);
-    verifyNoMoreInteractions(delegate);
+    queue.put(1);
+    queue.put(2);
 
-    queue.put(17);
-    queue.put(4711);
+    assertThat(f1.join(), is(1));
+    assertThat(f2.join(), is(1));
 
-    assertThat(f1.join(), is(17));
-    assertThat(f2.join(), is(17));
-
+    // Ensure that there was only one call to the underlying supplier
+    Thread.sleep(5000);
     verifyNoMoreInteractions(delegate);
   }
 
@@ -145,16 +172,44 @@ public class CachedSupplierTest {
   public void defaultTimeout() throws Throwable {
     sut = new CachedSupplier<>(delegate, time);
 
+    // Initial load
     var a = sut.get();
-    x = 100;
-    instant = instant.plus(29, SECONDS);
-    var b = sut.get();
-    instant = instant.plus(2, SECONDS);
-    var c = sut.get();
+    assertThat(a, is(INITIAL_VALUE));
+    verify(delegate, times(1)).get();
 
-    verify(delegate, times(2)).get();
-    assertThat(a, is(42));
-    assertThat(b, is(42));
-    assertThat(c, is(100));
+    // Make supplier return new value and progress time enough to trigger refresh
+    when(delegate.get()).thenReturn(NEW_VALUE);
+    now = now.plus(DEFAULT_TIMEOUT).plusSeconds(1);
+
+    // Eventually observe new value
+    await().until(() -> sut.get() == NEW_VALUE);
+  }
+
+  @Test
+  public void refreshesAsynchronously() throws Throwable {
+    // Initial load
+    var initialValue = sut.get();
+    assertThat(initialValue, is(INITIAL_VALUE));
+    verify(delegate).get();
+
+    // Set up reload to block
+    var reloadFuture = new CompletableFuture<Integer>();
+    when(delegate.get()).then(a -> reloadFuture.join());
+
+    // Progress time enough to exceed timeout
+    now = now.plus(TIMEOUT).plusSeconds(1);
+
+    // Trigger refresh - should return old value and not block
+    var triggerValue = sut.get();
+    assertThat(triggerValue, is(INITIAL_VALUE));
+
+    // Wait for refresh
+    await().until(() -> Try.of(() -> verify(delegate, times(2)).get()).isSuccess());
+
+    // Complete reload
+    reloadFuture.complete(NEW_VALUE);
+
+    // Eventually observe new value
+    await().until(() -> sut.get() == NEW_VALUE);
   }
 }

--- a/styx-common/src/test/java/com/spotify/styx/util/CachedSupplierTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/CachedSupplierTest.java
@@ -74,6 +74,22 @@ public class CachedSupplierTest {
   }
 
   @Test
+  public void testReturnsOldValueIfDelegateFails() throws Throwable {
+    int a = sut.get();
+    instant = instant.plus(20, SECONDS);
+    when(delegate.get()).then(__ -> {
+      throw new RuntimeException("Fail!"); });
+    int b = sut.get();
+    int c = sut.get();
+
+    verify(delegate, times(3)).get();
+
+    assertThat(a, is(42));
+    assertThat(b, is(42));
+    assertThat(c, is(42));
+  }
+
+  @Test
   public void testCacheTimesOut() throws Throwable {
     int a = sut.get();
     x = 100;


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Use guava cache instead of rolling our own caching.

## Motivation and Context
* Avoid having to maintain our own implementation.
* Gain useful features, like async refresh.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [x] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
