### PR TITLE
Global runner for submitting state

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -57,6 +57,7 @@ import com.spotify.styx.api.SchedulerResource;
 import com.spotify.styx.api.ServiceAccountUsageAuthorizer;
 import com.spotify.styx.api.WorkflowActionAuthorizer;
 import com.spotify.styx.docker.DockerRunner;
+import com.spotify.styx.docker.DockerRunnerId;
 import com.spotify.styx.docker.Fabric8KubernetesClient;
 import com.spotify.styx.model.Event;
 import com.spotify.styx.model.StyxConfig;
@@ -371,7 +372,7 @@ public class StyxScheduler implements AppInit {
     final StateManager stateManager = TracingProxy.instrument(StateManager.class, queuedStateManager);
 
     final Supplier<StyxConfig> styxConfig = new CachedSupplier<>(storage::config, time);
-    final Function<RunState, String> runnerId = (runState) -> getRunnerId(runState, styxConfig);
+    final Function<RunState, String> runnerId = new DockerRunnerId(styxConfig);
     final Debug debug = () -> styxConfig.get().debugEnabled();
     var secretWhitelist =
         get(config, config::getStringList, STYX_SECRET_WHITELIST).map(Set::copyOf).orElse(Set.of());
@@ -449,14 +450,6 @@ public class StyxScheduler implements AppInit {
     this.scheduler = scheduler;
     this.triggerManager = triggerManager;
     this.backfillTriggerManager = backfillTriggerManager;
-  }
-
-  @VisibleForTesting
-  static String getRunnerId(RunState runState, Supplier<StyxConfig> styxConfig) {
-    if (runState.state() == State.SUBMITTING) {
-      return styxConfig.get().globalDockerRunnerId();
-    }
-    return runState.data().runnerId().orElseGet(() -> styxConfig.get().globalDockerRunnerId());
   }
 
   @VisibleForTesting

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -453,6 +453,9 @@ public class StyxScheduler implements AppInit {
 
   @VisibleForTesting
   static String getRunnerId(RunState runState, Supplier<StyxConfig> styxConfig) {
+    if (runState.state() == State.SUBMITTING) {
+      return styxConfig.get().globalDockerRunnerId();
+    }
     return runState.data().runnerId().orElseGet(() -> styxConfig.get().globalDockerRunnerId());
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunnerId.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunnerId.java
@@ -2,7 +2,7 @@
  * -\-\-
  * Spotify Styx Scheduler Service
  * --
- * Copyright (C) 2016 Spotify AB
+ * Copyright (C) 2019 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunnerId.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunnerId.java
@@ -1,0 +1,44 @@
+/*-
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.docker;
+
+import com.spotify.styx.model.StyxConfig;
+import com.spotify.styx.state.RunState;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class DockerRunnerId implements Function<RunState, String> {
+
+  private Supplier<StyxConfig> styxConfig;
+
+  public DockerRunnerId(Supplier<StyxConfig> styxConfig) {
+    this.styxConfig = Objects.requireNonNull(styxConfig, "styxConfig");
+  }
+
+  @Override
+  public String apply(RunState runState) {
+    if (runState.state() == RunState.State.SUBMITTING) {
+      return styxConfig.get().globalDockerRunnerId();
+    }
+    return runState.data().runnerId().orElseGet(() -> styxConfig.get().globalDockerRunnerId());
+  }
+}

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
@@ -232,6 +232,15 @@ public class StyxSchedulerTest {
   }
 
   @Test
+  public void testGetRunnerIdFromConfigSupplierWhenSubmitting() {
+    when(configSupplier.get()).thenReturn(StyxConfig.newBuilder().globalDockerRunnerId("default").build());
+    var runState = RunState.create(mock(WorkflowInstance.class), State.SUBMITTING, StateData.newBuilder()
+        .runnerId(TEST_RUNNER_ID)
+        .build());
+    assertThat(StyxScheduler.getRunnerId(runState, configSupplier), is("default"));
+  }
+
+  @Test
   public void testGetRunnerIdFromRunState() {
     var runState = RunState.create(mock(WorkflowInstance.class), State.SUBMITTED, StateData.newBuilder()
         .runnerId(TEST_RUNNER_ID)

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -82,7 +81,6 @@ import org.mockito.MockitoAnnotations;
 public class StyxSchedulerTest {
 
   private static final int DEFAULT_KUBERNETES_REQUEST_TIMEOUT_MILLIS = 60_000;
-  private static final String TEST_RUNNER_ID = "test";
 
   @Captor private ArgumentCaptor<io.fabric8.kubernetes.client.Config> k8sClientConfigCaptor;
   @Captor private ArgumentCaptor<OkHttpClient> httpClientCaptor;
@@ -229,29 +227,5 @@ public class StyxSchedulerTest {
 
     verifyNoMoreInteractions(storage);
     verifyNoMoreInteractions(stateManager);
-  }
-
-  @Test
-  public void testGetRunnerIdFromConfigSupplierWhenSubmitting() {
-    when(configSupplier.get()).thenReturn(StyxConfig.newBuilder().globalDockerRunnerId("default").build());
-    var runState = RunState.create(mock(WorkflowInstance.class), State.SUBMITTING, StateData.newBuilder()
-        .runnerId(TEST_RUNNER_ID)
-        .build());
-    assertThat(StyxScheduler.getRunnerId(runState, configSupplier), is("default"));
-  }
-
-  @Test
-  public void testGetRunnerIdFromRunState() {
-    var runState = RunState.create(mock(WorkflowInstance.class), State.SUBMITTED, StateData.newBuilder()
-        .runnerId(TEST_RUNNER_ID)
-        .build());
-    assertThat(StyxScheduler.getRunnerId(runState, configSupplier), is(TEST_RUNNER_ID));
-  }
-
-  @Test
-  public void testGetRunnerIdFromConfigSupplier() {
-    when(configSupplier.get()).thenReturn(StyxConfig.newBuilder().globalDockerRunnerId("default").build());
-    var runState = RunState.create(mock(WorkflowInstance.class), State.QUEUED, StateData.zero());
-    assertThat(StyxScheduler.getRunnerId(runState, configSupplier), is("default"));
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/DockerRunnerIdTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/DockerRunnerIdTest.java
@@ -1,0 +1,76 @@
+/*-
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.docker;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.spotify.styx.model.StyxConfig;
+import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.state.RunState;
+import com.spotify.styx.state.RunState.State;
+import com.spotify.styx.state.StateData;
+import java.util.function.Supplier;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DockerRunnerIdTest {
+
+  private static final String TEST_RUNNER_ID = "test";
+
+  private DockerRunnerId dockerRunnerId;
+
+  @Mock private Supplier<StyxConfig> configSupplier;
+
+  @Before
+  public void setUp() {
+    when(configSupplier.get()).thenReturn(StyxConfig.newBuilder().globalDockerRunnerId("default").build());
+    dockerRunnerId = new DockerRunnerId(configSupplier);
+  }
+
+  @Test
+  public void testGetRunnerIdFromConfigSupplierWhenSubmitting() {
+    var runState = RunState.create(mock(WorkflowInstance.class), State.SUBMITTING, StateData.newBuilder()
+        .runnerId(TEST_RUNNER_ID)
+        .build());
+    assertThat(dockerRunnerId.apply(runState), is("default"));
+  }
+
+  @Test
+  public void testGetRunnerIdFromRunState() {
+    var runState = RunState.create(mock(WorkflowInstance.class), State.SUBMITTED, StateData.newBuilder()
+        .runnerId(TEST_RUNNER_ID)
+        .build());
+    assertThat(dockerRunnerId.apply(runState), is(TEST_RUNNER_ID));
+  }
+
+  @Test
+  public void testGetRunnerIdFromConfigSupplier() {
+    var runState = RunState.create(mock(WorkflowInstance.class), State.QUEUED, StateData.zero());
+    assertThat(dockerRunnerId.apply(runState), is("default"));
+  }
+}

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/DockerRunnerIdTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/DockerRunnerIdTest.java
@@ -2,7 +2,7 @@
  * -\-\-
  * Spotify Styx Scheduler Service
  * --
- * Copyright (C) 2016 Spotify AB
+ * Copyright (C) 2019 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Always use the globally configured runner when submitting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To make `runnerId` not sticky to the cluster it used before.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
