### PR TITLE
No backfill trigger or scheduling if disabled

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
@@ -117,6 +117,16 @@ class BackfillTriggerManager {
   private void tick0() {
     final Instant t0 = time.get();
 
+    try {
+      if (!storage.config().globalEnabled()) {
+        LOG.info("Triggering has been disabled globally.");
+        return;
+      }
+    } catch (IOException e) {
+      LOG.warn("Couldn't fetch global enabled status, skipping this run", e);
+      return;
+    }
+
     final List<Backfill> backfills;
     try {
       backfills = storage.backfills(false);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -147,7 +147,7 @@ public class Scheduler {
     try {
       resources = storage.resources().stream().collect(toMap(Resource::id, identity()));
       config = storage.config();
-      if (!storage.config().globalEnabled()) {
+      if (!config.globalEnabled()) {
         LOG.info("Scheduling has been disabled globally.");
         return;
       }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -91,6 +91,8 @@ import org.slf4j.LoggerFactory;
  */
 public class Scheduler {
 
+  private static final Logger LOG = LoggerFactory.getLogger(Scheduler.class);
+
   private static final String TICK_TYPE = UPPER_CAMEL.to(LOWER_UNDERSCORE,
       Scheduler.class.getSimpleName());
 
@@ -138,6 +140,16 @@ public class Scheduler {
 
   private void tick0() {
     final Instant t0 = time.get();
+
+    try {
+      if (!storage.config().globalEnabled()) {
+        LOG.info("Scheduling has been disabled globally.");
+        return;
+      }
+    } catch (IOException e) {
+      LOG.warn("Couldn't fetch global enabled status, skipping this run", e);
+      return;
+    }
 
     final Map<String, Resource> resources;
     final Optional<Long> globalConcurrency;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -145,13 +145,13 @@ public class Scheduler {
     final Optional<Long> globalConcurrency;
     final StyxConfig config;
     try {
-      resources = storage.resources().stream().collect(toMap(Resource::id, identity()));
       config = storage.config();
       if (!config.globalEnabled()) {
         LOG.info("Scheduling has been disabled globally.");
         return;
       }
       globalConcurrency = config.globalConcurrency();
+      resources = storage.resources().stream().collect(toMap(Resource::id, identity()));
     } catch (IOException e) {
       log.warn("Failed to read from storage", e);
       return;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -141,25 +141,19 @@ public class Scheduler {
   private void tick0() {
     final Instant t0 = time.get();
 
-    try {
-      if (!storage.config().globalEnabled()) {
-        LOG.info("Scheduling has been disabled globally.");
-        return;
-      }
-    } catch (IOException e) {
-      LOG.warn("Couldn't fetch global enabled status, skipping this run", e);
-      return;
-    }
-
     final Map<String, Resource> resources;
     final Optional<Long> globalConcurrency;
     final StyxConfig config;
     try {
       resources = storage.resources().stream().collect(toMap(Resource::id, identity()));
       config = storage.config();
+      if (!storage.config().globalEnabled()) {
+        LOG.info("Scheduling has been disabled globally.");
+        return;
+      }
       globalConcurrency = config.globalConcurrency();
     } catch (IOException e) {
-      log.warn("Failed to get resource limits", e);
+      log.warn("Failed to read from storage", e);
       return;
     }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/BackfillTriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/BackfillTriggerManagerTest.java
@@ -210,6 +210,13 @@ public class BackfillTriggerManagerTest {
   }
 
   @Test
+  public void shouldNotTriggerExecutionWhenFailedToReadConfig() throws IOException {
+    when(storage.config()).thenThrow(new IOException());
+    backfillTriggerManager.tick();
+    verify(storage, never()).backfills(anyBoolean());
+  }
+
+  @Test
   public void shouldTriggerBackfillsNew() throws IOException {
     final Workflow workflow = createWorkflow(WORKFLOW_ID1);
     initWorkflow(workflow);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -181,14 +181,14 @@ public class SchedulerTest {
   public void shouldNotScheduleExecutionOnDisabledGlobally() throws IOException {
     when(config.globalEnabled()).thenReturn(false);
     scheduler.tick();
-    verify(storage, never()).backfills(anyBoolean());
+    verify(storage, never()).listActiveInstances();
   }
 
   @Test
   public void shouldNotScheduleExecutionWhenFailedToReadConfig() throws IOException {
     when(storage.config()).thenThrow(new IOException());
     scheduler.tick();
-    verify(storage, never()).backfills(anyBoolean());
+    verify(storage, never()).listActiveInstances();
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -23,9 +23,10 @@ package com.spotify.styx;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -62,6 +63,7 @@ import com.spotify.styx.util.CounterCapacityException;
 import com.spotify.styx.util.EventUtil;
 import com.spotify.styx.util.ShardedCounter;
 import com.spotify.styx.util.Time;
+import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -128,6 +130,7 @@ public class SchedulerTest {
 
     when(storage.resources()).thenReturn(resourceLimits);
     when(config.globalConcurrency()).thenReturn(Optional.empty());
+    when(config.globalEnabled()).thenReturn(true);
     when(storage.config()).thenReturn(config);
 
     when(resourceDecorator.decorateResources(
@@ -172,6 +175,13 @@ public class SchedulerTest {
             .schedule(Schedule.HOURS)
             .resources(resources)
             .build());
+  }
+
+  @Test
+  public void shouldNotScheduleExecutionOnDisabledGlobally() throws IOException {
+    when(config.globalEnabled()).thenReturn(false);
+    scheduler.tick();
+    verify(storage, never()).backfills(anyBoolean());
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -24,7 +24,6 @@ import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/SchedulerTest.java
@@ -185,6 +185,13 @@ public class SchedulerTest {
   }
 
   @Test
+  public void shouldNotScheduleExecutionWhenFailedToReadConfig() throws IOException {
+    when(storage.config()).thenThrow(new IOException());
+    scheduler.tick();
+    verify(storage, never()).backfills(anyBoolean());
+  }
+
+  @Test
   public void shouldBeRateLimiting() {
     when(rateLimiter.acquire()).thenReturn(1.0);
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
@@ -153,6 +153,14 @@ public class TriggerManagerTest {
   }
 
   @Test
+  public void shouldNotTriggerExecutionWhenFailedToReadConfig() throws IOException {
+    when(storage.config()).thenThrow(new IOException());
+    triggerManager.tick();
+    verify(triggerListener, never()).event(any(), any(), any(), any());
+    verify(storage, never()).updateNextNaturalTrigger(any(), any());
+  }
+
+  @Test
   public void shouldNotUpdateNextNaturalTriggerIfTriggerListenerThrows() throws Exception {
     setupWithNextNaturalTrigger(true, parse("2016-10-01T00:00:00Z"));
     doThrow(new RuntimeException()).when(triggerListener).event(any(), any(), any(), any());

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
@@ -79,6 +79,7 @@ public class TriggerManagerTest {
 
   @Before
   public void setUp() throws IOException {
+    when(config.globalEnabled()).thenReturn(true);
     when(storage.config()).thenReturn(config);
     triggerManager = new TriggerManager(triggerListener, MANAGER_TIME, storage, Stats.NOOP);
   }
@@ -185,7 +186,6 @@ public class TriggerManagerTest {
   }
 
   private void setupWithNextNaturalTrigger(boolean enabled, Instant nextNaturalTrigger) throws IOException {
-    when(config.globalEnabled()).thenReturn(true);
     if (enabled) {
       when(storage.enabled()).thenReturn(ImmutableSet.of(WORKFLOW_DAILY.id()));
     } else {


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
If global enabled flag is false, stop triggering backfills and scheduling.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This would come handy when applying maintenance work.

Natural trigger should be OK if not beginning of an hour; backfills shouldn't be a lot; however stop
scheduling in this way might cause a big backlog if stopping too long.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
