### PR TITLE
Get workflows by componentId method in java client

### DIFF
--- a/styx-client/src/main/java/com/spotify/styx/client/StyxOkHttpClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxOkHttpClient.java
@@ -177,6 +177,12 @@ class StyxOkHttpClient implements StyxClient {
   }
 
   @Override
+  public CompletionStage<List<Workflow>> workflows(String componentId) {
+    return execute(forUri(urlBuilder("workflows", componentId)), Workflow[].class)
+        .thenApply(Arrays::asList);
+  }
+
+  @Override
   public CompletionStage<List<Workflow>> workflows() {
     return execute(forUri(urlBuilder("workflows")), Workflow[].class)
         .thenApply(Arrays::asList);

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxWorkflowClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxWorkflowClient.java
@@ -42,6 +42,13 @@ public interface StyxWorkflowClient extends AutoCloseable {
   CompletionStage<Workflow> workflow(String componentId, String workflowId);
 
   /**
+   * Get all {@link Workflow}s of a component
+   *
+   * @return all {@link Workflow}s of the given component
+   */
+  CompletionStage<List<Workflow>> workflows(String componentId);
+
+  /**
    * Get all {@link Workflow}s
    *
    * @return all {@link Workflow}s

--- a/styx-client/src/test/java/com/spotify/styx/client/StyxOkHttpClientTest.java
+++ b/styx-client/src/test/java/com/spotify/styx/client/StyxOkHttpClientTest.java
@@ -195,6 +195,23 @@ public class StyxOkHttpClientTest {
   }
 
   @Test
+  public void shouldGetAllWorkflowsOfAComponent() throws Exception {
+    final List<Workflow> workflows = Arrays.asList(WORKFLOW_1, WORKFLOW_2);
+    when(client.send(any(Request.class)))
+        .thenReturn(CompletableFuture.completedFuture(response(HTTP_OK, workflows)));
+    final String componentId = WORKFLOW_1.componentId();
+    final CompletableFuture<List<Workflow>> r = styx.workflows(componentId).toCompletableFuture();
+    verify(client, timeout(30_000)).send(requestCaptor.capture());
+    assertThat(r.isDone(), is(true));
+    final Request request = requestCaptor.getValue();
+    final HttpUrl url = API_URL.newBuilder().addPathSegment("workflows")
+        .addPathSegment(componentId).build();
+    assertThat(request.url().toString(), is(url.uri().toString()));
+    assertThat(request.method(), is("GET"));
+    assertThat(r.join(), is(workflows));
+  }
+
+  @Test
   public void shouldGetBackfill() throws Exception {
     final BackfillPayload payload = BackfillPayload.create(BACKFILL, Optional.empty());
     when(client.send(any(Request.class)))


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Add a client method to get all workflows for a component.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To have a more complete API and the user will not have to do filtering per component id on their end.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Added a unit test

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
