### PR TITLE
No common FJP for BigtableStorage

### DIFF
--- a/styx-service-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -61,6 +61,7 @@ public class AggregateStorage implements Storage {
 
   @Override
   public void close() throws IOException {
+    bigtableStorage.close();
     datastoreStorage.close();
   }
 

--- a/styx-service-common/src/main/java/com/spotify/styx/storage/BigtableStorage.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/BigtableStorage.java
@@ -117,6 +117,11 @@ public class BigtableStorage implements Closeable {
         .build();
   }
 
+  @Override
+  public void close() throws IOException {
+    closer.close();
+  }
+
   SortedSet<SequenceEvent> readEvents(WorkflowInstance workflowInstance) throws IOException {
     try (final Table eventsTable = connection.getTable(EVENTS_TABLE_NAME)) {
       final Scan scan = new Scan()
@@ -276,10 +281,5 @@ public class BigtableStorage implements Closeable {
 
   private static TreeSet<SequenceEvent> newSortedEventSet() {
     return Sets.newTreeSet(SequenceEvent.COUNTER_COMPARATOR);
-  }
-
-  @Override
-  public void close() throws IOException {
-    closer.close();
   }
 }

--- a/styx-service-common/src/main/java/com/spotify/styx/storage/BigtableStorage.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/BigtableStorage.java
@@ -246,13 +246,7 @@ public class BigtableStorage implements Closeable {
   private List<WorkflowInstanceExecutionData> executionData(
       Set<WorkflowInstance> workflowInstancesSet) {
     return workflowInstancesSet.stream()
-        .map(workflowInstance -> asyncIO(() -> {
-          try {
-            return executionData(workflowInstance);
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-        }))
+        .map(workflowInstance -> asyncIO(() -> executionData(workflowInstance)))
         .collect(toList())
         .stream()
         .map(CompletableFuture::join)

--- a/styx-service-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/DatastoreStorage.java
@@ -199,7 +199,8 @@ public class DatastoreStorage implements Closeable {
                    ExecutorService executor, Logger log) {
     this.datastore = Objects.requireNonNull(datastore);
     this.storageTransactionFactory = Objects.requireNonNull(storageTransactionFactory);
-    this.executor = MDCUtil.withMDC(Context.currentContextExecutor(register(closer, executor, "datastore-storage")));
+    this.executor = MDCUtil.withMDC(Context.currentContextExecutor(
+        register(closer, Objects.requireNonNull(executor, "executor"), "datastore-storage")));
     this.log = Objects.requireNonNull(log, "log");
   }
 

--- a/styx-service-common/src/test/java/com/spotify/styx/storage/AggregateStorageTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/storage/AggregateStorageTest.java
@@ -73,6 +73,12 @@ public class AggregateStorageTest {
   }
 
   @Test
+  public void shouldCloseBigTable() throws IOException {
+    sut.close();
+    verify(bigtable).close();
+  }
+
+  @Test
   public void readActiveWorkflowInstances() throws Exception {
     final Map<WorkflowInstance, RunState> activeStates =
         Map.of(workflowInstance, runState);

--- a/styx-service-common/src/test/java/com/spotify/styx/storage/AggregateStorageTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/storage/AggregateStorageTest.java
@@ -67,14 +67,9 @@ public class AggregateStorageTest {
   }
 
   @Test
-  public void shouldCloseDatastore() throws IOException {
+  public void shouldCloseAggregatedStorage() throws IOException {
     sut.close();
     verify(datastore).close();
-  }
-
-  @Test
-  public void shouldCloseBigTable() throws IOException {
-    sut.close();
     verify(bigtable).close();
   }
 

--- a/styx-service-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/storage/BigTableStorageTest.java
@@ -42,6 +42,8 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.hadoop.hbase.client.Connection;
 import org.junit.Rule;
 import org.junit.Test;
@@ -76,10 +78,13 @@ public class BigTableStorageTest {
   private Connection bigtable;
   private BigtableStorage storage;
 
+  private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
   public void setUp(int numFailures) throws Exception {
     bigtable = setupBigTableMockTable(numFailures);
     storage =
-        new BigtableStorage(bigtable, WaitStrategies.noWait(), StopStrategies.stopAfterAttempt(MAX_BIGTABLE_RETRIES));
+        new BigtableStorage(bigtable, executor, WaitStrategies.noWait(),
+            StopStrategies.stopAfterAttempt(MAX_BIGTABLE_RETRIES));
   }
 
   private Connection setupBigTableMockTable(int numFailures) throws IOException {


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Use dedicated FJP for IO operation.

~Depends on #780~

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using common FJP for IO operation is not a good practice. This change should also improve performance.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [x] Errors that cannot be handled where they occur are propagated
- [x] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
