### PR TITLE
silence state transition conflict spam + fix scheduler error handling

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -200,6 +200,8 @@ public class Scheduler {
                     currentResourceUsage, currentResourceDemand);
               } catch (StateTransitionConflictException e) {
                 LOG.debug("State transition conflict when scheduling instance: {}", instance, e);
+              } catch (Throwable e) {
+                LOG.warn("Caught exception when scheduling instance: {}", instance, e);
               }
             }), executor))
         .collect(toList());

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -93,8 +93,6 @@ import org.slf4j.LoggerFactory;
  */
 public class Scheduler {
 
-  private static final Logger LOG = LoggerFactory.getLogger(Scheduler.class);
-
   private static final String TICK_TYPE = UPPER_CAMEL.to(LOWER_UNDERSCORE,
       Scheduler.class.getSimpleName());
 
@@ -109,10 +107,19 @@ public class Scheduler {
   private final WorkflowExecutionGate gate;
   private final ShardedCounter shardedCounter;
   private final Executor executor;
+  private final Logger log;
 
-  public Scheduler(Time time, StateManager stateManager, Storage storage,
-                   WorkflowResourceDecorator resourceDecorator, Stats stats, RateLimiter dequeueRateLimiter,
-                   WorkflowExecutionGate gate, ShardedCounter shardedCounter, Executor executor) {
+  Scheduler(Time time, StateManager stateManager, Storage storage,
+            WorkflowResourceDecorator resourceDecorator, Stats stats, RateLimiter dequeueRateLimiter,
+            WorkflowExecutionGate gate, ShardedCounter shardedCounter, Executor executor) {
+    this(time, stateManager, storage, resourceDecorator, stats, dequeueRateLimiter, gate, shardedCounter, executor,
+        LoggerFactory.getLogger(Scheduler.class));
+  }
+
+
+  Scheduler(Time time, StateManager stateManager, Storage storage,
+            WorkflowResourceDecorator resourceDecorator, Stats stats, RateLimiter dequeueRateLimiter,
+            WorkflowExecutionGate gate, ShardedCounter shardedCounter, Executor executor, Logger log) {
     this.time = Objects.requireNonNull(time);
     this.stateManager = Objects.requireNonNull(stateManager);
     this.storage = Objects.requireNonNull(storage);
@@ -122,6 +129,7 @@ public class Scheduler {
     this.gate = Objects.requireNonNull(gate, "gate");
     this.shardedCounter = Objects.requireNonNull(shardedCounter, "shardedCounter");
     this.executor = Context.currentContextExecutor(Objects.requireNonNull(executor, "executor"));
+    this.log = Objects.requireNonNull(log, "log");
   }
 
   void tick() {
@@ -144,7 +152,7 @@ public class Scheduler {
       config = storage.config();
       globalConcurrency = config.globalConcurrency();
     } catch (IOException e) {
-      LOG.warn("Failed to get resource limits", e);
+      log.warn("Failed to get resource limits", e);
       return;
     }
 
@@ -199,9 +207,9 @@ public class Scheduler {
                 processInstance(config, resources, workflows, instance, resourceExhaustedCache,
                     currentResourceUsage, currentResourceDemand);
               } catch (StateTransitionConflictException e) {
-                LOG.debug("State transition conflict when scheduling instance: {}", instance, e);
+                log.debug("State transition conflict when scheduling instance: {}", instance, e);
               } catch (Throwable e) {
-                LOG.warn("Caught exception when scheduling instance: {}", instance, e);
+                log.warn("Caught exception when scheduling instance: {}", instance, e);
               }
             }), executor))
         .collect(toList());
@@ -216,7 +224,7 @@ public class Scheduler {
                                AtomicLongMap<String> currentResourceUsage,
                                AtomicLongMap<String> currentResourceDemand) {
 
-    LOG.debug("Processing instance: {}", instance);
+    log.debug("Processing instance: {}", instance);
 
     // Get the run state or exit if it does not exist
     var runStateOpt = stateManager.getActiveState(instance);
@@ -236,7 +244,7 @@ public class Scheduler {
       return;
     }
 
-    LOG.debug("Evaluating instance for dequeue: {}", instance);
+    log.debug("Evaluating instance for dequeue: {}", instance);
 
     // Get the workflow configuration
     var workflowOpt = workflows.computeIfAbsent(instance.workflowId(), this::readWorkflow);
@@ -273,7 +281,7 @@ public class Scheduler {
         .sorted()
         .collect(toList());
     if (!depletedResources.isEmpty()) {
-      LOG.debug("Resource limit reached for instance, not dequeueing: {}: exhausted resources={}",
+      log.debug("Resource limit reached for instance, not dequeueing: {}: exhausted resources={}",
           instance, depletedResources);
       MessageUtil.emitResourceLimitReachedMessage(stateManager, runState, depletedResources);
       return;
@@ -284,7 +292,7 @@ public class Scheduler {
     if (blocker.isPresent()) {
       var retry = Event.retryAfter(instance, blocker.get().delay().toMillis());
       stateManager.receiveIgnoreClosed(retry, runState.counter());
-      LOG.debug("Dequeue rescheduled: {}: {}", instance, blocker.get());
+      log.debug("Dequeue rescheduled: {}: {}", instance, blocker.get());
       return;
     }
 
@@ -305,7 +313,7 @@ public class Scheduler {
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     } catch (ExecutionException | TimeoutException e) {
-      LOG.warn("Failed to check execution blocker for {}, assuming there is no blocker", instance, e);
+      log.warn("Failed to check execution blocker for {}, assuming there is no blocker", instance, e);
       return Optional.empty();
     }
   }
@@ -323,7 +331,7 @@ public class Scheduler {
       try {
         return !shardedCounter.counterHasSpareCapacity(resourceId);
       } catch (RuntimeException | IOException e) {
-        LOG.warn("Failed to check resource counter limit", e);
+        log.warn("Failed to check resource counter limit", e);
         return false;
       }
     });
@@ -347,14 +355,14 @@ public class Scheduler {
     if (sleepingTimeSeconds > 0.0001) {
       final double sleepingTimeMillis = sleepingTimeSeconds * 1000;
       final String message = "Dequeue rate limited and slept for " + sleepingTimeMillis + " ms";
-      LOG.debug(message, sleepingTimeMillis);
+      log.debug(message, sleepingTimeMillis);
       tracer.getCurrentSpan().addAnnotation(message);
     }
 
     if (state.data().tries() == 0) {
-      LOG.info("Executing {}", workflowInstance);
+      log.info("Executing {}", workflowInstance);
     } else {
-      LOG.info("Executing {}, retry #{}", workflowInstance, state.data().tries());
+      log.info("Executing {}, retry #{}", workflowInstance, state.data().tries());
     }
     var dequeue = Event.dequeue(workflowInstance, resourceIds);
     stateManager.receiveIgnoreClosed(dequeue, state.counter());

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/PersistentStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/PersistentStateManager.java
@@ -136,16 +136,16 @@ public class PersistentStateManager implements StateManager {
       var stateOpt = storage.readActiveState(instance);
       stateOpt.ifPresent(state -> tickInstance(instance, state));
     } catch (Exception e) {
-      LOG.error("Error ticking instance: {}", instance, e);
+      log.error("Error ticking instance: {}", instance, e);
     }
   }
 
   private void tickInstance(WorkflowInstance instance, RunState state) {
-    LOG.info("Ticking instance: {}: #{} {}", instance, state.counter(), state.state());
+    log.info("Ticking instance: {}: #{} {}", instance, state.counter(), state.state());
     try {
       outputHandler.transitionInto(state);
     } catch (StateTransitionConflictException e) {
-      LOG.debug("State transition conflict when ticking instance: {}", instance, e);
+      log.debug("State transition conflict when ticking instance: {}", instance, e);
     }
   }
 
@@ -388,7 +388,7 @@ public class PersistentStateManager implements StateManager {
     try {
       outputHandler.transitionInto(runState);
     } catch (StateTransitionConflictException e) {
-      log.debug("State transition conflict when invoking output handler: {}", runState, e);
+      log.debug("State transition conflict when invoking output handler: {}", runState.workflowInstance(), e);
     }
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/PersistentStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/PersistentStateManager.java
@@ -134,18 +134,18 @@ public class PersistentStateManager implements StateManager {
   private void tickInstance(WorkflowInstance instance) {
     try {
       var stateOpt = storage.readActiveState(instance);
-      stateOpt.ifPresent(state -> tickInstance(instance, state));
+      stateOpt.ifPresent(this::tickInstance);
     } catch (Exception e) {
       log.error("Error ticking instance: {}", instance, e);
     }
   }
 
-  private void tickInstance(WorkflowInstance instance, RunState state) {
-    log.info("Ticking instance: {}: #{} {}", instance, state.counter(), state.state());
+  private void tickInstance(RunState state) {
+    log.info("Ticking instance: {}: #{} {}", state.workflowInstance(), state.counter(), state.state());
     try {
       outputHandler.transitionInto(state);
     } catch (StateTransitionConflictException e) {
-      log.debug("State transition conflict when ticking instance: {}", instance, e);
+      log.debug("State transition conflict when ticking instance: {}", state.workflowInstance(), e);
     }
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/StateTransitionConflictException.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/StateTransitionConflictException.java
@@ -2,7 +2,7 @@
  * -\-\-
  * Spotify Styx Scheduler Service
  * --
- * Copyright (C) 2016 - 2018 Spotify AB
+ * Copyright (C) 2016 - 2019 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,16 @@
 package com.spotify.styx.state;
 
 /**
- * An exception thrown from State Manager when a stale event is encountered. This can happen when
- * a single-threaded looping tick enqueues the same event more than once due to slow state transitions.
+ * An exception signifying a {@link RunState} transition failed due to conflict with another concurrent transition.
+ * It is generally safe to swallow this exception in situations where it is known that the operation will be retried.
  */
-public class StaleEventException extends RuntimeException {
+public class StateTransitionConflictException extends RuntimeException {
 
-  public StaleEventException(String message) {
+  public StateTransitionConflictException(Throwable cause) {
+    super(cause);
+  }
+
+  public StateTransitionConflictException(String message) {
     super(message);
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/PersistentStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/PersistentStateManagerTest.java
@@ -165,12 +165,37 @@ public class PersistentStateManagerTest {
     when(storage.readActiveState(instance1)).thenReturn(Optional.of(runState1));
     when(storage.readActiveState(instance2)).thenReturn(Optional.of(runState2));
 
-    doThrow(new RuntimeException("fail!")).when(outputHandler).transitionInto(runState1);
+    var cause = new RuntimeException("fail!");
+    doThrow(cause).when(outputHandler).transitionInto(runState1);
 
     stateManager.tick();
 
     verify(outputHandler).transitionInto(runState1);
     verify(outputHandler).transitionInto(runState2);
+
+    verify(logger).error("Error ticking instance: {}", instance1, cause );
+  }
+
+  @Test
+  public void tickShouldTolerateOutputHandlerStateTransitionConflict() throws IOException {
+    var instance1 = WorkflowInstance.create(TestData.WORKFLOW_ID, "2016-05-01");
+    var instance2 = WorkflowInstance.create(TestData.WORKFLOW_ID, "2016-05-02");
+    var runState1 = RunState.create(instance1, State.SUBMITTING, StateData.zero(), NOW.minusMillis(2), 17);
+    var runState2 = RunState.create(instance2, State.TERMINATED, StateData.zero(), NOW.minusMillis(1), 4711);
+
+    when(storage.listActiveInstances()).thenReturn(Set.of(instance1, instance2));
+    when(storage.readActiveState(instance1)).thenReturn(Optional.of(runState1));
+    when(storage.readActiveState(instance2)).thenReturn(Optional.of(runState2));
+
+    var cause = new StateTransitionConflictException("conflict!");
+    doThrow(cause).when(outputHandler).transitionInto(runState1);
+
+    stateManager.tick();
+
+    verify(outputHandler).transitionInto(runState1);
+    verify(outputHandler).transitionInto(runState2);
+
+    verify(logger).debug("State transition conflict when ticking instance: {}", instance1, cause);
   }
 
   @Test
@@ -516,7 +541,7 @@ public class PersistentStateManagerTest {
   }
 
   @Test
-  public void receiveShouldHandleThrowingOutputHandler() throws Exception {
+  public void receiveShouldPropagateOutputHandlerException() throws Exception {
     Optional<RunState> runState = Optional.of(
         RunState.create(INSTANCE, State.QUEUED, StateData.zero(), NOW.minusMillis(1), 17));
     when(transaction.readActiveState(INSTANCE)).thenReturn(runState);
@@ -529,6 +554,18 @@ public class PersistentStateManagerTest {
     } catch (Exception e) {
       assertThat(Throwables.getRootCause(e), is(rootCause));
     }
+  }
+
+  @Test
+  public void receiveShouldHandleOutputHandlerThrowingStateTransitionConflict() throws Exception {
+    Optional<RunState> runState = Optional.of(
+        RunState.create(INSTANCE, State.QUEUED, StateData.zero(), NOW.minusMillis(1), 17));
+    when(transaction.readActiveState(INSTANCE)).thenReturn(runState);
+
+    final StateTransitionConflictException rootCause = new StateTransitionConflictException("conflict!");
+    doThrow(rootCause).when(outputHandler).transitionInto(any());
+    stateManager.receive(Event.dequeue(INSTANCE, ImmutableSet.of()));
+    verify(logger).debug("State transition conflict when invoking output handler: {}", INSTANCE, rootCause);
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/PersistentStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/PersistentStateManagerTest.java
@@ -381,7 +381,7 @@ public class PersistentStateManagerTest {
     try {
       stateManager.receive(event, 16);
       fail();
-    } catch (StaleEventException ignore) {
+    } catch (StateTransitionConflictException ignore) {
     }
 
     verify(storage, never()).writeEvent(any());

--- a/styx-service-common/src/main/java/com/spotify/styx/state/FanOutputHandler.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/state/FanOutputHandler.java
@@ -21,15 +21,11 @@
 package com.spotify.styx.state;
 
 import java.util.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A {@link OutputHandler} that fans out to a list of other outputHandlers.
  */
 class FanOutputHandler implements OutputHandler {
-
-  private static final Logger LOG = LoggerFactory.getLogger(FanOutputHandler.class);
 
   private final Iterable<OutputHandler> outputHandlers;
 
@@ -40,12 +36,7 @@ class FanOutputHandler implements OutputHandler {
   @Override
   public void transitionInto(RunState state) {
     for (OutputHandler handler : outputHandlers) {
-      try {
-        handler.transitionInto(state);
-      } catch (Throwable e) {
-        LOG.warn("Output handler {} threw", handler, e);
-        throw e;
-      }
+      handler.transitionInto(state);
     }
   }
 }

--- a/styx-service-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -935,8 +935,9 @@ public class DatastoreStorage implements Closeable {
       final T value = f.apply(tx);
       tx.commit();
       return value;
+    } catch (DatastoreIOException e) {
+      throw new TransactionException(e.getCause());
     } catch (DatastoreException e) {
-      tx.rollback();
       throw new TransactionException(e);
     } finally {
       if (tx.isActive()) {

--- a/styx-service-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -905,6 +905,28 @@ public class DatastoreStorageTest {
   }
 
   @Test
+  public void runInTransactionShouldThrowTransactionExceptionOnDatastoreIOException() throws Exception {
+    var storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory, executor);
+    var transaction = datastore.newTransaction();
+    var storageTransaction = spy(new DatastoreStorageTransaction(transaction));
+    when(storageTransactionFactory.apply(any())).thenReturn(storageTransaction);
+
+    var datastoreException = new DatastoreException(1, "", "");
+    var datastoreIOException = new DatastoreIOException(datastoreException);
+    when(transactionFunction.apply(any())).thenThrow(datastoreIOException);
+
+    try {
+      storage.runInTransaction(transactionFunction);
+      fail("Expected exception!");
+    } catch (TransactionException e) {
+      assertThat(e.getCause(), is(datastoreException));
+    }
+
+    verify(transactionFunction).apply(storageTransaction);
+    verify(storageTransaction).rollback();
+  }
+
+  @Test
   public void runInTransactionShouldThrowIfDatastoreNewTransactionFails() throws Exception {
     CheckedDatastore datastore = mock(CheckedDatastore.class);
     final DatastoreStorage storage = new DatastoreStorage(datastore, Duration.ZERO, storageTransactionFactory, executor);


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Some fixes for https://github.com/spotify/styx/pull/714

* Throw a new specialized Exception, `StateTransitionConflictException` on state transition failure due to transaction conflict or stale events (concurrent transition conflict). 
* Swallow this exception in periodically invoked tick-style call-sites.

* Handle processing errors in the scheduler tick.

## Motivation and Context
* There is too much conflict spam in the logs.
* Any failure during the scheduler tick is causing the tick duration to not be reported.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
