### PR TITLE
use sequence to simplify usage of Try

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/StatusResource.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javaslang.control.Try;
@@ -161,12 +162,8 @@ public class StatusResource {
             .collect(toList()))
         .join();
 
-    var sequence = Try.sequence(activeStatesOrExceptions);
-    if (sequence.isFailure()) {
-      throw new IOException(sequence.getCause());
-    }
-
-    return sequence.get()
+    return Try.sequence(activeStatesOrExceptions)
+        .getOrElseThrow((Function<Throwable, IOException>) IOException::new)
         .toJavaStream()
         .flatMap(map -> map.entrySet().stream())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
`Try.sequence` does things for us so we can limit to `IOException` only in a compact way.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
