### PR TITLE
Make FlyteRunner connect flyteadmin base on id

### DIFF
--- a/styx-e2e-test/src/test/resources/styx-e2e-test-scheduler.conf
+++ b/styx-e2e-test/src/test/resources/styx-e2e-test-scheduler.conf
@@ -11,9 +11,9 @@ styx.gke.default.namespace = ${styx.test.namespace}
 
 # flyte conf
 styx.flyte.enabled = false # TODO: Make end to end test for flyte
-styx.flyte.admin.host = ""
-styx.flyte.admin.port = 1234
-styx.flyte.admin.insecure = true
+styx.flyte.admin.default.host = ""
+styx.flyte.admin.default.port = 1234
+styx.flyte.admin.default.insecure = true
 
 
 # k8s request timeout in ms

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/AbstractRoutingRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/AbstractRoutingRunner.java
@@ -1,0 +1,44 @@
+/*-
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.docker;
+
+import com.spotify.styx.state.RunState;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+public class AbstractRoutingRunner<T> {
+
+  protected final Function<String, T> runnerFactory;
+  protected final Function<RunState, String> runnerId;
+  protected final ConcurrentMap<String, T> runners = new ConcurrentHashMap<>();
+
+  public AbstractRoutingRunner(Function<String, T> runnerFactory, Function<RunState, String> runnerId) {
+    this.runnerFactory = Objects.requireNonNull(runnerFactory);
+    this.runnerId = Objects.requireNonNull(runnerId);
+  }
+
+  protected T runner(RunState runState) {
+    var id = runnerId.apply(runState);
+    return runners.computeIfAbsent(id, runnerFactory);
+  }
+}

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -61,8 +61,8 @@ public class FlyteAdminClientRunner implements FlyteRunner {
   public String createExecution(RunState runState, final String execName, final FlyteExecConf flyteExecConf)
       throws CreateExecutionException {
     requireNonNull(runState, "runState");
-    requireNonNull(runState, "name");
-    requireNonNull(runState, "flyteExecConf");
+    requireNonNull(execName, "name");
+    requireNonNull(flyteExecConf, "flyteExecConf");
     final var launchPlanIdentifier = flyteExecConf.referenceId();
 
     // TODO: verify if the execution already exist

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -60,6 +60,9 @@ public class FlyteAdminClientRunner implements FlyteRunner {
   @Override
   public String createExecution(RunState runState, final String execName, final FlyteExecConf flyteExecConf)
       throws CreateExecutionException {
+    requireNonNull(runState, "runState");
+    requireNonNull(runState, "name");
+    requireNonNull(runState, "flyteExecConf");
     final var launchPlanIdentifier = flyteExecConf.referenceId();
 
     // TODO: verify if the execution already exist
@@ -91,8 +94,8 @@ public class FlyteAdminClientRunner implements FlyteRunner {
   @Override
   public void poll(FlyteExecutionId flyteExecutionId, RunState runState)
       throws PollingException {
-    requireNonNull(flyteExecutionId);
-    requireNonNull(runState);
+    requireNonNull(flyteExecutionId, "flyteExecutionId");
+    requireNonNull(runState, "runState");
     try {
       final ExecutionOuterClass.Execution execution =
           flyteAdminClient.getExecution(flyteExecutionId.project(),
@@ -140,5 +143,4 @@ public class FlyteAdminClientRunner implements FlyteRunner {
           return UNKNOWN_ERROR_EXIT_CODE;
     }
   }
-
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/RoutingFlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/RoutingFlyteRunner.java
@@ -1,0 +1,48 @@
+/*-
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.flyte;
+
+import com.spotify.styx.docker.AbstractRoutingRunner;
+import com.spotify.styx.model.FlyteExecConf;
+import com.spotify.styx.state.RunState;
+import java.util.function.Function;
+
+public class RoutingFlyteRunner extends AbstractRoutingRunner<FlyteRunner>
+    implements FlyteRunner {
+
+  public RoutingFlyteRunner(
+      FlyteRunnerFactory runnerFactory,
+      Function<RunState, String> runnerId) {
+    super(runnerFactory, runnerId);
+  }
+
+
+  @Override
+  public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf)
+      throws CreateExecutionException {
+    return runner(runState).createExecution(runState, name, flyteExecConf);
+  }
+
+  @Override
+  public void poll(FlyteExecutionId flyteExecutionId, RunState runState) throws PollingException {
+    runner(runState).poll(flyteExecutionId, runState);
+  }
+}

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
@@ -22,11 +22,11 @@ package com.spotify.styx;
 
 import static com.spotify.styx.model.Schedule.DAYS;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.theInstance;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
@@ -288,12 +288,27 @@ public class StyxSchedulerTest {
   public void testCreateFlyteRunner() {
     var configMap = ImmutableMap.<String, String>builder()
         .put("styx.flyte.enabled", "true")
-        .put("styx.flyte.admin.host", "localhost")
-        .put("styx.flyte.admin.port", "81")
-        .put("styx.flyte.admin.insecure", "true");
+        .put("styx.flyte.admin.production.host", "localhost")
+        .put("styx.flyte.admin.production.port", "81")
+        .put("styx.flyte.admin.production.insecure", "true");
     var config = ConfigFactory.parseMap(configMap.build());
-    final FlyteRunner flyteRunner = StyxScheduler.createFlyteRunner("runnerId", config, stateManager);
+    final FlyteRunner flyteRunner = StyxScheduler.createFlyteRunner("production", config, stateManager);
 
     assertThat(flyteRunner.isEnabled(), is(true));
+  }
+
+  @Test
+  public void testCreateFlyteRunnerForMissingRunnerIdConfig() {
+    var configMap = ImmutableMap.<String, String>builder()
+        .put("styx.flyte.enabled", "true")
+        .put("styx.flyte.admin.production.host", "localhost")
+        .put("styx.flyte.admin.production.port", "81")
+        .put("styx.flyte.admin.production.insecure", "true");
+    var config = ConfigFactory.parseMap(configMap.build());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> StyxScheduler.createFlyteRunner("staging", config, stateManager)
+    );
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/AbstractRoutingRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/AbstractRoutingRunnerTest.java
@@ -1,0 +1,58 @@
+/*-
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.docker;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.google.common.collect.Maps;
+import com.spotify.styx.state.RunState;
+import java.util.Map;
+import java.util.function.Function;
+import org.mockito.Mock;
+
+public abstract class AbstractRoutingRunnerTest<T> {
+
+  private int createCounter = 0;
+  protected final Map<String, T> createdRunners = Maps.newHashMap();
+
+  @Mock protected Function<RunState, String> runnerId;
+  @Mock protected RunState runState;
+
+  protected abstract T mockRunner();
+
+  protected T create(String id) {
+    var mock = mockRunner();
+    createCounter++;
+    createdRunners.put(id, mock);
+    return mock;
+  }
+
+  protected void assertThatCreateCountersContains(String... ids) {
+    assertThat(createCounter, equalTo(ids.length));
+    assertThat(createdRunners.keySet(), hasSize(ids.length));
+    for (var id : ids) {
+      assertThat(createdRunners, hasKey(id));
+    }
+  }
+}

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/RoutingFlyteRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/RoutingFlyteRunnerTest.java
@@ -1,0 +1,89 @@
+/*-
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.flyte;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.spotify.styx.docker.AbstractRoutingRunnerTest;
+import com.spotify.styx.model.FlyteExecConf;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RoutingFlyteRunnerTest extends AbstractRoutingRunnerTest<FlyteRunner> {
+
+  private static final String EXEC_NAME = "exec-name";
+
+  @Mock private FlyteExecutionId executionId;
+  @Mock private FlyteExecConf execConf;
+
+  private FlyteRunner flyteRunner;
+
+  @Before
+  public void setUp() {
+    flyteRunner = new RoutingFlyteRunner(this::create, runnerId);
+    when(runnerId.apply(runState)).thenReturn("default");
+  }
+
+  @Test
+  public void shouldCreateRunnerOnCreateExecution() throws FlyteRunner.CreateExecutionException {
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
+
+    assertThatCreateCountersContains("default");
+    verify(createdRunners.get("default")).createExecution(runState, EXEC_NAME, execConf);
+  }
+
+  @Test
+  public void testUsesCreatesRunnerOnPoll() throws FlyteRunner.PollingException {
+    flyteRunner.poll(executionId, runState);
+
+    assertThatCreateCountersContains("default");
+    verify(createdRunners.get("default")).poll(executionId, runState);
+  }
+
+  @Test
+  public void testCreatesOnlyOneRunnerPerDockerId() throws Exception {
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
+
+    assertThatCreateCountersContains("default");
+  }
+
+  @Test
+  public void testSwitchesDockerRunner() throws Exception {
+    when(runnerId.apply(runState)).thenReturn("id-1", "id-2");
+
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
+
+    assertThatCreateCountersContains("id-1", "id-2");
+  }
+
+  @Override
+  protected FlyteRunner mockRunner() {
+    return mock(FlyteRunner.class);
+  }
+}

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
@@ -146,7 +146,7 @@ public class FlyteRunnerHandlerTest {
 
   @Test()
   @Parameters({"SUBMITTING", "SUBMITTED", "RUNNING"})
-  public void shouldNotThrowExceptionIfEvenRouterIsClosed(State state) throws Exception {
+  public void shouldNotThrowExceptionIfEventRouterIsClosed(State state) throws Exception {
     doThrow(IsClosedException.class).when(eventRouter).receive(any(), anyLong());
     RunState runState = RunState.create(WORKFLOW_INSTANCE, state, StateData.newBuilder()
         .executionId(EXECUTION_ID)

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
@@ -59,7 +59,7 @@ public class FlyteRunnerHandlerTest {
   @Mock EventRouter eventRouter;
   @Mock FlyteRunner flyteRunner;
 
-  static private final Function<String, String> reverse =
+  private static final Function<String, String> reverse =
       (id) -> new StringBuilder(id).reverse().toString();
   private static final String EXECUTION_NAME = reverse.apply(EXECUTION_ID);
 
@@ -144,7 +144,7 @@ public class FlyteRunnerHandlerTest {
   }
 
 
-  @Test(expected = Test.None.class)
+  @Test()
   @Parameters({"SUBMITTING", "SUBMITTED", "RUNNING"})
   public void shouldNotThrowExceptionIfEvenRouterIsClosed(State state) throws Exception {
     doThrow(IsClosedException.class).when(eventRouter).receive(any(), anyLong());
@@ -166,7 +166,7 @@ public class FlyteRunnerHandlerTest {
     flyteRunnerHandler.transitionInto(runState, eventRouter);
 
     verify(flyteRunner).poll(getFlyteExecutionId(FLYTE_EXECUTION_DESCRIPTION,
-        reverse.apply(EXECUTION_ID)), runState);
+        EXECUTION_NAME), runState);
   }
 
   @Test


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Route Flyteadmin connections depending on the runnerid.

## Motivation and Context
Usually there is several environments: production and staging and with this change, 
we can configure flyteadmin connections per runner ids like this:
```
styx.flyte.admin.production.host = "flyteadmin.production.example.com"
styx.flyte.admin.production.port = 81
styx.flyte.admin.production.insecure = false

styx.flyte.admin.staging.host = "flyteadmin.staging.example.com"
styx.flyte.admin.staging.port = 81
styx.flyte.admin.staging.insecure = false
```

## Have you tested this? If so, how?
I have included unit tests. And we will do manual tests later. Full end to end for Flyte is coming in a different PR.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
