### PR TITLE
new api endpoint for workflow with state

### DIFF
--- a/doc/api.apib
+++ b/doc/api.apib
@@ -203,6 +203,49 @@ Returns 204 No Content if the Workflow was found and deleted, 404 Not Found othe
 + Response 204
 + Response 404
 
+## Workflow with state [/{version}/workflows/{component_id}/{workflow_id}/full]
+
++ Parameters
+    + version: `v3` (enum[string]) - API version
+        + Members
+            + `v3`
+    + component_id: `styx-canary` (string) - Workflow Component
+    + workflow_id: `StyxCanary` (string) - Workflow ID
+
+### Get Workflow with State [GET]
+
++ Response 200 (application/json)
+
+        {
+            "workflow": {
+                "component_id": "styx-canary",
+                "workflow_id": "StyxCanary",
+                "component_uri": "file:///etc/styx/schedule.yaml",
+                "configuration": {
+                    "id": "StyxCanary",
+                    "schedule": "hours",
+                    "offset": null,
+                    "docker_image": null,
+                    "docker_args": [
+                      "luigi",
+                      "--module",
+                      "canary_job",
+                      "CanaryJob"
+                    ],
+                    "docker_termination_logging": false,
+                    "env": {"FOO": "bar"},
+                    "secret": null,
+                    "resources": [],
+                    "running_timeout": "PT2H"
+                  }
+            },
+            "state": {
+                "enabled": "true",
+                "next_natural_trigger": "2017-01-01T01:00:00Z",
+                "next_natural_offset_trigger": "2017-01-01T02:00:00Z"
+            }
+        }
+
 ## Workflow Instances [/{version}/workflows/{component_id}/{workflow_id}/instances{?offset,limit,tail,start,stop}]
 
 Query can be done in three different styles: `offset+limit`, `start+stop` or `tail+limit`.
@@ -331,8 +374,6 @@ returned is specified by `limit` but fewer instances may be returned even though
 
         {
             "enabled": "true",
-            "docker_image": "styx-canary-dummy:dummy",
-            "commit_sha": "f043333085fa87738ac24f04d64fb58ecc845111",
             "next_natural_trigger": "2017-01-01T01:00:00Z",
             "next_natural_offset_trigger": "2017-01-01T02:00:00Z"
         }
@@ -352,8 +393,6 @@ returned is specified by `limit` but fewer instances may be returned even though
 
         {
             "enabled": "false",
-            "docker_image": "styx-canary-dummy:dummy",
-            "commit_sha": "f043333085fa87738ac24f04d64fb58ecc845111",
             "next_natural_trigger": "2017-01-01T01:00:00Z",
             "next_natural_offset_trigger": "2017-01-01T02:00:00Z"
         }

--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -39,6 +39,7 @@ import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.WorkflowWithState;
 import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import com.spotify.styx.storage.Storage;
 import com.spotify.styx.util.ParameterUtil;
@@ -89,6 +90,9 @@ public final class WorkflowResource {
         Route.with(
             json(), "GET", BASE + "/<cid>/<wfid>",
             rc -> workflow(arg("cid", rc), arg("wfid", rc))),
+        Route.with(
+            json(), "GET", BASE + "/<cid>/<wfid>/full",
+            rc -> workflowWithState(arg("cid", rc), arg("wfid", rc))),
         Route.with(
             json(), "GET", BASE,
             rc -> workflows()),
@@ -247,6 +251,17 @@ public final class WorkflowResource {
       return Response.forPayload(storage.workflowState(workflowId));
     } catch (IOException e) {
       throw new RuntimeException("Failed to get the state of workflow " + workflowId.toKey(), e);
+    }
+  }
+
+  private Response<WorkflowWithState> workflowWithState(String componentId, String id) {
+    var workflowId = WorkflowId.create(componentId, id);
+    try {
+      return storage.workflowWithState(workflowId)
+          .map(Response::forPayload)
+          .orElse(Response.forStatus(Status.NOT_FOUND));
+    } catch (IOException e) {
+      throw new RuntimeException("Failed get workflow " + workflowId.toKey(), e);
     }
   }
 

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -826,6 +826,28 @@ public class WorkflowResourceTest extends VersionedApiTest {
     assertThat(response, hasStatus(withCode(Status.INTERNAL_SERVER_ERROR)));
   }
 
+  @Test
+  public void shouldReturnWorkflowWithState() throws Exception {
+    sinceVersion(Api.Version.V3);
+
+    storage.storeWorkflow(Workflow.create("other_component", WORKFLOW_CONFIGURATION));
+
+    var response = awaitResponse(serviceHelper.request("GET", path("/foo/bar/full")));
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertJson(response, "workflow.component_id", is("foo"));
+    assertJson(response, "state.enabled", is(false));
+  }
+
+  @Test
+  public void shouldReturn404WhenWorkflowWithStateNotFound() throws Exception {
+    sinceVersion(Api.Version.V3);
+
+    var response = awaitResponse(serviceHelper.request("GET", path("/example/workflow/full")));
+
+    assertThat(response, hasStatus(withCode(Status.NOT_FOUND)));
+  }
+
   private long ms(String time) {
     return Instant.parse("2016-08-10T" + time + "Z").toEpochMilli();
   }

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -848,6 +848,18 @@ public class WorkflowResourceTest extends VersionedApiTest {
     assertThat(response, hasStatus(withCode(Status.NOT_FOUND)));
   }
 
+  @Test
+  public void shouldFailToReturnWorkflowWithState() throws Exception {
+    sinceVersion(Api.Version.V3);
+
+    when(storage.workflowWithState(WorkflowId.create("foo", "bar"))).thenThrow(new IOException());
+
+    Response<ByteString> response = awaitResponse(
+        serviceHelper.request("GET", path("/foo/bar/full")));
+
+    assertThat(response, hasStatus(withCode(Status.INTERNAL_SERVER_ERROR)));
+  }
+
   private long ms(String time) {
     return Instant.parse("2016-08-10T" + time + "Z").toEpochMilli();
   }

--- a/styx-cli-unshaded/src/main/java/com/spotify/styx/cli/CliMain.java
+++ b/styx-cli-unshaded/src/main/java/com/spotify/styx/cli/CliMain.java
@@ -72,7 +72,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import javaslang.Tuple;
@@ -609,17 +608,12 @@ public final class CliMain {
   }
 
   private void workflowShow() throws ExecutionException, InterruptedException {
-    final String component = namespace.getString(parser.workflowShowComponentId.getDest());
-    final String workflow = namespace.getString(parser.workflowShowWorkflowId.getDest());
+    var component = namespace.getString(parser.workflowShowComponentId.getDest());
+    var workflow = namespace.getString(parser.workflowShowWorkflowId.getDest());
 
-    final CompletableFuture<Workflow> workflowFuture =
-        styxClient.workflow(component, workflow).toCompletableFuture();
-    final CompletableFuture<WorkflowState> workflowStateFuture =
-        styxClient.workflowState(component, workflow).toCompletableFuture();
-
-    final Tuple2<Workflow, WorkflowState> tuple =
-        workflowFuture.thenCombine(workflowStateFuture, Tuple::of).toCompletableFuture().get();
-    cliOutput.printWorkflow(tuple._1, tuple._2);
+    var workflowWithStateFuture =
+        styxClient.workflowWithState(component, workflow).toCompletableFuture().get();
+    cliOutput.printWorkflow(workflowWithStateFuture.workflow(), workflowWithStateFuture.state());
   }
 
   private void workflowList() throws ExecutionException, InterruptedException {

--- a/styx-cli-unshaded/src/main/java/com/spotify/styx/cli/JsonCliOutput.java
+++ b/styx-cli-unshaded/src/main/java/com/spotify/styx/cli/JsonCliOutput.java
@@ -29,9 +29,9 @@ import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Resource;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.WorkflowWithState;
 import com.spotify.styx.model.data.EventInfo;
 import com.spotify.styx.serialization.Json;
-import io.norberg.automatter.AutoMatter;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -86,7 +86,7 @@ class JsonCliOutput implements CliOutput {
 
   @Override
   public void printWorkflow(Workflow workflow, WorkflowState state) {
-    printJson(WorkflowWithState.of(workflow, state));
+    printJson(WorkflowWithState.create(workflow, state));
   }
 
   @Override
@@ -97,20 +97,5 @@ class JsonCliOutput implements CliOutput {
   @Override
   public void printError(String message) {
     System.err.println(message);
-  }
-
-  @AutoMatter
-  interface WorkflowWithState {
-
-    Workflow workflow();
-
-    WorkflowState state();
-
-    static WorkflowWithState of(Workflow workflow, WorkflowState state) {
-      return new WorkflowWithStateBuilder()
-          .workflow(workflow)
-          .state(state)
-          .build();
-    }
   }
 }

--- a/styx-cli-unshaded/src/test/java/com/spotify/styx/cli/CliMainTest.java
+++ b/styx-cli-unshaded/src/test/java/com/spotify/styx/cli/CliMainTest.java
@@ -54,6 +54,7 @@ import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.WorkflowWithState;
 import com.spotify.styx.serialization.Json;
 import com.spotify.styx.util.WorkflowValidator;
 import java.io.File;
@@ -128,6 +129,16 @@ public class CliMainTest {
   }
 
   @Test
+  public void testWorkflowShow() {
+    var payload = mock(WorkflowWithState.class);
+    when(client.workflowWithState("foo", "bar"))
+        .thenReturn(CompletableFuture.completedFuture(payload));
+    CliMain.run(cliContext, "workflow", "show", "foo", "bar");
+    verify(client).workflowWithState("foo", "bar");
+    verify(cliOutput).printWorkflow(payload.workflow(), payload.state());
+  }
+
+  @Test
   public void testWorkflowCreate() throws Exception {
     final String component = "quux";
 
@@ -186,7 +197,6 @@ public class CliMainTest {
     verify(cliOutput).printError(contains(
         "Workflow configuration doesn't conform to the expected structure, "));
   }
-
 
   @Test
   public void testWorkflowCreateInvalid() throws Exception {

--- a/styx-cli-unshaded/src/test/java/com/spotify/styx/cli/JsonCliOutputTest.java
+++ b/styx-cli-unshaded/src/test/java/com/spotify/styx/cli/JsonCliOutputTest.java
@@ -28,9 +28,7 @@ import static org.junit.Assert.assertThat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.spotify.styx.api.BackfillPayload;
 import com.spotify.styx.api.RunStateDataPayload;
-import com.spotify.styx.api.RunStateDataPayload.RunStateData;
-import com.spotify.styx.cli.JsonCliOutput.WorkflowWithState;
-import com.spotify.styx.model.Backfill;
+import com.spotify.styx.api.RunStateDataPayload.RunStateData;import com.spotify.styx.model.Backfill;
 import com.spotify.styx.model.Schedule;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowConfiguration;
@@ -38,6 +36,7 @@ import com.spotify.styx.model.WorkflowConfiguration.Secret;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.WorkflowWithState;
 import com.spotify.styx.state.StateData;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -183,7 +182,6 @@ public class JsonCliOutputTest {
         .build();
     cliOutput.printWorkflow(workflow, state);
     assertThat(OBJECT_MAPPER.readValue(outContent.toString(), WorkflowWithState.class),
-        is(WorkflowWithState.of(workflow, state)));
+        is(WorkflowWithState.create(workflow, state)));
   }
-
 }

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxOkHttpClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxOkHttpClient.java
@@ -45,6 +45,7 @@ import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.WorkflowWithState;
 import com.spotify.styx.model.data.EventInfo;
 import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import com.spotify.styx.serialization.Json;
@@ -204,6 +205,11 @@ class StyxOkHttpClient implements StyxClient {
   public CompletionStage<WorkflowState> workflowState(String componentId, String workflowId) {
     return execute(forUri(urlBuilder("workflows", componentId, workflowId, "state")),
                    WorkflowState.class);
+  }
+
+  @Override
+  public CompletionStage<WorkflowWithState> workflowWithState(String componentId, String workflowId) {
+    return execute(forUri(urlBuilder("workflows", componentId, workflowId, "full")), WorkflowWithState.class);
   }
 
   @Override

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxWorkflowClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxWorkflowClient.java
@@ -23,6 +23,7 @@ package com.spotify.styx.client;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.WorkflowWithState;
 import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -81,6 +82,15 @@ public interface StyxWorkflowClient extends AutoCloseable {
    * @return the {@link WorkflowState}
    */
   CompletionStage<WorkflowState> workflowState(String componentId, String workflowId);
+
+  /**
+   * Get a {@link WorkflowWithState}
+   *
+   * @param componentId component id
+   * @param workflowId  workflow id
+   * @return the {@link WorkflowWithState}
+   */
+  CompletionStage<WorkflowWithState> workflowWithState(String componentId, String workflowId);
 
   /**
    * Get execution data of an instance of a {@link Workflow}

--- a/styx-client/src/test/java/com/spotify/styx/client/StyxOkHttpClientTest.java
+++ b/styx-client/src/test/java/com/spotify/styx/client/StyxOkHttpClientTest.java
@@ -63,6 +63,7 @@ import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.WorkflowWithState;
 import com.spotify.styx.model.data.EventInfo;
 import com.spotify.styx.model.data.WorkflowInstanceExecutionData;
 import com.spotify.styx.serialization.Json;
@@ -368,6 +369,21 @@ public class StyxOkHttpClientTest {
     assertThat(request.url().toString(), is(uri.toString()));
     assertThat(request.method(), is("GET"));
     assertThat(r.join(), is(WorkflowState.empty()));
+  }
+
+  @Test
+  public void shouldGetWorkflowWithState() throws Exception {
+    var workflowWithState = WorkflowWithState.create(WORKFLOW_1, WorkflowState.empty());
+    when(client.send(any(Request.class)))
+        .thenReturn(CompletableFuture.completedFuture(response(HTTP_OK, workflowWithState)));
+    var r = styx.workflowWithState("component", "workflow").toCompletableFuture();
+    verify(client, timeout(30_000)).send(requestCaptor.capture());
+    assertThat(r.isDone(), is(true));
+    var request = requestCaptor.getValue();
+    var uri = URI.create(API_URL + "/workflows/component/workflow/full");
+    assertThat(request.url().toString(), is(uri.toString()));
+    assertThat(request.method(), is("GET"));
+    assertThat(r.join(), is(workflowWithState));
   }
 
   @Test


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
With the new model, we can make one single API call to get both workflow and its state.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To save some traffic and make it more handy to script.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [x] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
