### PR TITLE
datastore: disable client built-in retries

### DIFF
--- a/styx-service-common/src/main/java/com/spotify/styx/util/Connections.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/util/Connections.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx.util;
 
+import com.google.cloud.ServiceOptions;
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
@@ -56,6 +57,16 @@ public final class Connections {
     final Datastore datastore = DatastoreOptions.newBuilder()
         .setNamespace(namespace)
         .setProjectId(projectId)
+        // Disable retries as the datastore client (at the time of writing) has a retry bug
+        // where it incorrectly retries ABORTED lookup operations in transactions without
+        // restarting the transaction. This results in 3 INVALID_ARGUMENT "transaction closed" errors
+        // that pollute our warning/error logs.
+        // We have our own retry implementation in DatastoreStorage#storeWithRetries.
+        // This has the downside that retryable transient RPC errors inside transactions will now
+        // cause transactions to be rolled back and retried, which is a more expensive operation than
+        // immediately retrying the RPC.
+        // TODO: Use the datastore client retry mechanism instead when the above bug has been fixed
+        .setRetrySettings(ServiceOptions.getNoRetrySettings())
         .build()
         .getService();
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
datastore: disable client built-in retries

## Motivation and Context
Disable retries as the datastore client (at the time of writing) has a retry bug
where it incorrectly retries ABORTED lookup operations in transactions without
restarting the transaction. This results in 3 INVALID_ARGUMENT "transaction closed" errors
that pollute our warning/error logs.
We have our own retry implementation in DatastoreStorage#storeWithRetries.
This has the downside that retryable transient RPC errors inside transactions will now
cause transactions to be rolled back and retried, which is a more expensive operation than
immediately retrying the RPC.


## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
