### PR TITLE
Remove dual writing

### DIFF
--- a/styx-service-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/DatastoreStorageTransaction.java
@@ -41,7 +41,6 @@ import static com.spotify.styx.storage.DatastoreStorage.getWorkflowOpt;
 import static com.spotify.styx.storage.DatastoreStorage.instantToTimestamp;
 import static com.spotify.styx.storage.DatastoreStorage.parseWorkflowJson;
 import static com.spotify.styx.storage.DatastoreStorage.runStateToEntity;
-import static com.spotify.styx.storage.DatastoreStorage.workflowKey;
 import static com.spotify.styx.storage.DatastoreStorage.workflowKeyNew;
 import static com.spotify.styx.util.ShardedCounter.KIND_COUNTER_LIMIT;
 import static com.spotify.styx.util.ShardedCounter.KIND_COUNTER_SHARD;
@@ -142,7 +141,6 @@ public class DatastoreStorageTransaction implements StorageTransaction {
 
   @Override
   public void deleteWorkflow(WorkflowId workflowId) throws IOException {
-    tx.delete(workflowKey(tx.getDatastore()::newKeyFactory, workflowId));
     tx.delete(workflowKeyNew(tx.getDatastore()::newKeyFactory, workflowId));
   }
 
@@ -173,11 +171,6 @@ public class DatastoreStorageTransaction implements StorageTransaction {
     var key = workflowKeyNew(keyFactory, workflow.id());
     var entity = DatastoreStorage.workflowToEntity(workflow, state, existing, key);
     tx.put(entity);
-
-    // TODO: stop writing legacy workflow after migration
-    var legacyKey = workflowKey(keyFactory, workflow.id());
-    var legacyEntity = DatastoreStorage.workflowToEntity(workflow, state, existing, legacyKey);
-    tx.put(legacyEntity);
 
     return workflow.id();
   }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
As part of the flattening of the workflow keys now we stop writing (and deleting) workflows with the legacy keys. We are still filtering the old keys when reading
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
