### PR TITLE
Fix parsing of auth tocken with google cloud compute metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <metrics.version>3.2.6</metrics.version>
     <opencensus.version>0.19.2</opencensus.version>
     <google.client.lib.version>1.28.0</google.client.lib.version>
-    <google.http.client.lib.version>1.29.1</google.http.client.lib.version>
+    <google.http.client.lib.version>1.29.2</google.http.client.lib.version>
   </properties>
 
   <repositories>

--- a/styx-service-common/src/test/java/com/spotify/styx/api/GoogleIdTokenParserTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/GoogleIdTokenParserTest.java
@@ -1,0 +1,84 @@
+/*-
+ * -\-\-
+ * Spotify Styx Service Common
+ * --
+ * Copyright (C) 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.api;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.util.Utils;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.webtoken.JsonWebSignature;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.time.Instant;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GoogleIdTokenParserTest {
+
+  private PrivateKey privateKey;
+
+  @Before
+  public void setUp() throws Exception {
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    keyGen.initialize(571);
+    KeyPair pair = keyGen.generateKeyPair();
+    privateKey = pair.getPrivate();
+  }
+
+  @Test
+  public void shouldParseTokensFromComputeEngine() throws GeneralSecurityException, IOException {
+    var parsedToken = GoogleIdToken.parse(Utils.getDefaultJsonFactory(), createToken());
+
+    assertThat(parsedToken, is(notNullValue()));
+  }
+
+  private String createToken() throws GeneralSecurityException, IOException {
+    var issuedAt = Instant.now().getEpochSecond();
+    var expiredAt = issuedAt + 3600; // One hour later
+    var payload = new GoogleIdToken.Payload();
+    payload.setAuthorizedParty("103411466401044735393");
+    payload.setEmail("some.email@project.iam.gserviceaccount.com");
+    payload.setEmailVerified(true);
+    payload.setIssuedAtTimeSeconds(issuedAt);
+    payload.setExpirationTimeSeconds(expiredAt);
+    payload.setIssuer("https://accounts.google.com");
+    payload.setSubject("103411466401044735393");
+    GenericJson googleMetadata = new GenericJson()
+        .set("compute_engine", new GenericJson()
+                                   .set("instance_creation_timestamp", 1556025719L)
+                                   .set("instance_id", "5850837338805153689")
+                                   .set("instance_name", "gew1-metricscatalogbro-b-b7z2")
+                                   .set("project_id", "metrics-catalog")
+                                   .set("project_number", 283581591831L)
+                                   .set("zone", "europe-west1-d")
+        );
+    payload.set("google", googleMetadata);
+
+    var header = new JsonWebSignature.Header().setAlgorithm("RS256");
+    return JsonWebSignature.signUsingRsaSha256(privateKey, Utils.getDefaultJsonFactory(), header, payload);
+  }
+}

--- a/styx-service-common/src/test/java/com/spotify/styx/api/GoogleIdTokenVerifierTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/GoogleIdTokenVerifierTest.java
@@ -101,10 +101,10 @@ public class GoogleIdTokenVerifierTest {
     setField(keysManager, "expirationTimeMilliseconds", Long.MAX_VALUE);
   }
 
-  private void setField(GooglePublicKeysManager keysManager, String name, Object publicKey1)
+  private void setField(GooglePublicKeysManager keysManager, String name, Object value)
       throws NoSuchFieldException, IllegalAccessException {
     final var field = GooglePublicKeysManager.class.getDeclaredField(name);
     field.setAccessible(true);
-    field.set(keysManager, publicKey1);
+    field.set(keysManager, value);
   }
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
JWT with extra google cloud compute metadata triggers a parsing bug  in the google.http.client.lib  1.29.1.

```yaml
{
  azp: 103411466401044735393,
  email: some.email@project.iam.gserviceaccount.com,
  email_verified: true,
  exp: 1565270045,
  iat: 1565266445,
  iss: https://accounts.google.com,
  sub: 103411466401044735393,
  google: {
    compute_engine: {
      instance_creation_timestamp: 1556025719,
      instance_id: 5853837336805153889,
      instance_name: some-host,
      project_id: some-project,
      project_number: 213281561831,
      zone: europe-west1-d
    }
  }
}
```

In this example everything under `google` key is the "extra" metadata and causes a problem parsing the project number as a `int` (overflows).

Here we create a Unit Test to reproduce the problem and bump the library that reverts the problematic commit that caused the problem.

See https://github.com/googleapis/google-http-java-client/releases/tag/v1.29.2
and https://github.com/googleapis/google-http-java-client/pull/662
## Motivation and Context
See description

## Have you tested this? If so, how?
I have included unit tests.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
