### PR TITLE
Rewatch

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -99,6 +99,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link DockerRunner} implementation that submits container executions to a Kubernetes cluster.
@@ -753,9 +754,26 @@ class KubernetesDockerRunner implements DockerRunner {
       emitPodEvents(pod, runState.get());
     }
 
+    private void reconnect() {
+      LOG.warn("Re-establishing pod watcher");
+
+      try {
+        watch = client.pods()
+            .watch(this);
+      } catch (Throwable e) {
+        LOG.warn("Retry threw", e);
+        scheduleReconnect();
+      }
+    }
+
+    private void scheduleReconnect() {
+      scheduledExecutor.schedule(this::reconnect, RECONNECT_DELAY_SECONDS, TimeUnit.SECONDS);
+    }
+
     @Override
     public void onClose(KubernetesClientException e) {
       LOG.warn("Watch closed", e);
+      scheduleReconnect();
     }
   }
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
This reverts https://github.com/spotify/styx/pull/734

There are cases that fabric8 won't reconnect on itself, e.g. in case of `HTTP_GONE`.

There was [an attempted fix](https://github.com/fabric8io/kubernetes-client/pull/1800) in upstream, but eventually got rolled back because it broke the contract.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
