### PR TITLE
flexible retry

### DIFF
--- a/doc/api.apib
+++ b/doc/api.apib
@@ -130,7 +130,8 @@ or updated. Note that a non-null value is required for docker_image.
           "secret": null,
           "service_account": null,
           "resources": [],
-          "running_timeout": "PT2H"
+          "running_timeout": "PT2H",
+          "retry_condition": "tries < 3"
         }
 
 + Response 200 (application/json)
@@ -155,7 +156,8 @@ or updated. Note that a non-null value is required for docker_image.
             "secret": null,
             "service_account": null,
             "resources": [],
-            "running_timeout": "PT2H"
+            "running_timeout": "PT2H",
+            "retry_condition": "tries < 3"
           },
           "__from_api": "V3"
         }
@@ -192,7 +194,8 @@ or updated. Note that a non-null value is required for docker_image.
                 "env": {"FOO": "bar"},
                 "secret": null,
                 "resources": [],
-                "running_timeout": "PT2H"
+                "running_timeout": "PT2H",
+                "retry_condition": "tries < 3"
               }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,11 @@
         <artifactId>config</artifactId>
         <version>1.3.3</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache-extras.beanshell</groupId>
+        <artifactId>bsh</artifactId>
+        <version>2.0b6</version>
+      </dependency>
 
       <!-- tracing -->
       <dependency>

--- a/styx-common/pom.xml
+++ b/styx-common/pom.xml
@@ -83,6 +83,10 @@
       <artifactId>google-api-client</artifactId>
       <version>1.28.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache-extras.beanshell</groupId>
+      <artifactId>bsh</artifactId>
+    </dependency>
 
     <!-- test deps -->
     <dependency>

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
@@ -67,6 +67,8 @@ public interface WorkflowConfiguration {
 
   Optional<Duration> runningTimeout();
 
+  Optional<String> retryCondition();
+
   default Instant addOffset(Instant next) {
     final String offset = offset().orElseGet(this::defaultOffset);
 

--- a/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
+++ b/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
@@ -137,6 +137,7 @@ public final class TestData {
           .dockerArgs(List.of("x", "y"))
           .secret(Secret.create("name", "/path"))
           .serviceAccount("foo@bar.baz.quux")
+          .retryCondition("exitCode == 1 && (tries < 3 || consecutiveFailures < 4) && triggerType == \"natural\"")
           .build();
 
   public static final WorkflowConfiguration HOURLY_WORKFLOW_CONFIGURATION_WITH_RESOURCES_RUNNING_TIMEOUT =

--- a/styx-common/src/test/java/com/spotify/styx/util/BasicWorkflowValidatorTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/BasicWorkflowValidatorTest.java
@@ -64,6 +64,7 @@ public class BasicWorkflowValidatorTest {
   private static final int MAX_SECRET_NAME_LENGTH = 253;
   private static final int MAX_SECRET_MOUNT_PATH_LENGTH = 1024;
   private static final int MAX_SERVICE_ACCOUNT_LENGTH = 256;
+  private static final int MAX_RETRY_CONDITION_LENGTH = 256;
   private static final int MAX_ENV_VARS = 128;
   private static final int MAX_ENV_SIZE = 16 * 1024;
   private static final Duration MIN_RUNNING_TIMEOUT = Duration.ofMinutes(1);
@@ -119,7 +120,6 @@ public class BasicWorkflowValidatorTest {
     assertThat(errors, containsInAnyOrder("invalid image: foo", "invalid image: bar"));
   }
 
-
   @Test
   public void validateInvalidWorkflow() {
     final String id = Strings.repeat("id", 1024);
@@ -135,6 +135,7 @@ public class BasicWorkflowValidatorTest {
         .collect(toMap(i -> "env-var-" + i, i -> "env-val-" + i));
     final long envSize = env.entrySet().stream().mapToLong(e -> e.getKey().length() + e.getValue().length()).sum();
     final Duration runningTimeout = Duration.ofSeconds(59L);
+    var retryCondition = Strings.repeat("foo -> bar", 1024);
 
     final WorkflowConfiguration invalidConfiguration = WorkflowConfiguration.builder()
         .id(id)
@@ -148,6 +149,7 @@ public class BasicWorkflowValidatorTest {
         .serviceAccount(serviceAccount)
         .env(env)
         .runningTimeout(runningTimeout)
+        .retryCondition(retryCondition)
         .build();
 
     final List<String> errors = sut.validateWorkflow(Workflow.create("test", invalidConfiguration));
@@ -167,6 +169,8 @@ public class BasicWorkflowValidatorTest {
         .add(limit("env too big", envSize, MAX_ENV_SIZE))
         .add(limit("running timeout is too small", runningTimeout, MIN_RUNNING_TIMEOUT))
         .add("service account is not a valid email address: " + serviceAccount)
+        .add(limit("retry condition too long", retryCondition.length(), MAX_RETRY_CONDITION_LENGTH))
+        .add("invalid retry condition: In file: <unknown> Encountered \">\" at line 1, column 6.\n")
         .build();
 
     assertThat(errors, containsInAnyOrder(expectedErrors.toArray()));

--- a/styx-scheduler-service/pom.xml
+++ b/styx-scheduler-service/pom.xml
@@ -65,6 +65,10 @@
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache-extras.beanshell</groupId>
+      <artifactId>bsh</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.spotify</groupId>

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -389,7 +389,7 @@ public class StyxScheduler implements AppInit {
     // These output handlers will be invoked in order.
     outputHandlers.addAll(OutputHandler.tracing(List.of(
         new DockerRunnerHandler(dockerRunner, stateManager),
-        new TerminationHandler(retryUtil, stateManager),
+        new TerminationHandler(retryUtil, storage, stateManager),
         new MonitoringHandler(stats),
         new ExecutionDescriptionHandler(storage, stateManager, workflowValidator),
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TerminationHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TerminationHandler.java
@@ -28,6 +28,7 @@ import bsh.Interpreter;
 import bsh.NameSpace;
 import bsh.Primitive;
 import bsh.UtilEvalError;
+import com.google.common.annotations.VisibleForTesting;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowInstance;
@@ -145,12 +146,14 @@ public class TerminationHandler implements OutputHandler {
         .orElse(false);
   }
 
+  @VisibleForTesting
   boolean retryConditionMet(RunState state,
                             Optional<Integer> exitCode,
                             String retryCondition) {
     return AccessController
-        .doPrivileged((PrivilegedAction<Boolean>) () -> retryConditionMet0(state, exitCode, retryCondition),
-            null, new PropertyPermission("user.dir", "read"), new PropertyPermission("saveClasses", "read"));
+        .doPrivileged((PrivilegedAction<Boolean>) () -> retryConditionMet0(state, exitCode, retryCondition), null,
+            // minimum permission required for BeanShell to function
+            new PropertyPermission("saveClasses", "read"));
   }
 
   private boolean retryConditionMet0(RunState state,

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TerminationHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TerminationHandler.java
@@ -20,6 +20,8 @@
 
 package com.spotify.styx.state.handlers;
 
+import static java.lang.Boolean.TRUE;
+
 import bsh.EvalError;
 import bsh.Interpreter;
 import com.spotify.styx.model.Event;
@@ -139,8 +141,7 @@ public class TerminationHandler implements OutputHandler {
       interpreter.set("tries", state.data().tries());
       interpreter.set("triggerType", state.data().trigger().map(TriggerUtil::triggerType).orElse(null));
       interpreter.set("consecutiveFailures", state.data().consecutiveFailures());
-      final Object result = interpreter.eval(retryCondition);
-      return result instanceof Boolean && (boolean) result;
+      return TRUE.equals(interpreter.eval(retryCondition));
     } catch (EvalError evalError) {
       return false;
     }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TerminationHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TerminationHandler.java
@@ -39,9 +39,12 @@ import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.RetryUtil;
 import com.spotify.styx.util.TriggerUtil;
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.PropertyPermission;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,6 +146,14 @@ public class TerminationHandler implements OutputHandler {
   }
 
   boolean retryConditionMet(RunState state,
+                            Optional<Integer> exitCode,
+                            String retryCondition) {
+    return AccessController
+        .doPrivileged((PrivilegedAction<Boolean>) () -> retryConditionMet0(state, exitCode, retryCondition),
+            null, new PropertyPermission("user.dir", "read"), new PropertyPermission("saveClasses", "read"));
+  }
+
+  private boolean retryConditionMet0(RunState state,
                             Optional<Integer> exitCode,
                             String retryCondition) {
     var ns = new NameSpace(bcm, state.data().executionId().orElseGet(() -> String.valueOf(UUID.randomUUID())));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/TerminationHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/TerminationHandlerTest.java
@@ -52,6 +52,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.IntStream;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -226,6 +227,17 @@ public class TerminationHandlerTest {
             StateData.zero()),
         Optional.of(1),
         "foo -> bar");
+    assertThat(result, is(false));
+  }
+
+  @Test
+  @Ignore("require enabling security manager")
+  public void shouldFailToEvaluateDueToMissingPermission() {
+    var result = terminationHandler.retryConditionMet(
+        RunState.create(WORKFLOW_INSTANCE, FAILED,
+            StateData.zero()),
+        Optional.of(1),
+        "System.exit(1); true");
     assertThat(result, is(false));
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/TerminationHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/TerminationHandlerTest.java
@@ -53,6 +53,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.IntStream;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -256,7 +257,7 @@ public class TerminationHandlerTest {
   }
 
   @Test
-  //@Ignore("require enabling security manager: -Djava.security.manager -Djava.security.policy=security.policy")
+  @Ignore("require enabling security manager: -Djava.security.manager -Djava.security.policy=security.policy")
   public void shouldFailToEvaluateDueToMissingPermission() {
     var result = terminationHandler.retryConditionMet(
         RunState.create(WORKFLOW_INSTANCE, FAILED,


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Support using a boolean expression to decide whether retry should be done or not.

e.g `exitCode == 1 && (tries < 3 || consecutiveFailures < 4) && triggerType == "natural"`

`50` as a special exit code still has higher priority than retry condition. Max number of retries are not affected by this feature.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Users will be able to control when to stop retrying in a flexible way.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [x] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
