### PR TITLE
flexible retry alt

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ secret:
   name: my-secret
   mount_path: /etc/my-keys
 service_account: my-service-account@my-project.iam.gserviceaccount.com
+running_timeout: PT2H
+retry_condition: #exitCode == 1 && (#tries < 3 || #consecutiveFailures < 4) && #triggerType == "natural"
 ```
 
 #### `id` **[string]**
@@ -214,6 +216,19 @@ Custom environment variables to be injected into running container.
 #### `running_timeout` **[string]**
 An [ISO 8601 Duration] specification for timing out container execution. Defaults to 24 hours that also
 serves as the upper boundary.
+
+#### `retry_condition` **[string]**
+A [SpEL](https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#expressions) boolean expression.
+If the expression evaluates to `false`, Styx will stop retrying and halt the workflow instance immediately. This
+configuration has no impact on possible max number of tries, meaning it can only be used to halt workflow instance
+earlier.
+
+The following variables will be injected by Styx so that they can be used in the expression:
+* \#exitCode: the exit code from the last execution
+* \#tries: total number of tries, which equals to `1` when the first time a workflow instance gets executed and `2` when
+  the first retry is issued
+* \#consecutiveFailures: total number of consecutive failures that is not `missing dependency`
+* \#triggerType: `natural`, `backfill` or `ad-hoc`
 
 ### Triggering and executions
 

--- a/doc/api.apib
+++ b/doc/api.apib
@@ -130,7 +130,8 @@ or updated. Note that a non-null value is required for docker_image.
           "secret": null,
           "service_account": null,
           "resources": [],
-          "running_timeout": "PT2H"
+          "running_timeout": "PT2H",
+          "retry_condition": "#tries < 3"
         }
 
 + Response 200 (application/json)
@@ -155,7 +156,8 @@ or updated. Note that a non-null value is required for docker_image.
             "secret": null,
             "service_account": null,
             "resources": [],
-            "running_timeout": "PT2H"
+            "running_timeout": "PT2H",
+            "retry_condition": "#tries < 3"
           },
           "__from_api": "V3"
         }
@@ -192,7 +194,8 @@ or updated. Note that a non-null value is required for docker_image.
                 "env": {"FOO": "bar"},
                 "secret": null,
                 "resources": [],
-                "running_timeout": "PT2H"
+                "running_timeout": "PT2H",
+                "retry_condition": "#tries < 3"
               }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,11 @@
         <artifactId>config</artifactId>
         <version>1.3.3</version>
       </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-expression</artifactId>
+        <version>5.2.2.RELEASE</version>
+      </dependency>
 
       <!-- tracing -->
       <dependency>

--- a/styx-common/pom.xml
+++ b/styx-common/pom.xml
@@ -83,6 +83,10 @@
       <artifactId>google-api-client</artifactId>
       <version>1.28.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
+    </dependency>
 
     <!-- test deps -->
     <dependency>

--- a/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
+++ b/styx-common/src/main/java/com/spotify/styx/model/WorkflowConfiguration.java
@@ -67,6 +67,8 @@ public interface WorkflowConfiguration {
 
   Optional<Duration> runningTimeout();
 
+  Optional<String> retryCondition();
+
   default Instant addOffset(Instant next) {
     final String offset = offset().orElseGet(this::defaultOffset);
 

--- a/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
+++ b/styx-common/src/main/java/com/spotify/styx/testdata/TestData.java
@@ -137,6 +137,7 @@ public final class TestData {
           .dockerArgs(List.of("x", "y"))
           .secret(Secret.create("name", "/path"))
           .serviceAccount("foo@bar.baz.quux")
+          .retryCondition("#exitCode == 1 && (#tries < 3 || #consecutiveFailures < 4) && #triggerType == \"natural\"")
           .build();
 
   public static final WorkflowConfiguration HOURLY_WORKFLOW_CONFIGURATION_WITH_RESOURCES_RUNNING_TIMEOUT =

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -374,7 +374,7 @@ public class StyxScheduler implements AppInit {
     // These output handlers will be invoked in order.
     var outputHandlers = OutputHandler.tracing(List.of(
         new DockerRunnerHandler(dockerRunner),
-        new TerminationHandler(retryUtil),
+        new TerminationHandler(retryUtil, workflowCache),
         new MonitoringHandler(stats),
         new ExecutionDescriptionHandler(storage, workflowValidator),
         // Emit timeouts last in order to not over-eagerly time out an instance that

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TerminationHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TerminationHandler.java
@@ -136,7 +136,7 @@ public class TerminationHandler implements OutputHandler {
 
     var workflow = workflows.get().get(state.workflowInstance().workflowId());
     if (workflow == null) {
-      LOG.debug("Workflow {} does not exist possibly due to stale caching",
+      LOG.debug("Workflow {} does not exist possibly due to stale workflow cache",
           state.workflowInstance().workflowId().toKey());
       return false;
     }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TerminationHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/TerminationHandler.java
@@ -136,8 +136,9 @@ public class TerminationHandler implements OutputHandler {
 
     var workflow = workflows.get().get(state.workflowInstance().workflowId());
     if (workflow == null) {
-      LOG.info("Workflow {} does not exist", state.workflowInstance().workflowId().toKey());
-      return true;
+      LOG.debug("Workflow {} does not exist possibly due to stale caching",
+          state.workflowInstance().workflowId().toKey());
+      return false;
     }
 
     return workflow.configuration().retryCondition()

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/TerminationHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/TerminationHandlerTest.java
@@ -20,23 +20,37 @@
 
 package com.spotify.styx.state.handlers;
 
+import static com.spotify.styx.model.Schedule.HOURS;
 import static com.spotify.styx.state.RunState.State.FAILED;
 import static com.spotify.styx.state.RunState.State.TERMINATED;
 import static com.spotify.styx.state.handlers.TerminationHandler.MAX_RETRY_COST;
+import static com.spotify.styx.testdata.TestData.HOURLY_WORKFLOW_CONFIGURATION;
+import static com.spotify.styx.testdata.TestData.VALID_SHA;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.spotify.styx.model.Event;
+import com.spotify.styx.model.Workflow;
+import com.spotify.styx.model.WorkflowConfiguration;
+import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.state.EventRouter;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateData;
+import com.spotify.styx.state.Trigger;
 import com.spotify.styx.testdata.TestData;
 import com.spotify.styx.util.RetryUtil;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,15 +65,27 @@ public class TerminationHandlerTest {
 
   @Mock EventRouter eventRouter;
   @Mock RetryUtil retryUtil;
+  @Mock private Supplier<Map<WorkflowId, Workflow>> workflows;
 
   private TerminationHandler terminationHandler;
 
+  private static final Workflow WORKFLOW =
+      Workflow.create(TestData.WORKFLOW_ID.componentId(), HOURLY_WORKFLOW_CONFIGURATION);
+  private static final Workflow WORKFLOW_WITH_RETRY_CONDITION =
+      Workflow.create(TestData.WORKFLOW_ID.componentId(), WorkflowConfiguration.builder()
+          .id("styx.TestEndpoint")
+          .commitSha(VALID_SHA)
+          .dockerImage("busybox")
+          .schedule(HOURS)
+          .retryCondition("#exitCode == 1")
+          .build());
   private static final WorkflowInstance WORKFLOW_INSTANCE =
       WorkflowInstance.create(TestData.WORKFLOW_ID, "2016-04-04");
 
   @Before
   public void setUp() {
-    terminationHandler = new TerminationHandler(retryUtil);
+    when(workflows.get()).thenReturn(Map.of(WORKFLOW.id(), WORKFLOW));
+    terminationHandler = new TerminationHandler(retryUtil, workflows);
   }
 
   @Test
@@ -126,11 +152,112 @@ public class TerminationHandlerTest {
   }
 
   @Test
-  public void shouldFailOnFailFastExitCodeReceived() {
-    StateData data = data(1, 1.0, Optional.of(50));
-    RunState maxedTerm = RunState.create(WORKFLOW_INSTANCE, FAILED, data, NOW, COUNTER);
-    terminationHandler.transitionInto(maxedTerm, eventRouter);
+  public void shouldStopOnFailFastExitCodeReceived() {
+    var data = data(1, 1.0, Optional.of(50));
+    var failed = RunState.create(WORKFLOW_INSTANCE, FAILED, data, NOW, COUNTER);
+    terminationHandler.transitionInto(failed, eventRouter);
     verify(eventRouter).receiveIgnoreClosed(Event.stop(WORKFLOW_INSTANCE), COUNTER);
+  }
+
+  @Test
+  public void shouldStopOnWorkflowNotFound() {
+    var data = data(1, 1.0, Optional.empty());
+    var failed = RunState.create(WORKFLOW_INSTANCE, FAILED, data, NOW, COUNTER);
+    when(workflows.get()).thenReturn(Map.of());
+    terminationHandler.transitionInto(failed, eventRouter);
+    verify(eventRouter).receiveIgnoreClosed(Event.stop(WORKFLOW_INSTANCE), COUNTER);
+  }
+
+  @Test
+  public void shouldScheduleRetryOnRetryConditionMet() {
+    var data = data(1, 1.0, Optional.of(1));
+    var nonZeroTerm = RunState.create(WORKFLOW_INSTANCE, TERMINATED, data, NOW, COUNTER);
+    Duration expectedDelay = Duration.ofMillis(4711);
+    when(retryUtil.calculateDelay(anyInt())).thenReturn(expectedDelay);
+    when(workflows.get()).thenReturn(Map.of(WORKFLOW_WITH_RETRY_CONDITION.id(), WORKFLOW_WITH_RETRY_CONDITION));
+    terminationHandler.transitionInto(nonZeroTerm, eventRouter);
+    verify(eventRouter).receiveIgnoreClosed(Event.retryAfter(WORKFLOW_INSTANCE, expectedDelay.toMillis()), COUNTER);
+  }
+
+  @Test
+  public void shouldStopOnRetryConditionNotMet() {
+    var data = data(1, 1.0, Optional.of(2));
+    var nonZeroTerm = RunState.create(WORKFLOW_INSTANCE, TERMINATED, data, NOW, COUNTER);
+    when(workflows.get()).thenReturn(Map.of(WORKFLOW_WITH_RETRY_CONDITION.id(), WORKFLOW_WITH_RETRY_CONDITION));
+    terminationHandler.transitionInto(nonZeroTerm, eventRouter);
+    verify(eventRouter).receiveIgnoreClosed(Event.stop(WORKFLOW_INSTANCE), COUNTER);
+  }
+
+  @Test(timeout = 1000)
+  public void shouldEvaluateToTrueUnderMultiThreadEnv() {
+    var forkJoinPool = new ForkJoinPool(32);
+    var results = forkJoinPool.submit(() -> IntStream.range(0, 10000)
+        .parallel()
+        .mapToObj(i -> terminationHandler.retryConditionMet(
+            RunState.create(WORKFLOW_INSTANCE, FAILED,
+                StateData.newBuilder()
+                    .tries(3)
+                    .consecutiveFailures(2)
+                    .trigger(Trigger.natural())
+                    .build()),
+            Optional.of(1),
+            "#exitCode == 1 && (#tries < 3 || #consecutiveFailures < 4) && #triggerType == \"natural\"")))
+        .join()
+        .collect(toList());
+    forkJoinPool.shutdownNow();
+    results.forEach(result -> assertThat(result, is(true)));
+  }
+
+  @Test
+  public void shouldFailToParse() {
+    var result = terminationHandler.retryConditionMet(
+        RunState.create(WORKFLOW_INSTANCE, FAILED,
+            StateData.zero()),
+        Optional.of(1),
+        "foo -> bar");
+    assertThat(result, is(false));
+  }
+
+  @Test
+  public void shouldFailToEvaluate() {
+    var result = terminationHandler.retryConditionMet(
+        RunState.create(WORKFLOW_INSTANCE, FAILED,
+            StateData.zero()),
+        Optional.of(1),
+        "\"foo\"");
+    assertThat(result, is(false));
+  }
+
+  @Test
+  public void shouldEvaluateToFalseWhenMissingExitCode() {
+    var result = terminationHandler.retryConditionMet(
+        RunState.create(WORKFLOW_INSTANCE, FAILED,
+            StateData.zero()),
+        Optional.empty(),
+        "#exitCode == 1");
+    assertThat(result, is(false));
+  }
+
+  @Test
+  public void shouldEvaluateToFalseWhenMissingTriggerType() {
+    var result = terminationHandler.retryConditionMet(
+        RunState.create(WORKFLOW_INSTANCE, FAILED,
+            StateData.newBuilder()
+                .tries(3)
+                .consecutiveFailures(2)
+                .build()),
+        Optional.of(1),
+        "#exitCode == 1 && (#tries < 3 || #consecutiveFailures < 4) && #triggerType == \"natural\"");
+    assertThat(result, is(false));
+  }
+
+  @Test
+  public void shouldEvaluateToFalseIfRetryConditionIsNotBooleanExpression() {
+    var result = terminationHandler.retryConditionMet(
+        RunState.create(WORKFLOW_INSTANCE, FAILED, StateData.zero()),
+        Optional.of(1),
+        "21 * 2");
+    assertThat(result, is(false));
   }
 
   private StateData data(int tries, double cost, Optional<Integer> lastExit) {


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Alternative of #783 

A [SpEL](https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#expressions) boolean expression.
If the expression evaluates to `false`, Styx will stop retrying and halt the workflow instance immediately. This
configuration has no impact on possible max number of tries, meaning it can only be used to halt workflow instance
earlier.

The following variables will be injected by Styx so that they can be used in the expression:
* \#exitCode: the exit code from the last execution
* \#tries: total number of tries, which equals to `1` when the first time a workflow instance gets executed and `2` when
  the first retry is issued
* \#consecutiveFailures: total number of consecutive failures that is not `missing dependency`
* \#triggerType: `natural`, `backfill` or `ad-hoc`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users want to have flexible retry condition. This PR exposes parameters impacting retry and gives users mechanism to have their own retry policy.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [x] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
