### PR TITLE
K8s: check pod exists before creating and log more

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -188,6 +188,13 @@ class KubernetesDockerRunner implements DockerRunner {
 
   @Override
   public void start(WorkflowInstance workflowInstance, RunSpec runSpec) throws IOException {
+    // First make cheap check for if pod already exists
+    var existingPod = client.pods().withName(runSpec.executionId()).get();
+    if (existingPod != null) {
+      LOG.info("Pod already exists, not creating: {}: {}", workflowInstance, existingPod);
+      return;
+    }
+
     final KubernetesSecretSpec secretSpec = ensureSecrets(workflowInstance, runSpec);
     try {
       client.pods().create(createPod(workflowInstance, runSpec, secretSpec, styxEnvironment));


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
* Check if pod exists before creating
* log more pod creation info

## Motivation and Context
Provide more log messages that can be used to debug unexpected pod creation behavior.
 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
