### PR TITLE
Submit jacoco aggregate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             # Maven heap size
             MAVEN_OPTS: -Xmx256m -Xms256m
           command: mvn -B verify -P disable-static-analysis
-      - run: bash <(curl -s https://codecov.io/bash) -f '!**/jacoco-aggregate/**'
+      - run: bash <(curl -s https://codecov.io/bash) -f styx-report/target/site/jacoco-aggregate/jacoco.xml
       - run: |
           mkdir test-reports
           find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} test-reports/ \;


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Submit the coverage report aggregated by jacoco instead of relying on codecov.

## Motivation and Context
Codecov cannot aggregate the complete inter-module coverage because jacoco strips away inter-module coverage from the per-module jacoco.xml reports. Codecov relies on and aggregates the per-module jacoco.xml reports and then ends up missing all the inter-module method traces.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
