### PR TITLE
No custom retryer in bigtable storage

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -83,8 +83,6 @@ public class StyxApi implements AppInit {
   private static final String SCHEDULER_SERVICE_BASE_URL = "styx.scheduler.base-url";
   private static final String DEFAULT_SCHEDULER_SERVICE_BASE_URL = "http://localhost:8080";
 
-  private static final Duration DEFAULT_RETRY_BASE_DELAY_BT = Duration.ofSeconds(1);
-
   private static final String STYX_RUNNING_STATE_TTL_CONFIG = "styx.stale-state-ttls.running";
   private static final String STYX_SECRET_WHITELIST = "styx.secret-whitelist";
   private static final Duration DEFAULT_STYX_RUNNING_STATE_TTL = Duration.ofHours(24);
@@ -242,7 +240,7 @@ public class StyxApi implements AppInit {
 
     final Connection bigTable = closer.register(createBigTableConnection(config));
     final Datastore datastore = createDatastore(config, stats);
-    return closer.register(new AggregateStorage(bigTable, datastore, DEFAULT_RETRY_BASE_DELAY_BT));
+    return closer.register(new AggregateStorage(bigTable, datastore));
   }
 
   private static Stats stats(Environment environment) {

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -75,7 +75,6 @@ import com.spotify.styx.storage.DatastoreEmulator;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.WorkflowValidator;
 import java.io.IOException;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -180,8 +179,8 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Override
   protected void init(Environment environment) {
-    storage = spy(new AggregateStorage(bigtable, datastoreEmulator.client(),
-        Duration.ZERO));
+    storage = spy(new AggregateStorage(bigtable, datastoreEmulator.client()
+    ));
 
     when(requestAuthenticator.authenticate(any())).thenReturn(() -> Optional.of(idToken));
     final BackfillResource backfillResource = closer.register(

--- a/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/BackfillResourceTest.java
@@ -179,8 +179,7 @@ public class BackfillResourceTest extends VersionedApiTest {
 
   @Override
   protected void init(Environment environment) {
-    storage = spy(new AggregateStorage(bigtable, datastoreEmulator.client()
-    ));
+    storage = spy(new AggregateStorage(bigtable, datastoreEmulator.client()));
 
     when(requestAuthenticator.authenticate(any())).thenReturn(() -> Optional.of(idToken));
     final BackfillResource backfillResource = closer.register(

--- a/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/ResourceResourceTest.java
@@ -45,7 +45,6 @@ import com.spotify.styx.model.Resource;
 import com.spotify.styx.storage.AggregateStorage;
 import com.spotify.styx.storage.DatastoreEmulator;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Map;
 import okio.ByteString;
 import org.apache.hadoop.hbase.client.Connection;
@@ -73,8 +72,8 @@ public class ResourceResourceTest extends VersionedApiTest {
   protected void init(Environment environment) {
     storage = spy(new AggregateStorage(
         mock(Connection.class),
-        datastoreEmulator.client(),
-        Duration.ZERO));
+        datastoreEmulator.client()
+    ));
 
     ResourceResource resourceResource = new ResourceResource(storage);
 

--- a/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/StatusResourceTest.java
@@ -57,7 +57,6 @@ import com.spotify.styx.storage.BigtableStorage;
 import com.spotify.styx.storage.DatastoreEmulator;
 import com.spotify.styx.storage.Storage;
 import java.io.IOException;
-import java.time.Duration;
 import java.time.Instant;
 import okio.ByteString;
 import org.apache.hadoop.hbase.client.Connection;
@@ -120,8 +119,7 @@ public class StatusResourceTest extends VersionedApiTest {
   @Override
   protected void init(Environment environment) {
     accountUsageAuthorizer = mock(ServiceAccountUsageAuthorizer.class);
-    storage = spy(new AggregateStorage(bigtable, datastoreEmulator.client(),
-        Duration.ZERO));
+    storage = spy(new AggregateStorage(bigtable, datastoreEmulator.client()));
     final StatusResource statusResource = new StatusResource(storage, accountUsageAuthorizer);
 
     environment.routingEngine()

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -157,7 +157,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
   @Override
   protected void init(Environment environment) {
-    rawStorage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
+    rawStorage = new AggregateStorage(bigtable, datastore);
     storage = spy(rawStorage);
     when(workflowValidator.validateWorkflow(any())).thenReturn(Collections.emptyList());
     when(requestAuthenticator.authenticate(any())).thenReturn(() -> Optional.of(idToken));

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -157,7 +157,6 @@ public class StyxScheduler implements AppInit {
   private static final Duration RUNTIME_CONFIG_UPDATE_INTERVAL = Duration.ofSeconds(5);
   private static final Duration DEFAULT_RETRY_BASE_DELAY = Duration.ofMinutes(3);
   private static final int DEFAULT_RETRY_MAX_EXPONENT = 4;
-  private static final Duration DEFAULT_RETRY_BASE_DELAY_BT = Duration.ofSeconds(1);
   private static final RetryUtil DEFAULT_RETRY_UTIL =
       new RetryUtil(DEFAULT_RETRY_BASE_DELAY, DEFAULT_RETRY_MAX_EXPONENT);
   private static final double DEFAULT_SUBMISSION_RATE_PER_SEC = 1000D;
@@ -581,7 +580,7 @@ public class StyxScheduler implements AppInit {
 
     final Connection bigTable = closer.register(createBigTableConnection(config));
     final Datastore datastore = createDatastore(config, stats);
-    return new AggregateStorage(bigTable, datastore, DEFAULT_RETRY_BASE_DELAY_BT);
+    return new AggregateStorage(bigTable, datastore);
   }
 
   private static DockerRunner createDockerRunner(

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -53,7 +53,6 @@ import com.spotify.styx.util.StorageFactory;
 import com.spotify.styx.util.Time;
 import com.spotify.styx.util.TriggerInstantSpec;
 import java.io.IOException;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -128,7 +127,7 @@ public class StyxSchedulerServiceFixture {
   public void setUp() {
 
     final Datastore datastore = datastoreEmulator.client();
-    storage = new AggregateStorage(bigtable, datastore, Duration.ZERO);
+    storage = new AggregateStorage(bigtable, datastore);
 
     StorageFactory storageFactory = (env, stats) -> storage;
     StatsFactory statsFactory = (env) -> Stats.NOOP;

--- a/styx-service-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -33,7 +33,6 @@ import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.util.TriggerInstantSpec;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,8 +49,8 @@ public class AggregateStorage implements Storage {
   private final BigtableStorage bigtableStorage;
   private final DatastoreStorage datastoreStorage;
 
-  public AggregateStorage(Connection connection, Datastore datastore, Duration retryBaseDelay) {
-    this(new BigtableStorage(connection, retryBaseDelay),
+  public AggregateStorage(Connection connection, Datastore datastore) {
+    this(new BigtableStorage(connection),
          new DatastoreStorage(new CheckedDatastore(datastore)));
   }
 

--- a/styx-service-common/src/main/java/com/spotify/styx/storage/BigtableStorage.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/BigtableStorage.java
@@ -23,9 +23,16 @@ package com.spotify.styx.storage;
 import static com.spotify.styx.serialization.Json.deserializeEvent;
 import static com.spotify.styx.serialization.Json.serialize;
 
-import com.google.cloud.datastore.DatastoreException;
+import com.github.rholder.retry.Attempt;
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.StopStrategy;
+import com.github.rholder.retry.WaitStrategies;
+import com.github.rholder.retry.WaitStrategy;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.SequenceEvent;
@@ -34,15 +41,15 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import com.spotify.styx.util.ResourceNotFoundException;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import javaslang.control.Try;
 import okio.ByteString;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Connection;
@@ -68,14 +75,26 @@ public class BigtableStorage {
   private static final byte[] EVENT_CF = Bytes.toBytes("event");
   private static final byte[] EVENT_QUALIFIER = Bytes.toBytes("event");
 
-  static final int MAX_BIGTABLE_RETRIES = 100;
+  private static final WaitStrategy DEFAULT_WAIT_STRATEGY = WaitStrategies.fixedWait(1, TimeUnit.SECONDS);
+  private static final StopStrategy DEFAULT_RETRY_STOP_STRATEGY = StopStrategies.stopAfterAttempt(100);
 
   private final Connection connection;
-  private final Duration retryBaseDelay;
+  private final Retryer<Void> retryer;
 
-  BigtableStorage(Connection connection, Duration retryBaseDelay) {
-    this.connection = Objects.requireNonNull(connection);
-    this.retryBaseDelay = Objects.requireNonNull(retryBaseDelay);
+  BigtableStorage(Connection connection) {
+    this(connection, DEFAULT_WAIT_STRATEGY, DEFAULT_RETRY_STOP_STRATEGY);
+  }
+
+  @VisibleForTesting
+  BigtableStorage(Connection connection, WaitStrategy waitStrategy, StopStrategy retryStopStrategy) {
+    this.connection = Objects.requireNonNull(connection, "connection");
+
+    retryer = RetryerBuilder.<Void>newBuilder()
+        .retryIfExceptionOfType(IOException.class)
+        .withWaitStrategy(Objects.requireNonNull(waitStrategy, "waitStrategy"))
+        .withStopStrategy(Objects.requireNonNull(retryStopStrategy, "retryStopStrategy"))
+        .withRetryListener(BigtableStorage::onRequestAttempt)
+        .build();
   }
 
   SortedSet<SequenceEvent> readEvents(WorkflowInstance workflowInstance) throws IOException {
@@ -93,18 +112,28 @@ public class BigtableStorage {
   }
 
   void writeEvent(SequenceEvent sequenceEvent) throws IOException {
-    storeWithRetries(() -> {
-      try (final Table eventsTable = connection.getTable(EVENTS_TABLE_NAME)) {
-        final String workflowInstanceKey = sequenceEvent.event().workflowInstance().toKey();
-        final String keyString = String.format("%s#%08d", workflowInstanceKey, sequenceEvent.counter());
-        final byte[] key = Bytes.toBytes(keyString);
-        final Put put = new Put(key, sequenceEvent.timestamp());
+    try {
+      retryer.call(() -> {
+        try (final Table eventsTable = connection.getTable(EVENTS_TABLE_NAME)) {
+          final String workflowInstanceKey = sequenceEvent.event().workflowInstance().toKey();
+          final String keyString = String.format("%s#%08d", workflowInstanceKey, sequenceEvent.counter());
+          final byte[] key = Bytes.toBytes(keyString);
+          final Put put = new Put(key, sequenceEvent.timestamp());
 
-        final byte[] eventBytes = serialize(sequenceEvent.event()).toByteArray();
-        put.addColumn(EVENT_CF, EVENT_QUALIFIER, eventBytes);
-        eventsTable.put(put);
+          final byte[] eventBytes = serialize(sequenceEvent.event()).toByteArray();
+          put.addColumn(EVENT_CF, EVENT_QUALIFIER, eventBytes);
+          eventsTable.put(put);
+          return null;
+        }
+      });
+    } catch (ExecutionException | RetryException e) {
+      var cause = e.getCause();
+      if (cause instanceof IOException) {
+        throw (IOException) cause;
+      } else {
+        throw new RuntimeException(cause);
       }
-    });
+    }
   }
 
   List<WorkflowInstanceExecutionData> executionData(WorkflowId workflowId, String offset, int limit)
@@ -211,32 +240,10 @@ public class BigtableStorage {
     return SequenceEvent.parseKey(key, event, timestamp);
   }
 
-  private void storeWithRetries(Try.CheckedRunnable storingOperation) throws IOException {
-    int storeRetries = 0;
-    boolean succeeded = false;
-
-    while (storeRetries < MAX_BIGTABLE_RETRIES && !succeeded) {
-      try {
-        storingOperation.run();
-        succeeded = true;
-      } catch (ResourceNotFoundException e) {
-        throw e;
-      } catch (DatastoreException | IOException e) {
-        storeRetries++;
-        if (storeRetries == MAX_BIGTABLE_RETRIES) {
-          throw e;
-        }
-        LOG.warn(String.format("Failed to read/write from/to Bigtable (attempt #%d)", storeRetries), e);
-        try {
-          Thread.sleep(retryBaseDelay.toMillis());
-        } catch (InterruptedException e1) {
-          Thread.currentThread().interrupt();
-          throw new RuntimeException(e1);
-        }
-      } catch (Throwable e) {
-        Throwables.throwIfUnchecked(e);
-        throw new RuntimeException(e);
-      }
+  private static <T> void onRequestAttempt(Attempt<T> attempt) {
+    if (attempt.hasException()) {
+      LOG.warn(String.format("Failed to write to Bigtable (attempt #%d)", attempt.getAttemptNumber()),
+          attempt.getExceptionCause());
     }
   }
 

--- a/styx-service-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
@@ -23,8 +23,12 @@ package com.spotify.styx.storage;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.SequenceEvent;
 import com.spotify.styx.model.TriggerParameters;
@@ -35,7 +39,6 @@ import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.util.ResourceNotFoundException;
 import java.io.IOException;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -60,6 +63,8 @@ public class BigTableStorageTest {
   private static final Trigger TRIGGER2 = Trigger.unknown("triggerId2");
   private static final Trigger TRIGGER3 = Trigger.unknown("triggerId3");
 
+  private static final int MAX_BIGTABLE_RETRIES = 3;
+
   private static final TriggerParameters TRIGGER_PARAMETERS = TriggerParameters.builder()
       .env("FOO", "foo",
           "BAR", "bar")
@@ -68,11 +73,14 @@ public class BigTableStorageTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
+
+  private Connection bigtable;
   private BigtableStorage storage;
 
   public void setUp(int numFailures) throws Exception {
-    Connection bigtable = setupBigTableMockTable(numFailures);
-    storage = new BigtableStorage(bigtable, Duration.ZERO);
+    bigtable = setupBigTableMockTable(numFailures);
+    storage =
+        new BigtableStorage(bigtable, WaitStrategies.noWait(), StopStrategies.stopAfterAttempt(MAX_BIGTABLE_RETRIES));
   }
 
   private Connection setupBigTableMockTable(int numFailures) throws IOException {
@@ -220,7 +228,7 @@ public class BigTableStorageTest {
 
   @Test
   public void shouldProduceIOExceptionIfTooManyPutRetries() throws Exception {
-    setUp(BigtableStorage.MAX_BIGTABLE_RETRIES);
+    setUp(MAX_BIGTABLE_RETRIES);
 
     thrown.expect(IOException.class);
     thrown.expectMessage(containsString("Something went wrong in performing put operation"));
@@ -230,7 +238,20 @@ public class BigTableStorageTest {
 
   @Test
   public void shouldNotProduceIOExceptionIfPutRetrySucceeds() throws Exception {
-    setUp(BigtableStorage.MAX_BIGTABLE_RETRIES - 1);
+    setUp(MAX_BIGTABLE_RETRIES - 1);
+
+    storage.writeEvent(SequenceEvent.create(Event.success(WFI1), 1, 0));
+  }
+
+  @Test
+  public void shouldProduceRuntimeExceptionWrappingRuntimeException() throws Exception {
+    setUp(0);
+
+    var e = new RuntimeException();
+    doThrow(e).when(bigtable).getTable(any());
+
+    thrown.expect(RuntimeException.class);
+    thrown.expectCause(is(e));
 
     storage.writeEvent(SequenceEvent.create(Event.success(WFI1), 1, 0));
   }

--- a/styx-service-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
@@ -73,7 +73,6 @@ public class BigTableStorageTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-
   private Connection bigtable;
   private BigtableStorage storage;
 

--- a/styx-service-common/src/test/java/com/spotify/styx/util/ShardedCounterSnapshotFactoryTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/util/ShardedCounterSnapshotFactoryTest.java
@@ -33,7 +33,6 @@ import com.spotify.styx.storage.AggregateStorage;
 import com.spotify.styx.storage.DatastoreEmulator;
 import com.spotify.styx.storage.Storage;
 import java.io.IOException;
-import java.time.Duration;
 import org.apache.hadoop.hbase.client.Connection;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -60,7 +59,7 @@ public class ShardedCounterSnapshotFactoryTest {
   public static void setUpClass() {
     var datastore = datastoreEmulator.client();
     connection = Mockito.mock(Connection.class);
-    storage = Mockito.spy(new AggregateStorage(connection, datastore, Duration.ZERO));
+    storage = Mockito.spy(new AggregateStorage(connection, datastore));
   }
 
   @AfterClass

--- a/styx-service-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/util/ShardedCounterTest.java
@@ -59,7 +59,6 @@ import com.spotify.styx.storage.DatastoreEmulator;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.storage.StorageTransaction;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.stream.IntStream;
 import org.apache.hadoop.hbase.client.Connection;
@@ -96,7 +95,7 @@ public class ShardedCounterTest {
   public static void setUpClass() {
     datastore = datastoreEmulator.client();
     connection = mock(Connection.class);
-    storage = new AggregateStorage(connection, datastore, Duration.ZERO);
+    storage = new AggregateStorage(connection, datastore);
   }
 
   @AfterClass


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Use retryer lib instead.

~Depends on #779~

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To simply code.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [x] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
