### PR TITLE
validator: disallow hash in component

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -173,8 +173,7 @@ public final class WorkflowResource {
 
     workflowActionAuthorizer.authorizeWorkflowAction(ac, workflow);
 
-    final Collection<String> errors =
-        workflowValidator.validateWorkflowConfiguration(workflowConfig);
+    var errors = workflowValidator.validateWorkflow(workflow);
     if (!errors.isEmpty()) {
       return Response.forStatus(
           Status.BAD_REQUEST.withReasonPhrase("Invalid workflow configuration: " + errors));

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -212,7 +212,6 @@ public class BackfillResourceTest extends VersionedApiTest {
   @Before
   public void setUp() throws Exception {
     when(workflowValidator.validateWorkflow(any())).thenReturn(Collections.emptyList());
-    when(workflowValidator.validateWorkflowConfiguration(any())).thenReturn(Collections.emptyList());
     storage.storeWorkflow(Workflow.create(
         BACKFILL_1.workflowId().componentId(),
         WorkflowConfiguration.builder()

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -159,7 +159,6 @@ public class WorkflowResourceTest extends VersionedApiTest {
   protected void init(Environment environment) {
     storage = spy(new AggregateStorage(bigtable, datastore, Duration.ZERO));
     when(workflowValidator.validateWorkflow(any())).thenReturn(Collections.emptyList());
-    when(workflowValidator.validateWorkflowConfiguration(any())).thenReturn(Collections.emptyList());
     when(requestAuthenticator.authenticate(any())).thenReturn(() -> Optional.of(idToken));
     WorkflowResource workflowResource =
         new WorkflowResource(storage, workflowValidator, workflowInitializer, workflowConsumer,
@@ -628,7 +627,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
             serviceHelper
                 .request("POST", path("/foo"), serialize(WORKFLOW_CONFIGURATION)));
 
-    verify(workflowValidator).validateWorkflowConfiguration(WORKFLOW_CONFIGURATION);
+    verify(workflowValidator).validateWorkflow(WORKFLOW);
     verify(workflowInitializer).store(eq(WORKFLOW), any());
     verify(workflowConsumer).accept(Optional.empty(), Optional.of(WORKFLOW));
 
@@ -647,7 +646,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
             serviceHelper
                 .request("POST", path("/foo"), serialize(WORKFLOW_CONFIGURATION)));
 
-    verify(workflowValidator).validateWorkflowConfiguration(WORKFLOW_CONFIGURATION);
+    verify(workflowValidator).validateWorkflow(WORKFLOW);
     verify(workflowInitializer).store(eq(WORKFLOW), any());
     verify(workflowConsumer).accept(Optional.of(EXISTING_WORKFLOW), Optional.of(WORKFLOW));
 
@@ -688,7 +687,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
             serviceHelper
                 .request("POST", path("/foo"), serialize(WORKFLOW_CONFIGURATION)));
 
-    verify(workflowValidator).validateWorkflowConfiguration(WORKFLOW_CONFIGURATION);
+    verify(workflowValidator).validateWorkflow(WORKFLOW);
 
     assertThat(response, hasStatus(withCode(Status.BAD_REQUEST)));
   }
@@ -752,12 +751,12 @@ public class WorkflowResourceTest extends VersionedApiTest {
   public void shouldFailInvalidWorkflowImage() throws Exception {
     sinceVersion(Api.Version.V3);
 
-    when(workflowValidator.validateWorkflowConfiguration(any())).thenReturn(List.of("bad", "image"));
+    when(workflowValidator.validateWorkflow(any())).thenReturn(List.of("bad", "image"));
 
     Response<ByteString> response = awaitResponse(serviceHelper
         .request("POST", path("/foo"), serialize(WORKFLOW_CONFIGURATION)));
 
-    verify(workflowValidator).validateWorkflowConfiguration(WORKFLOW_CONFIGURATION);
+    verify(workflowValidator).validateWorkflow(Workflow.create("foo", WORKFLOW_CONFIGURATION));
 
     assertThat(serviceHelper.stubClient().sentRequests(), is(empty()));
 

--- a/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -402,7 +402,8 @@ public final class CliMain {
 
     boolean invalid = false;
     for (WorkflowConfiguration configuration : configurations) {
-      final Collection<String> errors = cliContext.workflowValidator().validateWorkflowConfiguration(configuration);
+      var workflow = Workflow.create(component, configuration);
+      var errors = cliContext.workflowValidator().validateWorkflow(workflow);
       if (!errors.isEmpty()) {
         cliOutput.printError("Invalid workflow configuration: " + configuration.id());
         errors.forEach(error -> cliOutput.printError("  error: " + error));

--- a/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
+++ b/styx-cli/src/test/java/com/spotify/styx/cli/CliMainTest.java
@@ -98,7 +98,6 @@ public class CliMainTest {
     MockitoAnnotations.initMocks(this);
 
     when(cliContext.workflowValidator()).thenReturn(validator);
-    when(validator.validateWorkflowConfiguration(any())).thenReturn(Collections.emptyList());
     when(validator.validateWorkflow(any())).thenReturn(Collections.emptyList());
     when(cliContext.createClient(any())).thenReturn(client);
     when(cliContext.output(any())).thenReturn(cliOutput);
@@ -164,7 +163,8 @@ public class CliMainTest {
     assertThat(expected, is(not(Matchers.empty())));
 
     for (WorkflowConfiguration configuration : expected) {
-      when(validator.validateWorkflowConfiguration(configuration)).thenReturn(
+      var workflow = Workflow.create(component, configuration);
+      when(validator.validateWorkflow(workflow)).thenReturn(
           List.of("bad-" + configuration.id(), "cfg-" + configuration.id()));
     }
 

--- a/styx-common/src/main/java/com/spotify/styx/util/WorkflowValidator.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/WorkflowValidator.java
@@ -24,7 +24,6 @@ import static java.lang.String.format;
 
 import com.google.common.base.Preconditions;
 import com.spotify.styx.model.Workflow;
-import com.spotify.styx.model.WorkflowConfiguration;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
@@ -60,12 +59,25 @@ public class WorkflowValidator {
   }
 
   public List<String> validateWorkflow(Workflow workflow) {
-    final WorkflowConfiguration configuration = workflow.configuration();
-    return validateWorkflowConfiguration(configuration);
-  }
+    var workflowId = workflow.id();
+    var cfg = workflow.configuration();
 
-  public List<String> validateWorkflowConfiguration(WorkflowConfiguration cfg) {
     final List<String> e = new ArrayList<>();
+
+    var componentId = workflowId.componentId();
+    if (componentId.isEmpty()) {
+      e.add("component id cannot be empty");
+    } else if (componentId.contains("#")) {
+      e.add("component id cannot contain #");
+    }
+
+    if (workflowId.id().isEmpty()) {
+      e.add("workflow id cannot be empty");
+    }
+
+    if (!workflowId.id().equals(cfg.id())) {
+      e.add("workflow id mismatch");
+    }
 
     // TODO: validate more of the contents
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/api/SchedulerResourceTest.java
@@ -123,7 +123,6 @@ public class SchedulerResourceTest {
   public void setUp() throws Exception {
     when(storage.workflow(WFI.workflowId())).thenReturn(Optional.of(FULL_DAILY_WORKFLOW));
     when(workflowValidator.validateWorkflow(any())).thenReturn(Collections.emptyList());
-    when(workflowValidator.validateWorkflowConfiguration(any())).thenReturn(Collections.emptyList());
     when(requestAuthenticator.authenticate(any())).thenReturn(() -> Optional.of(idToken));
   }
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Disallow hash in component.

## Motivation and Context
Avoid collisions now that we key workflows by concatenating component id and workflow id by '#'.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
