### PR TITLE
halt workflow instance if disabled and naturally triggered

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowWithState.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowWithState.java
@@ -1,0 +1,40 @@
+/*-
+ * -\-\-
+ * Spotify Styx Common
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.styx.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class WorkflowWithState {
+  @JsonProperty
+  public abstract Workflow workflow();
+
+  @JsonProperty
+  public abstract WorkflowState workflowState();
+
+  @JsonCreator
+  public static WorkflowWithState create(
+      @JsonProperty("workflow") Workflow workflow,
+      @JsonProperty("workflow_state") WorkflowState workflowState) {
+    return new AutoValue_WorkflowWithState(workflow, workflowState);
+  }
+}

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowWithState.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowWithState.java
@@ -2,7 +2,7 @@
  * -\-\-
  * Spotify Styx Common
  * --
- * Copyright (C) 2016 Spotify AB
+ * Copyright (C) 2019 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowWithState.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowWithState.java
@@ -29,12 +29,12 @@ public abstract class WorkflowWithState {
   public abstract Workflow workflow();
 
   @JsonProperty
-  public abstract WorkflowState workflowState();
+  public abstract WorkflowState state();
 
   @JsonCreator
   public static WorkflowWithState create(
       @JsonProperty("workflow") Workflow workflow,
-      @JsonProperty("workflow_state") WorkflowState workflowState) {
-    return new AutoValue_WorkflowWithState(workflow, workflowState);
+      @JsonProperty("state") WorkflowState state) {
+    return new AutoValue_WorkflowWithState(workflow, state);
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -116,7 +116,7 @@ public class ExecutionDescriptionHandler implements OutputHandler {
     );
 
     var isWorkflowEnabled = workflowWithState.state().enabled().orElse(false);
-    var isNaturalTrigger = data.trigger().map(t -> t.equals(Trigger.natural()).orElse(false);
+    var isNaturalTrigger = data.trigger().map(t -> t.equals(Trigger.natural())).orElse(false);
 
     if (!isWorkflowEnabled && isNaturalTrigger) {
       throw new MissingRequiredPropertyException(format("%s is disabled, halting %s", workflowId, workflowInstance));

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -122,7 +122,7 @@ public class ExecutionDescriptionHandler implements OutputHandler {
       }
     }
 
-    final Collection<String> errors = validator.validateWorkflow(workflowWithState.workflow());
+    final Collection<String> errors = validator.validateWorkflow(workflow);
     if (!errors.isEmpty()) {
       throw new MissingRequiredPropertyException(format(
           "%s configuration is invalid, halting %s. Errors: %s",

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -117,7 +117,7 @@ public class ExecutionDescriptionHandler implements OutputHandler {
 
     if (data.trigger().isPresent()) {
       if (data.trigger().orElseThrow().equals(Trigger.natural()) &&
-          !workflowWithState.workflowState().enabled().orElse(false)) {
+          !workflowWithState.state().enabled().orElse(false)) {
         throw new MissingRequiredPropertyException(format("%s is disabled, halting %s", workflowId, workflowInstance));
       }
     }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandler.java
@@ -115,11 +115,11 @@ public class ExecutionDescriptionHandler implements OutputHandler {
             format("%s has no docker image, halting %s", workflowId, workflowInstance))
     );
 
-    if (data.trigger().isPresent()) {
-      if (data.trigger().orElseThrow().equals(Trigger.natural()) &&
-          !workflowWithState.state().enabled().orElse(false)) {
-        throw new MissingRequiredPropertyException(format("%s is disabled, halting %s", workflowId, workflowInstance));
-      }
+    var isWorkflowEnabled = workflowWithState.state().enabled().orElse(false);
+    var isNaturalTrigger = data.trigger().map(t -> t.equals(Trigger.natural()).orElse(false);
+
+    if (!isWorkflowEnabled && isNaturalTrigger) {
+      throw new MissingRequiredPropertyException(format("%s is disabled, halting %s", workflowId, workflowInstance));
     }
 
     final Collection<String> errors = validator.validateWorkflow(workflow);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/ExecutionDescriptionHandlerTest.java
@@ -42,8 +42,12 @@ import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowConfigurationBuilder;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.WorkflowWithState;
 import com.spotify.styx.state.RunState;
+import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
+import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.WorkflowValidator;
 import java.io.IOException;
@@ -90,17 +94,19 @@ public class ExecutionDescriptionHandlerTest {
 
   @Test
   public void shouldTransitionIntoSubmittingIfMissingDockerArgs() throws Exception {
-    Workflow workflow = Workflow.create("id", workflowConfiguration());
-    WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14");
-    RunState runState = RunState.create(workflowInstance, PREPARE, NOW, COUNTER);
+    var workflow = Workflow.create("id", workflowConfiguration());
+    var workflowState = WorkflowState.builder().enabled(true).build();
+    var workflowWithState = WorkflowWithState.create(workflow, workflowState);
+    var workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14");
+    var runState = RunState.create(workflowInstance, PREPARE, NOW, COUNTER);
 
-    when(storage.workflow(workflow.id())).thenReturn(Optional.of(workflow));
+    when(storage.workflowWithState(workflow.id())).thenReturn(Optional.of(workflowWithState));
 
     toTest.transitionInto(runState);
 
     verify(stateManager).receive(eventCaptor.capture(), eq(COUNTER));
 
-    final Event event = eventCaptor.getValue();
+    var event = eventCaptor.getValue();
     event.accept(eventVisitor);
     verify(eventVisitor)
         .submit(workflowInstanceCaptor.capture(), executionDescriptionCaptor.capture(), executionIdCaptor.capture());
@@ -113,17 +119,23 @@ public class ExecutionDescriptionHandlerTest {
 
   @Test
   public void shouldTransitionIntoSubmitting() throws Exception {
-    Workflow workflow = Workflow.create("id", workflowConfiguration("--date", "{}", "--bar"));
-    WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14");
-    RunState runState = RunState.create(workflowInstance, PREPARE, NOW, COUNTER);
+    var workflow = Workflow.create("id", workflowConfiguration("--date", "{}", "--bar"));
+    var workflowState = WorkflowState.builder().enabled(true).build();
+    var workflowWithState = WorkflowWithState.create(workflow, workflowState);
+    var workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14");
+    var runState = RunState.create(workflowInstance,
+        PREPARE,
+        StateData.newBuilder().trigger(Trigger.natural()).build(),
+        NOW,
+        COUNTER);
 
-    when(storage.workflow(workflow.id())).thenReturn(Optional.of(workflow));
+    when(storage.workflowWithState(workflow.id())).thenReturn(Optional.of(workflowWithState));
 
     toTest.transitionInto(runState);
 
     verify(stateManager).receive(eventCaptor.capture(), eq(COUNTER));
 
-    final Event event = eventCaptor.getValue();
+    var event = eventCaptor.getValue();
     event.accept(eventVisitor);
 
     verify(eventVisitor)
@@ -137,12 +149,11 @@ public class ExecutionDescriptionHandlerTest {
 
   @Test
   public void shouldTransitionIntoFailedIfStorageError() throws Exception {
-    Workflow workflow = Workflow.create("id", workflowConfiguration("--date", "{}", "--bar"));
-    WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14");
+    var workflow = Workflow.create("id", workflowConfiguration("--date", "{}", "--bar"));
+    var workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14");
 
-    IOException exception = new IOException("TEST");
-    when(storage.workflow(workflow.id()))
-        .thenThrow(exception);
+    var exception = new IOException("TEST");
+    when(storage.workflowWithState(workflow.id())).thenThrow(exception);
 
     RunState runState = RunState.create(workflowInstance, PREPARE, NOW, COUNTER);
 
@@ -153,10 +164,10 @@ public class ExecutionDescriptionHandlerTest {
 
   @Test
   public void shouldHaltIfMissingWorkflow() throws Exception {
-    WorkflowInstance workflowInstance = WorkflowInstance.create(WorkflowId.create("c", "e"), "2016-03-14T15");
-    RunState runState = RunState.create(workflowInstance, PREPARE, NOW, COUNTER);
+    var workflowInstance = WorkflowInstance.create(WorkflowId.create("c", "e"), "2016-03-14T15");
+    var runState = RunState.create(workflowInstance, PREPARE, NOW, COUNTER);
 
-    when(storage.workflow(any())).thenReturn(Optional.empty());
+    when(storage.workflowWithState(any())).thenReturn(Optional.empty());
 
     toTest.transitionInto(runState);
 
@@ -165,15 +176,36 @@ public class ExecutionDescriptionHandlerTest {
 
   @Test
   public void shouldHaltIfMissingDockerImage() throws Exception {
-    WorkflowConfiguration workflowConfiguration =
+    var workflowConfiguration =
         WorkflowConfigurationBuilder.from(workflowConfiguration("foo", "bar"))
             .dockerImage(Optional.empty())
             .build();
-    Workflow workflow = Workflow.create("id", workflowConfiguration);
-    WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
-    RunState runState = RunState.create(workflowInstance, PREPARE, NOW, COUNTER);
+    var workflow = Workflow.create("id", workflowConfiguration);
+    var workflowState = WorkflowState.builder().enabled(true).build();
+    var workflowWithState = WorkflowWithState.create(workflow, workflowState);
+    var workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
+    var runState = RunState.create(workflowInstance, PREPARE, NOW, COUNTER);
 
-    when(storage.workflow(workflow.id())).thenReturn(Optional.of(workflow));
+    when(storage.workflowWithState(workflow.id())).thenReturn(Optional.of(workflowWithState));
+
+    toTest.transitionInto(runState);
+
+    verify(stateManager).receiveIgnoreClosed(Event.halt(workflowInstance), COUNTER);
+  }
+
+  @Test
+  public void shouldHaltIfDisabledAndNaturallyTriggered() throws Exception {
+    var workflow = Workflow.create("id", workflowConfiguration("--date", "{}", "--bar"));
+    var workflowState = WorkflowState.builder().enabled(false).build();
+    var workflowWithState = WorkflowWithState.create(workflow, workflowState);
+    var workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
+    var runState = RunState.create(workflowInstance,
+        PREPARE,
+        StateData.newBuilder().trigger(Trigger.natural()).build(),
+        NOW,
+        COUNTER);
+
+    when(storage.workflowWithState(workflow.id())).thenReturn(Optional.of(workflowWithState));
 
     toTest.transitionInto(runState);
 
@@ -184,11 +216,13 @@ public class ExecutionDescriptionHandlerTest {
   public void shouldHaltIfInvalidConfiguration() throws Exception {
     when(workflowValidator.validateWorkflow(any())).thenReturn(List.of("foo", "bar"));
 
-    Workflow workflow = Workflow.create("id", FULL_WORKFLOW_CONFIGURATION);
-    WorkflowInstance workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
-    RunState runState = RunState.create(workflowInstance, PREPARE, NOW, COUNTER);
+    var workflow = Workflow.create("id", FULL_WORKFLOW_CONFIGURATION);
+    var workflowState = WorkflowState.builder().enabled(true).build();
+    var workflowWithState = WorkflowWithState.create(workflow, workflowState);
+    var workflowInstance = WorkflowInstance.create(workflow.id(), "2016-03-14T15");
+    var runState = RunState.create(workflowInstance, PREPARE, NOW, COUNTER);
 
-    when(storage.workflow(workflow.id())).thenReturn(Optional.of(workflow));
+    when(storage.workflowWithState(workflow.id())).thenReturn(Optional.of(workflowWithState));
 
     toTest.transitionInto(runState);
 

--- a/styx-service-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -29,6 +29,7 @@ import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.WorkflowWithState;
 import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.util.TriggerInstantSpec;
@@ -207,6 +208,11 @@ public class AggregateStorage implements Storage {
   @Override
   public WorkflowState workflowState(WorkflowId workflowId) throws IOException {
     return datastoreStorage.workflowState(workflowId);
+  }
+
+  @Override
+  public Optional<WorkflowWithState> workflowWithState(WorkflowId workflowId) throws IOException {
+    return datastoreStorage.workflowWithState(workflowId);
   }
 
   @Override

--- a/styx-service-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -28,6 +28,7 @@ import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.WorkflowWithState;
 import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.util.TriggerInstantSpec;
@@ -276,10 +277,18 @@ public interface Storage extends Closeable {
   /**
    * Get the persisted workflow state for a workflow.
    *
-   * @param workflowId The workflow to get the repository for
+   * @param workflowId The workflow to get the state for
    * @return workflow state.
    */
   WorkflowState workflowState(WorkflowId workflowId) throws IOException;
+
+  /**
+   * Get workflow definition and the persisted workflow state.
+   *
+   * @param workflowId The workflow to get the definition and state for
+   * @return workflow and workflow state.
+   */
+  Optional<WorkflowWithState> workflowWithState(WorkflowId workflowId) throws IOException;
 
   Optional<Resource> resource(String id) throws IOException;
 

--- a/styx-service-common/src/test/java/com/spotify/styx/storage/AggregateStorageTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/storage/AggregateStorageTest.java
@@ -113,4 +113,10 @@ public class AggregateStorageTest {
     exception.expectCause(is(rootCause));
     sut.runInTransactionWithRetries(tx -> "foobar");
   }
+
+  @Test
+  public void shouldReturnWorkflowWithState() throws IOException {
+    sut.workflowWithState(workflowInstance.workflowId());
+    verify(datastore).workflowWithState(workflowInstance.workflowId());
+  }
 }

--- a/styx-service-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -559,7 +559,7 @@ public class DatastoreStorageTest {
     var retrieved = storage.workflowWithState(WORKFLOW.id());
 
     assertThat(retrieved.orElseThrow().workflow(), is(WORKFLOW));
-    assertThat(retrieved.orElseThrow().workflowState(), is(state));
+    assertThat(retrieved.orElseThrow().state(), is(state));
   }
 
   @Test


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
If the workflow has been disabled between retry and it is naturally triggered, we halt it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The hypothesis is in this case users would most likely want the instance to stop.

**Note, this is a breaking change.**

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [x] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
