### PR TITLE
No backfill trigger and back to queue if disabled

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/BackfillTriggerManager.java
@@ -117,6 +117,16 @@ class BackfillTriggerManager {
   private void tick0() {
     final Instant t0 = time.get();
 
+    try {
+      if (!storage.config().globalEnabled()) {
+        LOG.info("Triggering has been disabled globally.");
+        return;
+      }
+    } catch (IOException e) {
+      LOG.warn("Couldn't fetch global enabled status, skipping this run", e);
+      return;
+    }
+
     final List<Backfill> backfills;
     try {
       backfills = storage.backfills(false);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/BackfillTriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/BackfillTriggerManagerTest.java
@@ -210,6 +210,13 @@ public class BackfillTriggerManagerTest {
   }
 
   @Test
+  public void shouldNotTriggerExecutionWhenFailedToReadConfig() throws IOException {
+    when(storage.config()).thenThrow(new IOException());
+    backfillTriggerManager.tick();
+    verify(storage, never()).backfills(anyBoolean());
+  }
+
+  @Test
   public void shouldTriggerBackfillsNew() throws IOException {
     final Workflow workflow = createWorkflow(WORKFLOW_ID1);
     initWorkflow(workflow);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
@@ -153,6 +153,14 @@ public class TriggerManagerTest {
   }
 
   @Test
+  public void shouldNotTriggerExecutionWhenFailedToReadConfig() throws IOException {
+    when(storage.config()).thenThrow(new IOException());
+    triggerManager.tick();
+    verify(triggerListener, never()).event(any(), any(), any(), any());
+    verify(storage, never()).updateNextNaturalTrigger(any(), any());
+  }
+
+  @Test
   public void shouldNotUpdateNextNaturalTriggerIfTriggerListenerThrows() throws Exception {
     setupWithNextNaturalTrigger(true, parse("2016-10-01T00:00:00Z"));
     doThrow(new RuntimeException()).when(triggerListener).event(any(), any(), any(), any());

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/TriggerManagerTest.java
@@ -79,6 +79,7 @@ public class TriggerManagerTest {
 
   @Before
   public void setUp() throws IOException {
+    when(config.globalEnabled()).thenReturn(true);
     when(storage.config()).thenReturn(config);
     triggerManager = new TriggerManager(triggerListener, MANAGER_TIME, storage, Stats.NOOP);
   }
@@ -185,7 +186,6 @@ public class TriggerManagerTest {
   }
 
   private void setupWithNextNaturalTrigger(boolean enabled, Instant nextNaturalTrigger) throws IOException {
-    when(config.globalEnabled()).thenReturn(true);
     if (enabled) {
       when(storage.enabled()).thenReturn(ImmutableSet.of(WORKFLOW_DAILY.id()));
     } else {


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
If global enabled flag is false, stop triggering backfills. Scheduling is stopped effectively by sending instances back to queue.

Alternative of https://github.com/spotify/styx/pull/814

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This would come handy when applying maintenance work.

Natural trigger should be OK if not beginning of an hour; backfills shouldn't be a lot; randomized delay could smear out big backlog.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
