### PR TITLE
allow using a managed service account key

### DIFF
--- a/styx-service-common/src/main/java/com/spotify/styx/api/ManagedServiceAccountKeyCredential.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/ManagedServiceAccountKeyCredential.java
@@ -1,0 +1,147 @@
+/*-
+ * -\-\-
+ * Spotify Styx Service Common
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api;
+
+import com.google.api.client.auth.oauth2.TokenRequest;
+import com.google.api.client.auth.oauth2.TokenResponse;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.util.Utils;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.json.webtoken.JsonWebToken;
+import com.google.api.client.util.Joiner;
+import com.google.api.services.iam.v1.Iam;
+import com.google.api.services.iam.v1.model.SignJwtRequest;
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A service account {@link GoogleCredential} that does not need a physical service account key.
+ * <p>
+ * Note that the service account must be granted the "Service Account Token Creator" role for itself.
+ * <p>
+ * The fundamental difference between this class and the regular {@link GoogleCredential} implementation is that
+ * it calls the GCP IAM {@code projects.serviceAccounts.signJwt} method in order to sign the access token request
+ * assertion instead of using a local service account key to sign it.
+ * <p>
+ * As opposed to the {@link com.google.auth.oauth2.ImpersonatedCredentials}, this implementation allows specifying a
+ * domain user to impersonate when accessing e.g. G Suite APIs.
+ */
+class ManagedServiceAccountKeyCredential extends GoogleCredential {
+
+  private static final Logger log = LoggerFactory.getLogger(ManagedServiceAccountKeyCredential.class);
+
+  private final Iam iam;
+
+  private ManagedServiceAccountKeyCredential(Builder builder) {
+    super(builder);
+    Objects.requireNonNull(getServiceAccountId(), "serviceAccountId");
+    Objects.requireNonNull(getServiceAccountUser(), "serviceAccountUser");
+    Objects.requireNonNull(getServiceAccountScopes(), "serviceAccountScopes");
+    this.iam = Objects.requireNonNull(builder.iam, "iam");
+  }
+
+  @Override
+  protected TokenResponse executeRefreshToken() throws IOException {
+    log.debug("Refreshing access token for {} using {} with scopes {}",
+        getServiceAccountUser(), getServiceAccountId(), getServiceAccountScopes());
+
+    var jwtPayload = jwtPayload();
+
+    log.debug("Signing access token request jwt: {}", jwtPayload);
+
+    var signedJwt = signJwt(getServiceAccountId(), jwtPayload);
+
+    log.debug("Fetching access token using signed jwt for {}. ", getServiceAccountUser());
+
+    var tokenResponse = requestToken(signedJwt);
+
+    log.debug("Successfully fetched access token using signed jwt for {}", getServiceAccountUser());
+
+    return tokenResponse;
+  }
+
+  private JsonWebToken.Payload jwtPayload() {
+    var currentTime = System.currentTimeMillis();
+    var payload = new JsonWebToken.Payload();
+    payload.setIssuer(getServiceAccountId());
+    payload.setAudience(getTokenServerEncodedUrl());
+    payload.setIssuedAtTimeSeconds(currentTime / 1000);
+    payload.setExpirationTimeSeconds(currentTime / 1000 + 3600);
+    payload.setSubject(getServiceAccountUser());
+    payload.put("scope", Joiner.on(' ').join(getServiceAccountScopes()));
+    return payload;
+  }
+
+  private String signJwt(String serviceAccount, JsonWebToken.Payload payload) throws IOException {
+    var fullServiceAccountName = "projects/-/serviceAccounts/" + serviceAccount;
+    var request = new SignJwtRequest()
+        .setPayload(Utils.getDefaultJsonFactory().toString(payload));
+    return iam.projects().serviceAccounts()
+        .signJwt(fullServiceAccountName, request)
+        .execute()
+        .getSignedJwt();
+  }
+
+  private TokenResponse requestToken(String signedJwt) throws IOException {
+    var tokenRequest = new TokenRequest(Utils.getDefaultTransport(), Utils.getDefaultJsonFactory(),
+        new GenericUrl(getTokenServerEncodedUrl()), "urn:ietf:params:oauth:grant-type:jwt-bearer");
+    tokenRequest.put("assertion", signedJwt);
+    return tokenRequest.execute();
+  }
+
+  static class Builder extends GoogleCredential.Builder {
+
+    private final Iam iam;
+
+    Builder(Iam iam) {
+      this.iam = Objects.requireNonNull(iam, "iam");
+      setServiceAccountPrivateKey(DummyKey.INSTANCE);
+    }
+
+    @Override
+    public GoogleCredential build() {
+      return new ManagedServiceAccountKeyCredential(this);
+    }
+  }
+
+  private static class DummyKey implements PrivateKey {
+
+    private static final DummyKey INSTANCE = new DummyKey();
+
+    @Override
+    public String getAlgorithm() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getFormat() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getEncoded() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/styx-service-common/src/main/java/com/spotify/styx/api/ServiceAccounts.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/ServiceAccounts.java
@@ -1,0 +1,42 @@
+/*-
+ * -\-\-
+ * Spotify Styx Service Common
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api;
+
+import com.google.auth.ServiceAccountSigner;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ImpersonatedCredentials;
+
+class ServiceAccounts {
+
+  private ServiceAccounts() {
+    throw new UnsupportedOperationException();
+  }
+
+  static String serviceAccountEmail(GoogleCredentials credentials) {
+    if (credentials instanceof ImpersonatedCredentials) {
+      return ((ImpersonatedCredentials) credentials).toBuilder().getTargetPrincipal();
+    } else if (credentials instanceof ServiceAccountSigner) {
+      return ((ServiceAccountSigner) credentials).getAccount();
+    } else {
+      throw new IllegalArgumentException("Credential is not a service account");
+    }
+  }
+}

--- a/styx-service-common/src/test/java/com/spotify/styx/api/ManagedServiceAccountKeyCredentialTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/ManagedServiceAccountKeyCredentialTest.java
@@ -1,0 +1,81 @@
+/*-
+ * -\-\-
+ * Spotify Styx Service Common
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import com.google.api.client.googleapis.util.Utils;
+import com.google.api.services.iam.v1.Iam;
+import com.google.api.services.iam.v1.IamScopes;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ImpersonatedCredentials;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ManagedServiceAccountKeyCredentialTest {
+
+  private static final String SERVICE_ACCOUNT = "styx-test-user@styx-oss-test.iam.gserviceaccount.com";
+
+  private Iam iam;
+
+  @Before
+  public void setUp() throws Exception {
+    var defaultCredentials = GoogleCredentials.getApplicationDefault();
+
+    var serviceCredentials = ImpersonatedCredentials.create(
+        defaultCredentials, SERVICE_ACCOUNT,
+        List.of(), List.of("https://www.googleapis.com/auth/cloud-platform"), 300);
+
+    try {
+      serviceCredentials.refreshAccessToken();
+    } catch (IOException e) {
+      // Do not run this test if we do not have permission to impersonate the test user.
+      Assume.assumeNoException(e);
+    }
+
+    iam = new Iam.Builder(
+        Utils.getDefaultTransport(), Utils.getDefaultJsonFactory(),
+        new HttpCredentialsAdapter(serviceCredentials.createScoped(IamScopes.all())))
+        .setApplicationName("styx-test")
+        .build();
+  }
+
+  @Test
+  public void testRefreshToken() throws IOException {
+    var credentials = new ManagedServiceAccountKeyCredential.Builder(iam)
+        .setServiceAccountId(SERVICE_ACCOUNT)
+        .setServiceAccountUser(SERVICE_ACCOUNT)
+        .setServiceAccountScopes(Set.of("https://www.googleapis.com/auth/cloud-platform"))
+        .build();
+    var token = credentials.refreshToken();
+    assertThat(token, is(notNullValue()));
+  }
+}

--- a/styx-service-common/src/test/java/com/spotify/styx/api/ServiceAccountsTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/ServiceAccountsTest.java
@@ -1,0 +1,77 @@
+/*-
+ * -\-\-
+ * Spotify Styx Service Common
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api;
+
+import static com.spotify.styx.util.ClassEnforcer.assertNotInstantiable;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ImpersonatedCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import java.security.PrivateKey;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceAccountsTest {
+
+  private static final String SERVICE_ACCOUNT = "styx-test-user@styx-oss-test.iam.gserviceaccount.com";
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+
+  @Mock private GoogleCredentials sourceCredentials;
+  @Mock private PrivateKey privateKey;
+
+  @Test
+  public void serviceAccountEmailImpersonatedCredentials() {
+    var credentials = ImpersonatedCredentials.create(
+        sourceCredentials, SERVICE_ACCOUNT, List.of(), List.of(), 300);
+    assertThat(ServiceAccounts.serviceAccountEmail(credentials), is(SERVICE_ACCOUNT));
+  }
+
+  @Test
+  public void serviceAccountEmailServiceAccountCredentials() {
+    var credentials = ServiceAccountCredentials.newBuilder()
+        .setClientEmail(SERVICE_ACCOUNT)
+        .setPrivateKey(privateKey)
+        .build();
+    assertThat(ServiceAccounts.serviceAccountEmail(credentials), is(SERVICE_ACCOUNT));
+  }
+
+  @Test
+  public void serviceAccountEmailShouldFailIfNotServiceAccount() {
+    var credentials = GoogleCredentials.newBuilder().build();
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("Credential is not a service account");
+    ServiceAccounts.serviceAccountEmail(credentials);
+  }
+
+  @Test
+  public void testSingleton() throws ReflectiveOperationException {
+    assertThat(assertNotInstantiable(ServiceAccounts.class), is(true));
+  }
+}


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Do not require having a physical service account key for the styx api and scheduler.

## Motivation and Context
This will allow us to deploy styx using GCE host assigned managed service accounts instead of provisioning physical keys.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
