### PR TITLE
Treat ALREADY_EXISTS exception in createExecution as OK

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -67,7 +67,8 @@ public class FlyteAdminClientRunner implements FlyteRunner {
     final var launchPlanIdentifier = flyteExecConf.referenceId();
     final var execMode = runState.data().trigger()
         .map(this::toFlyteExecutionMode)
-        .orElse(ExecutionMode.UNRECOGNIZED);
+        .filter(mode -> mode != ExecutionMode.UNRECOGNIZED)
+        .orElseThrow(() -> new CreateExecutionException("Missing trigger or unknown in StateData: " + runState.data()));
 
     // TODO: verify if the execution already exist
     try {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
@@ -29,7 +29,6 @@ import static com.spotify.styx.state.RunState.UNRECOVERABLE_FAILURE_EXIT_CODE;
 import static flyteidl.admin.ExecutionOuterClass.ExecutionMetadata.ExecutionMode.SCHEDULED;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -65,7 +64,6 @@ import io.grpc.StatusRuntimeException;
 import java.util.Optional;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -181,6 +179,19 @@ public class FlyteAdminClientRunnerTest {
     assertThrows(
         FlyteRunner.LaunchPlanNotFound.class,
         () -> flyteRunner.createExecution(RUN_STATE, "exec", FLYTE_EXEC_CONF));
+  }
+
+  @Test
+  public void testCreateExecutionForAlreadyExistsException() throws FlyteRunner.CreateExecutionException {
+    doThrow(new StatusRuntimeException(Status.ALREADY_EXISTS))
+        .when(flyteAdminClient).createExecution(any(), any(), any(), any(),any());
+
+    var runnerId = flyteRunner.createExecution(RUN_STATE, "exec", FLYTE_EXEC_CONF);
+
+    assertThat(runnerId, is(RUNNER_ID));
+    verify(flyteAdminClient).createExecution(
+        LAUNCH_PLAN_IDENTIFIER.project(), LAUNCH_PLAN_IDENTIFIER.domain(), "exec",
+        toProto(LAUNCH_PLAN_IDENTIFIER), SCHEDULED);
   }
 
   @Test


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Treat ALREADY_EXISTS exception in `createExecution` as OK
 
## Motivation and Context
In the rare cases that we are repeating the event that leads to create the same execution twice we will get ALREADY_EXISTS. This PR catch this scenario and return as is we created the execution successfully.

## styx-run-id -> flyte exec name problem
There is a problem in translating styx-run-id to flyte exec name: flyte exec names are shorter. So we did a mapping that has a very low probability of generating a collisions 
([see](https://github.com/spotify/styx/blob/288995d6aad3040886fa271af78700f693df0578/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/StyxIdToFlyteExecNameMapper.java#L37)). A flyte exec name collision means that two styx-run-id bellowing to a different workflow+parameters produce the same flyte exec name. 
So we can tray to create an execution for workflow b and we get a ALREADY_EXIST because the collision (with a low probability). **We won't solve this issue** in this PR

## Have you tested this? If so, how?
I have included unit tests.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
