### PR TITLE
add runningTimeout to execution description

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/model/ExecutionDescription.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/ExecutionDescription.java
@@ -21,6 +21,7 @@
 package com.spotify.styx.model;
 
 import io.norberg.automatter.AutoMatter;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,6 +36,7 @@ public interface ExecutionDescription {
   Optional<String> serviceAccount();
   Optional<String> commitSha();
   Map<String, String> env();
+  Optional<Duration> runningTimeout();
 
   static ExecutionDescriptionBuilder builder() {
     return new ExecutionDescriptionBuilder();

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -138,6 +138,7 @@ public class ExecutionDescriptionHandler implements OutputHandler {
         .serviceAccount(workflow.configuration().serviceAccount())
         .commitSha(workflow.configuration().commitSha())
         .env(env)
+        .runningTimeout(workflow.configuration().runningTimeout())
         .build();
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
@@ -47,10 +47,12 @@ import com.spotify.styx.state.StateManager;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.WorkflowValidator;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -133,6 +135,8 @@ public class ExecutionDescriptionHandlerTest {
     assertThat(executionDescriptionCaptor.getValue().dockerImage(), is(DOCKER_IMAGE));
     assertThat(executionDescriptionCaptor.getValue().commitSha(), hasValue(COMMIT_SHA));
     assertThat(executionDescriptionCaptor.getValue().dockerArgs(), contains("--date", "2016-03-14", "--bar"));
+    assertThat(executionDescriptionCaptor.getValue().env(), is(Map.of("foo", "bar")));
+    assertThat(executionDescriptionCaptor.getValue().runningTimeout(), is(Optional.of(Duration.ZERO)));
   }
 
   @Test
@@ -202,6 +206,8 @@ public class ExecutionDescriptionHandlerTest {
         .commitSha(COMMIT_SHA)
         .dockerImage(DOCKER_IMAGE)
         .dockerArgs(Arrays.asList(args))
+        .env("foo", "bar")
+        .runningTimeout(Duration.ZERO)
         .build();
   }
 }

--- a/styx-service-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -207,6 +207,8 @@ public class DatastoreStorageTest {
               .secret(Secret.create("foobar", "/var/quux/baz"))
               .serviceAccount("foo@bar.baz")
               .commitSha("2d2bfa926b94508de5aab47b5f305659ead2274a")
+              .env("foo", "bar")
+              .runningTimeout(java.time.Duration.ZERO)
               .build())
           .resourceIds(ImmutableSet.of("GLOBAL_STYX_CLUSTER", "foo-resource", "bar-resource"))
           .addMessage(Message.info("foo"))


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
When adding this feature, we forgot to persist it. Adding `runningTimeout` in persistent event
will help users understand what the timeout was when the execution happened.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [x] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
