### PR TITLE
Use a new thread pool for get active states

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
@@ -21,11 +21,12 @@
 package com.spotify.styx.api;
 
 import static com.spotify.styx.api.Api.Version.V3;
+import static com.spotify.styx.util.CloserUtil.register;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 import com.google.api.client.util.Lists;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Closer;
 import com.spotify.apollo.RequestContext;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.Status;
@@ -49,6 +50,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
 import java.util.stream.Stream;
 import okio.ByteString;
 import org.slf4j.Logger;
@@ -60,15 +64,19 @@ import org.slf4j.LoggerFactory;
 public class StatusResource {
 
   private static final Logger log = LoggerFactory.getLogger(StatusResource.class);
+  private static final int CONCURRENCY = 32;
 
   static final String BASE = "/status";
 
   private final Storage storage;
   private final ServiceAccountUsageAuthorizer accountUsageAuthorizer;
+  private final ForkJoinPool forkJoinPool;
+  private final Closer closer = Closer.create();
 
   public StatusResource(Storage storage, ServiceAccountUsageAuthorizer accountUsageAuthorizer) {
     this.storage = requireNonNull(storage);
     this.accountUsageAuthorizer = requireNonNull(accountUsageAuthorizer);
+    this.forkJoinPool = register(closer, new ForkJoinPool(CONCURRENCY), "status-resource");
   }
 
   public Stream<Route<AsyncHandler<Response<ByteString>>>> routes() {
@@ -129,7 +137,7 @@ public class StatusResource {
     final List<RunStateData> runStates = Lists.newArrayList();
     try {
       activeStates = componentsOpt.isPresent() ? getActiveStates(componentsOpt.get()):
-                       getActiveStates(componentOpt, workflowOpt);
+                     getActiveStates(componentOpt, workflowOpt);
 
     } catch (InvalidParametersException e) {
       return Response.forStatus(Status.BAD_REQUEST.withReasonPhrase(e.getMessage()));
@@ -146,25 +154,36 @@ public class StatusResource {
 
   private Map<WorkflowInstance, RunState> getActiveStates(String componentsStr) throws IOException {
     final List<String> components = Arrays.asList(componentsStr.split(","));
-    final ImmutableMap.Builder<WorkflowInstance, RunState> mapBuilder = ImmutableMap.builder();
+    final ConcurrentHashMap<WorkflowInstance, RunState> concurrentHashMap = new ConcurrentHashMap<>();
 
-    final List<Optional<IOException>> exceptions = components.parallelStream().map( componentId -> {
-      Optional<IOException> exception = Optional.empty();
-      try{
-        final Map<WorkflowInstance, RunState> stateMap = storage.readActiveStates(componentId);
-        for (WorkflowInstance instance : stateMap.keySet()) {
-          mapBuilder.put(instance, stateMap.get(instance));
-        }
-      } catch (IOException e) {
-        exception = Optional.of(e);
-      }
-      return exception;
-      }).filter(Optional::isPresent).collect(toList());
+    final List<Optional<IOException>> exceptions =
+        components.stream()
+            .map(
+                componentId ->
+                    forkJoinPool.submit(
+                        () -> {
+                          Optional<IOException> exception = Optional.empty();
+                          try {
+                            final Map<WorkflowInstance, RunState> stateMap =
+                                storage.readActiveStates(componentId);
+                            for (WorkflowInstance instance : stateMap.keySet()) {
+                              concurrentHashMap.put(instance, stateMap.get(instance));
+                            }
+                          } catch (IOException e) {
+                            exception = Optional.of(e);
+                          }
+                          return exception;
+                        }))
+            .collect(toList())
+            .stream()
+            .map(ForkJoinTask::join)
+            .filter(Optional::isPresent)
+            .collect(toList());
     if (!exceptions.isEmpty()) {
       throw exceptions.get(0).orElseThrow();
     }
 
-    return mapBuilder.build();
+    return concurrentHashMap;
   }
 
   private Map<WorkflowInstance, RunState> getActiveStates(Optional<String> componentOpt, Optional<String> workflowOpt)


### PR DESCRIPTION
# Hey, I just made a Pull Request!

This PR addresses issues connecting to PR: https://github.com/spotify/styx/pull/774
Now the getActiveStates endpoint will use a separate thread pool instead of the main FJP and it uses the `concurrentHashMap` instead to prevent race condition.

## Description
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
