### PR TITLE
kdr: remove redundant watch reconnect

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -100,7 +100,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link DockerRunner} implementation that submits container executions to a Kubernetes cluster.
@@ -727,26 +726,9 @@ class KubernetesDockerRunner implements DockerRunner {
       emitPodEvents(pod, runState.get());
     }
 
-    private void reconnect() {
-      LOG.warn("Re-establishing pod watcher");
-
-      try {
-        watch = client.pods()
-            .watch(this);
-      } catch (Throwable e) {
-        LOG.warn("Retry threw", e);
-        scheduleReconnect();
-      }
-    }
-
-    private void scheduleReconnect() {
-      scheduledExecutor.schedule(this::reconnect, RECONNECT_DELAY_SECONDS, TimeUnit.SECONDS);
-    }
-
     @Override
     public void onClose(KubernetesClientException e) {
       LOG.warn("Watch closed", e);
-      scheduleReconnect();
     }
   }
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
kdr: remove redundant watch reconnect

## Motivation and Context
The fabric8 watcher handles reconnects on its own, so we were leaking
connections by creating a new watch on each disconnect.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
