### PR TITLE
do not fail at undefined flyte phase

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -118,6 +118,9 @@ public class FlyteAdminClientRunner implements FlyteRunner {
     final Execution.WorkflowExecution.Phase phase = execution.getClosure().getPhase();
     final FlytePhase flytePhase = FlytePhase.fromProto(phase);
     switch (flytePhase) {
+      case UNDEFINED:
+        LOG.info("Keep polling with FlytePhase UNDEFINED for: " + runState.workflowInstance());
+        break;
       case SUCCEEDED:
         LOG.info("Issue 'terminate' event for: " + runState.workflowInstance());
         stateManager.receive(Event.terminate(runState.workflowInstance(), Optional.of(SUCCESS_EXIT_CODE)));

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlytePhase.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlytePhase.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 public enum FlytePhase {
+  UNDEFINED,
   QUEUED,
   RUNNING,
   SUCCEEDING,
@@ -37,6 +38,7 @@ public enum FlytePhase {
 
   private final static Map<Execution.WorkflowExecution.Phase, FlytePhase> phaseMapper =
     ImmutableMap.<Execution.WorkflowExecution.Phase, FlytePhase>builder()
+        .put(Execution.WorkflowExecution.Phase.UNDEFINED, FlytePhase.UNDEFINED)
         .put(Execution.WorkflowExecution.Phase.QUEUED, FlytePhase.QUEUED)
         .put(Execution.WorkflowExecution.Phase.RUNNING, FlytePhase.RUNNING)
         .put(Execution.WorkflowExecution.Phase.SUCCEEDING, FlytePhase.SUCCEEDING)
@@ -49,7 +51,7 @@ public enum FlytePhase {
 
   public static FlytePhase fromProto(Execution.WorkflowExecution.Phase phase) {
     if (!phaseMapper.containsKey(phase)) {
-      throw new NoSuchElementException();
+      throw new NoSuchElementException("Could not find phase with name: " + phase.name());
     }
     return phaseMapper.get(phase);
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
@@ -35,6 +35,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.spotify.styx.flyte.client.FlyteAdminClient;
@@ -298,6 +299,8 @@ public class FlyteAdminClientRunnerTest {
     final FlyteExecutionId flyteExecutionId =
         FlyteExecutionId.create("flyte-test", "testing", "execution-name");
     flyteRunner.poll(flyteExecutionId, runState);
+
+    verifyNoInteractions(stateManager);
   }
 
   private WorkflowInstance createWorkflowInstance() {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
@@ -285,7 +285,7 @@ public class FlyteAdminClientRunnerTest {
   }
 
   @Test
-  public void testUndefinedShouldNotThrowException() throws Exception {
+  public void testUndefinedShouldNotInteractWithStateManager() throws Exception {
     WorkflowInstance workflowInstance = createWorkflowInstance();
 
     when(flyteAdminClient.getExecution("flyte-test", "testing", "execution-name")).thenReturn(

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
@@ -283,6 +283,23 @@ public class FlyteAdminClientRunnerTest {
                 Execution.WorkflowExecution.Phase.SUCCEEDED).build()).build(), runState));
   }
 
+  @Test
+  public void testUndefinedShouldNotThrowException() throws Exception {
+    WorkflowInstance workflowInstance = createWorkflowInstance();
+
+    when(flyteAdminClient.getExecution("flyte-test", "testing", "execution-name")).thenReturn(
+        ExecutionOuterClass.Execution
+            .newBuilder()
+            .setClosure(ExecutionOuterClass.ExecutionClosure.newBuilder()
+                .setPhase(Execution.WorkflowExecution.Phase.UNDEFINED).build())
+            .build());
+    when(runState.workflowInstance()).thenReturn(workflowInstance);
+
+    final FlyteExecutionId flyteExecutionId =
+        FlyteExecutionId.create("flyte-test", "testing", "execution-name");
+    flyteRunner.poll(flyteExecutionId, runState);
+  }
+
   private WorkflowInstance createWorkflowInstance() {
     Workflow workflow = Workflow.create("id", configuration());
     return WorkflowInstance.create(workflow.id(), "2016-03-14");

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlytePhaseTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlytePhaseTest.java
@@ -33,6 +33,7 @@ public class FlytePhaseTest {
 
   @Test
   public void testSuccessfulMapping() {
+    assertThat(FlytePhase.fromProto(Execution.WorkflowExecution.Phase.UNDEFINED), is(FlytePhase.UNDEFINED));
     assertThat(FlytePhase.fromProto(Execution.WorkflowExecution.Phase.QUEUED), is(FlytePhase.QUEUED));
     assertThat(FlytePhase.fromProto(Execution.WorkflowExecution.Phase.RUNNING), is(FlytePhase.RUNNING));
     assertThat(FlytePhase.fromProto(Execution.WorkflowExecution.Phase.SUCCEEDING), is(FlytePhase.SUCCEEDING));
@@ -45,7 +46,7 @@ public class FlytePhaseTest {
 
   @Test
   public void testUnknownMapping() {
-    assertThrows(NoSuchElementException.class, () -> FlytePhase.fromProto(Execution.WorkflowExecution.Phase.UNDEFINED));
+    assertThrows(NoSuchElementException.class, () -> FlytePhase.fromProto(Execution.WorkflowExecution.Phase.UNRECOGNIZED));
   }
 
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
An undefined phase should not be handled as an error
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
