### PR TITLE
track service account cleanup rate

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -113,7 +113,7 @@ public interface DockerRunner extends Closeable {
                                  String styxEnvironment,
                                  Set<String> secretWhitelist) {
     final KubernetesGCPServiceAccountSecretManager serviceAccountSecretManager =
-        new KubernetesGCPServiceAccountSecretManager(kubernetesClient, serviceAccountKeyManager);
+        new KubernetesGCPServiceAccountSecretManager(kubernetesClient, serviceAccountKeyManager, stats);
     final KubernetesDockerRunner dockerRunner =
         new KubernetesDockerRunner(id, kubernetesClient, stateManager, stats,
             serviceAccountSecretManager, debug, styxEnvironment, secretWhitelist);

--- a/styx-service-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
@@ -174,6 +174,9 @@ public final class MetricsStats implements Stats {
   static final MetricId COUNTER_CACHE_RATE = BASE
       .tagged("what", "counter-cache-rate");
 
+  static final MetricId SERVICE_ACCOUNT_CLEANUP_RATE = BASE
+      .tagged("what", "service-account-cleanup-rate");
+
   private static final String STATUS = "status";
   private static final String COUNTER_CACHE_RESULT = "result";
   private static final String COUNTER_CACHE_HIT = "hit";
@@ -191,6 +194,7 @@ public final class MetricsStats implements Stats {
   private final Meter workflowConsumerErrorMeter;
   private final Meter counterCacheHitMeter;
   private final Meter counterCacheMissMeter;
+  private final Meter serviceAccountCleanupMeter;
   private final ConcurrentMap<String, Histogram> storageOperationHistograms;
   private final ConcurrentMap<String, Meter> storageOperationMeters;
   private final ConcurrentMap<String, Histogram> dockerOperationHistograms;
@@ -231,6 +235,7 @@ public final class MetricsStats implements Stats {
     this.workflowConsumerErrorMeter = registry.meter(WORKFLOW_CONSUMER_ERROR_RATE);
     this.counterCacheHitMeter = registry.meter(COUNTER_CACHE_RATE.tagged(COUNTER_CACHE_RESULT, COUNTER_CACHE_HIT));
     this.counterCacheMissMeter = registry.meter(COUNTER_CACHE_RATE.tagged(COUNTER_CACHE_RESULT, COUNTER_CACHE_MISS));
+    this.serviceAccountCleanupMeter = registry.meter(SERVICE_ACCOUNT_CLEANUP_RATE);
     this.storageOperationHistograms = new ConcurrentHashMap<>();
     this.storageOperationMeters = new ConcurrentHashMap<>();
     this.dockerOperationHistograms = new ConcurrentHashMap<>();
@@ -409,6 +414,11 @@ public final class MetricsStats implements Stats {
   @Override
   public void recordCounterCacheMiss() {
     counterCacheMissMeter.mark();
+  }
+
+  @Override
+  public void recordServiceAccountCleanup() {
+    serviceAccountCleanupMeter.mark();
   }
 
   @Override

--- a/styx-service-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
@@ -178,6 +178,11 @@ final class NoopStats implements Stats {
   }
 
   @Override
+  public void recordServiceAccountCleanup() {
+    // nop
+  }
+
+  @Override
   public void recordKubernetesOperation(String operation, long durationMillis, String status) {
     // nop
   }

--- a/styx-service-common/src/main/java/com/spotify/styx/monitoring/Stats.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/monitoring/Stats.java
@@ -91,6 +91,8 @@ public interface Stats {
 
   void recordCounterCacheMiss();
 
+  void recordServiceAccountCleanup();
+
   void recordKubernetesOperation(String operation, long durationMillis, String status);
 
   void recordKubernetesOperationError(String operation, String type, int code);

--- a/styx-service-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
@@ -41,6 +41,7 @@ import static com.spotify.styx.monitoring.MetricsStats.PULL_IMAGE_ERROR_RATE;
 import static com.spotify.styx.monitoring.MetricsStats.RESOURCE_CONFIGURED;
 import static com.spotify.styx.monitoring.MetricsStats.RESOURCE_DEMANDED;
 import static com.spotify.styx.monitoring.MetricsStats.RESOURCE_USED;
+import static com.spotify.styx.monitoring.MetricsStats.SERVICE_ACCOUNT_CLEANUP_RATE;
 import static com.spotify.styx.monitoring.MetricsStats.STORAGE_DURATION;
 import static com.spotify.styx.monitoring.MetricsStats.STORAGE_RATE;
 import static com.spotify.styx.monitoring.MetricsStats.SUBMISSION_RATE_LIMIT;
@@ -108,6 +109,7 @@ public class MetricsStatsTest {
     when(registry.meter(WORKFLOW_CONSUMER_ERROR_RATE)).thenReturn(meter);
     when(registry.meter(COUNTER_CACHE_RATE.tagged("result", "miss"))).thenReturn(meter);
     when(registry.meter(COUNTER_CACHE_RATE.tagged("result", "hit"))).thenReturn(meter);
+    when(registry.meter(SERVICE_ACCOUNT_CLEANUP_RATE)).thenReturn(meter);
     stats = new MetricsStats(registry, time);
   }
 
@@ -348,6 +350,12 @@ public class MetricsStatsTest {
   @Test
   public void shouldRecordCounterCacheMiss() {
     stats.recordCounterCacheMiss();
+    verify(meter).mark();
+  }
+
+  @Test
+  public void shouldRecordServiceAccountCleanup() {
+    stats.recordServiceAccountCleanup();
     verify(meter).mark();
   }
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Add a new metric to track service account cleanup rate.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We can set up an alert when the rate drops below threshold so we know service account cleanup
stops working.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
