### PR TITLE
tracing: avoid large tick traces

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -54,6 +54,7 @@ import com.spotify.styx.util.ShardedCounter;
 import com.spotify.styx.util.Time;
 import io.grpc.Context;
 import io.opencensus.common.Scope;
+import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.samplers.Samplers;
@@ -177,6 +178,9 @@ public class Scheduler {
 
     final long durationMillis = t0.until(time.get(), ChronoUnit.MILLIS);
     stats.recordTickDuration(TICK_TYPE, durationMillis);
+
+    tracer.getCurrentSpan().addAnnotation("processed",
+        Map.of("instances", AttributeValue.longAttributeValue(activeInstances.size())));
   }
 
   private void updateResourceStats(Map<String, Resource> resources,
@@ -202,7 +206,8 @@ public class Scheduler {
     // Process instances in parallel
     var futures = shuffledInstances.stream()
         .map(instance -> CompletableFuture.runAsync(() ->
-            tracer.spanBuilder("processInstance").startSpanAndRun(() -> {
+            // Do not include all instance spans in parent tick span to avoid it growing too big
+            tracer.spanBuilderWithExplicitParent("Styx.Scheduler.processInstance", null).startSpanAndRun(() -> {
               try {
                 processInstance(config, resources, workflows, instance, resourceExhaustedCache,
                     currentResourceUsage, currentResourceDemand);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -103,10 +103,8 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
-import io.opencensus.common.Scope;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
-import io.opencensus.trace.samplers.Samplers;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
@@ -520,15 +518,6 @@ public class StyxScheduler implements AppInit {
   }
 
   private static void updateRuntimeConfig(Supplier<StyxConfig> config, RateLimiter rateLimiter) {
-    try (Scope ss = tracer.spanBuilder("Styx.StyxScheduler.updateRuntimeConfig")
-        .setRecordEvents(true)
-        .setSampler(Samplers.alwaysSample())
-        .startScopedSpan()) {
-      updateRuntimeConfig0(config, rateLimiter);
-    }
-  }
-
-  private static void updateRuntimeConfig0(Supplier<StyxConfig> config, RateLimiter rateLimiter) {
     try {
       double currentRate = rateLimiter.getRate();
       Double updatedRate = config.get().submissionRateLimit().orElse(


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
tracing: avoid large tick traces

## Motivation and Context
Do not include child spans in tick parent spans to avoid those spans
growing too large (if sampled) and causing styx to run out of memory.

Additionally, reporting backends (e.g. stackdriver) typically do not
support huge spans (which is reasonable) and the tick spans
currently typically get truncated anyway.

Annotate tick spans with the number of processed entities.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
