### PR TITLE
Make FlyteRunner.createExecution return the runnerId

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
@@ -28,7 +28,11 @@ public interface FlyteRunner {
     return true;
   }
 
-  FlyteExecutionId createExecution(final String name, final FlyteExecConf flyteExecConf) throws CreateExecutionException;
+  String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf)
+      throws CreateExecutionException;
+
+  void poll(FlyteExecutionId flyteExecutionId, RunState runState)
+      throws PollingException;
 
   static FlyteRunner noop() {
     return new NoopFlyteRunner();
@@ -53,9 +57,6 @@ public interface FlyteRunner {
       super("Launch plan not found: " + conf.referenceId(), cause);
     }
   }
-
-  void poll(FlyteExecutionId flyteExecutionId, RunState runState)
-      throws PollingException;
 
   class PollingException extends Exception {
     public PollingException(FlyteExecutionId id, Throwable cause) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
@@ -34,7 +34,7 @@ class NoopFlyteRunner implements FlyteRunner {
   }
 
   @Override
-  public FlyteExecutionId createExecution(String name, FlyteExecConf flyteExecConf)
+  public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf)
       throws CreateExecutionException {
     throw new CreateExecutionException("Cannot create execution for: " + flyteExecConf);
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -140,7 +140,7 @@ public class StyxSchedulerServiceFixture {
     StyxScheduler.DockerRunnerFactory dockerRunnerFactory =
         (id, env, states, stats, debug, secretWhitelist, time) -> fakeDockerRunner();
     StyxScheduler.FlyteRunnerFactory flyteRunnerFactory =
-        (config, stateManager) -> fakeFlyteRunner();
+        (id, config, stateManager) -> fakeFlyteRunner();
     WorkflowResourceDecorator resourceDecorator = (rs, cfg, res) ->
         Sets.union(res, resourceIdsToDecorateWith);
     StyxScheduler.EventConsumerFactory eventConsumerFactory =
@@ -353,17 +353,15 @@ public class StyxSchedulerServiceFixture {
   private FlyteRunner fakeFlyteRunner() {
     return new FlyteRunner() {
       @Override
-      public FlyteExecutionId createExecution(final String name, final FlyteExecConf flyteExecConf)
-          throws CreateExecutionException {
+      public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf) {
         final FlyteExecutionId response = FlyteExecutionId.create(flyteExecConf.referenceId().project(),
                 flyteExecConf.referenceId().domain(), name);
         flyteExecCreations.add(response);
-        return response;
+        return "fake-runner-id";
       }
 
       @Override
-      public void poll(final FlyteExecutionId flyteExecutionId, final RunState runState)
-          throws PollingException {
+      public void poll(FlyteExecutionId flyteExecutionId, RunState runState) {
         // do nothing
       }
     };

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
@@ -276,11 +276,11 @@ public class StyxSchedulerTest {
     var configMap = ImmutableMap.<String, String>builder()
         .put("styx.flyte.enabled", "false");
     var config = ConfigFactory.parseMap(configMap.build());
-    final FlyteRunner flyteRunner = StyxScheduler.createFlyteRunner(config, stateManager);
+    final FlyteRunner flyteRunner = StyxScheduler.createFlyteRunner("runnerId", config, stateManager);
 
     assertThat(flyteRunner, notNullValue());
     assertThat(flyteRunner.isEnabled(), is(false));
-    assertThrows(FlyteRunner.CreateExecutionException.class, () -> flyteRunner.createExecution(null, null));
+    assertThrows(FlyteRunner.CreateExecutionException.class, () -> flyteRunner.createExecution(null, null, null));
     assertThrows(FlyteRunner.PollingException.class, () -> flyteRunner.poll(FlyteExecutionId.create("flyte-test","testing","test"), null));
   }
 
@@ -292,7 +292,7 @@ public class StyxSchedulerTest {
         .put("styx.flyte.admin.port", "81")
         .put("styx.flyte.admin.insecure", "true");
     var config = ConfigFactory.parseMap(configMap.build());
-    final FlyteRunner flyteRunner = StyxScheduler.createFlyteRunner(config, stateManager);
+    final FlyteRunner flyteRunner = StyxScheduler.createFlyteRunner("runnerId", config, stateManager);
 
     assertThat(flyteRunner.isEnabled(), is(true));
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/NoopFlyteRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/NoopFlyteRunnerTest.java
@@ -23,12 +23,18 @@ package com.spotify.styx.flyte;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 
+import com.spotify.styx.state.RunState;
 import com.spotify.styx.testdata.TestData;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class NoopFlyteRunnerTest {
 
   private final NoopFlyteRunner runner = new NoopFlyteRunner();
+  @Mock private RunState runState;
 
   @Test
   public void testRunnerInNotEnabled() {
@@ -39,7 +45,7 @@ public class NoopFlyteRunnerTest {
   public void testCreateExecutionThrowsException() {
     assertThrows(
         FlyteRunner.CreateExecutionException.class,
-        () -> runner.createExecution("name", TestData.FLYTE_EXEC_CONF)
+        () -> runner.createExecution(runState, "name", TestData.FLYTE_EXEC_CONF)
     );
   }
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Make FlyteRunner.createExecution return the runnerId

## Motivation and Context
Currently `FlyteRunnerHandler` emit events with  "replace-me" id but it needs to emit event with the id of the underling runner.
The configuration will contain several configurations for different runnerId (see #845) but it depends on the FlyteRunner knowing what is the runnerId and communicate that to the Handler. We don't really need to return a FlyteExecutionId so we return the runnerId as it is done in `DockerRunner`

## Have you tested this? If so, how?
I have included unit tests. We will verify this on stagiing environment.
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
