### PR TITLE
do not log IAE as error

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/PersistentStateManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/PersistentStateManager.java
@@ -144,6 +144,8 @@ public class PersistentStateManager implements StateManager {
       log.debug("State transition conflict when ticking instance: {}", state.workflowInstance(), e);
     } catch (CounterCapacityException e) {
       log.debug("Counter capacity exhausted when ticking instance: {}", state.workflowInstance(), e);
+    } catch (IllegalArgumentException e) {
+      log.debug("Illegal argument when ticking instance: {}", state.workflowInstance(), e);
     }
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/PersistentStateManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/PersistentStateManagerTest.java
@@ -228,6 +228,28 @@ public class PersistentStateManagerTest {
   }
 
   @Test
+  public void tickShouldTolerateOutputHandlerIllegalArgumentException() throws IOException {
+    var instance1 = WorkflowInstance.create(TestData.WORKFLOW_ID, "2016-05-01");
+    var instance2 = WorkflowInstance.create(TestData.WORKFLOW_ID, "2016-05-02");
+    var runState1 = RunState.create(instance1, State.SUBMITTING, StateData.zero(), NOW.minusMillis(2), 17);
+    var runState2 = RunState.create(instance2, State.TERMINATED, StateData.zero(), NOW.minusMillis(1), 4711);
+
+    when(storage.listActiveInstances()).thenReturn(Set.of(instance1, instance2));
+    when(storage.readActiveState(instance1)).thenReturn(Optional.of(runState1));
+    when(storage.readActiveState(instance2)).thenReturn(Optional.of(runState2));
+
+    var cause = new IllegalArgumentException("unknown workflow");
+    doThrow(cause).when(outputHandler).transitionInto(runState1, stateManager);
+
+    stateManager.tick();
+
+    verify(outputHandler).transitionInto(runState1, stateManager);
+    verify(outputHandler).transitionInto(runState2, stateManager);
+
+    verify(logger).debug("Illegal argument when ticking instance: {}", instance1, cause);
+  }
+
+  @Test
   public void shouldInitializeAndTriggerWFInstance() throws Exception {
     when(storage.getLatestStoredCounter(INSTANCE)).thenReturn(Optional.empty());
     when(transaction.workflow(INSTANCE.workflowId())).thenReturn(Optional.of(WORKFLOW));


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
In most if not all cases, this IAE is caused by sending event to an already finished and deleted
workflow instance, and this exception has already been logged as warning. So this PR excludes
it from error log to decrease the noise level.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
