### PR TITLE
Passing the parameter to create execution

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/ParameterUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/ParameterUtil.java
@@ -109,6 +109,18 @@ public final class ParameterUtil {
         ISO_LOCAL_DATE_HOUR.parse(dateHour)).atOffset(UTC));
   }
 
+  public static Instant parseDateMonth(String dateMonth) {
+    return Instant.from(LocalDate.from(
+        DateTimeFormatter.ISO_LOCAL_DATE.parse(dateMonth + "-01"))
+        .atStartOfDay(UTC));
+  }
+
+  public static Instant parseDateYear(String dateYear) {
+    return Instant.from(LocalDate.from(
+        DateTimeFormatter.ISO_LOCAL_DATE.parse(dateYear + "-01-01"))
+        .atStartOfDay(UTC));
+  }
+
   public static String toParameter(Schedule schedule, Instant instant) {
     switch (schedule.wellKnown()) {
       case DAILY:

--- a/styx-common/src/test/java/com/spotify/styx/util/ParameterUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/ParameterUtilTest.java
@@ -130,6 +130,20 @@ public class ParameterUtilTest {
   }
 
   @Test
+  public void shouldParseDateMonth() {
+    final Instant instant = ParameterUtil.parseDateMonth("2016-01");
+
+    assertThat(instant, is(parse("2016-01-01T00:00:00.000Z")));
+  }
+
+  @Test
+  public void shouldParseDateYear() {
+    final Instant instant = ParameterUtil.parseDateYear("2016");
+
+    assertThat(instant, is(parse("2016-01-01T00:00:00.000Z")));
+  }
+
+  @Test
   public void shouldParseDate() {
     final Instant instant = ParameterUtil.parseDate("2016-01-19");
 

--- a/styx-flyte-client/pom.xml
+++ b/styx-flyte-client/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>styx-test</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>com.spotify</groupId>
+          <artifactId>styx-common</artifactId>
+      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/styx-flyte-client/pom.xml
+++ b/styx-flyte-client/pom.xml
@@ -58,6 +58,10 @@
           <groupId>com.spotify</groupId>
           <artifactId>styx-common</artifactId>
       </dependency>
+      <dependency>
+          <groupId>pl.pragmatists</groupId>
+          <artifactId>JUnitParams</artifactId>
+      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -22,7 +22,7 @@ package com.spotify.styx.flyte.client;
 
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.base.Verify.verifyNotNull;
-import static com.spotify.styx.flyte.client.FlyteInputsUtils.fillingParameterInInputs;
+import static com.spotify.styx.flyte.client.FlyteInputsUtils.fillParameterInInputs;
 
 import flyteidl.admin.Common;
 import flyteidl.admin.ExecutionOuterClass;
@@ -100,7 +100,7 @@ public class FlyteAdminClient {
                 .setProject(project)
                 .setName(name)
                 .setSpec(spec)
-                .setInputs(fillingParameterInInputs(inputs, parameter))
+                .setInputs(fillParameterInInputs(inputs, parameter))
                 .build());
 
     verifyNotNull(

--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -27,6 +27,7 @@ import static com.spotify.styx.flyte.client.FlyteInputsUtils.fillParameterInInpu
 import flyteidl.admin.Common;
 import flyteidl.admin.ExecutionOuterClass;
 import flyteidl.admin.ProjectOuterClass;
+import flyteidl.admin.LaunchPlanOuterClass;
 import flyteidl.core.IdentifierOuterClass;
 import flyteidl.service.AdminServiceGrpc;
 import io.grpc.ManagedChannelBuilder;
@@ -76,11 +77,7 @@ public class FlyteAdminClient {
             .setNesting(USER_TRIGGERED_EXECUTION_NESTING)
             .build();
 
-    var launchPlan =
-        stub.getLaunchPlan(
-            Common.ObjectGetRequest.newBuilder().
-                setId(launchPlanId).
-                build());
+    var launchPlan = getLaunchPlan(launchPlanId);
 
     var inputs = launchPlan.getSpec().getDefaultInputs();
 
@@ -112,6 +109,14 @@ public class FlyteAdminClient {
         launchPlanId);
 
     return response;
+  }
+
+  LaunchPlanOuterClass.LaunchPlan getLaunchPlan(IdentifierOuterClass.Identifier launchPlanId) {
+    LOG.debug("getLaunchPlan {}", launchPlanId);
+    var request = Common.ObjectGetRequest.newBuilder()
+        .setId(launchPlanId)
+        .build();
+    return stub.getLaunchPlan(request);
   }
 
   public ExecutionOuterClass.Execution getExecution(String project, String domain, String name) {

--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
@@ -28,10 +28,13 @@ import flyteidl.core.Interface;
 import flyteidl.core.Literals;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class FlyteInputsUtils {
   static final String PARAMETER_NAME = "styx_parameter";
+  private static final Logger LOG = LoggerFactory.getLogger(FlyteInputsUtils.class);
 
   private FlyteInputsUtils() {
     throw new UnsupportedOperationException();
@@ -57,7 +60,9 @@ public class FlyteInputsUtils {
                 return;
               }
               if (value.getVar().getType().getSimple() != DATETIME) {
-                literalMapBuilder.putLiterals(key, value.getDefault());
+                var message = PARAMETER_NAME + " should be of type DATETIME";
+                LOG.error(message);
+                throw new IllegalArgumentException(message);
               } else {
                 literalMapBuilder.putLiterals(key, buildLiteralForPartition(parameter));
               }

--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
@@ -31,7 +31,7 @@ import java.time.format.DateTimeParseException;
 
 
 public class FlyteInputsUtils {
-  private static final String PARAMETER_NAME = "parameter";
+  static final String PARAMETER_NAME = "styx_parameter";
 
   private FlyteInputsUtils() {
     throw new UnsupportedOperationException();
@@ -51,14 +51,14 @@ public class FlyteInputsUtils {
         .getParametersMap()
         .forEach(
             (key, value) -> {
-              if (key.toLowerCase().equals(PARAMETER_NAME)) {
-                if (value.getVar().getType().getSimple() != DATETIME) {
-                  literalMapBuilder.putLiterals(key, value.getDefault());
-                } else {
-                  literalMapBuilder.putLiterals(key, buildLiteralForPartition(parameter));
-                }
-              } else {
+              if (!key.toLowerCase().equals(PARAMETER_NAME)) {
                 literalMapBuilder.putLiterals(key, value.getDefault());
+                return;
+              }
+              if (value.getVar().getType().getSimple() != DATETIME) {
+                literalMapBuilder.putLiterals(key, value.getDefault());
+              } else {
+                literalMapBuilder.putLiterals(key, buildLiteralForPartition(parameter));
               }
             });
 

--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
@@ -20,7 +20,7 @@
 
 package com.spotify.styx.flyte.client;
 
-import static flyteidl.core.Types.SimpleType.DATETIME_VALUE;
+import static flyteidl.core.Types.SimpleType.DATETIME;
 
 import com.google.protobuf.Timestamp;
 import com.spotify.styx.util.ParameterUtil;
@@ -52,10 +52,7 @@ public class FlyteInputsUtils {
         .forEach(
             (key, value) -> {
               if (key.toLowerCase().equals(PARAMETER_NAME)) {
-                if (!value.getDefault().hasScalar()
-                    || !value.getDefault().getScalar().hasPrimitive()
-                    || value.getDefault().getScalar().getPrimitive().getValueCase().getNumber()
-                       != DATETIME_VALUE) {
+                if (value.getVar().getType().getSimple() != DATETIME) {
                   literalMapBuilder.putLiterals(key, value.getDefault());
                 } else {
                   literalMapBuilder.putLiterals(key, buildLiteralForPartition(parameter));

--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
@@ -56,7 +56,16 @@ public class FlyteInputsUtils {
         .forEach(
             (key, value) -> {
               if (!key.toLowerCase().equals(PARAMETER_NAME)) {
-                literalMapBuilder.putLiterals(key, value.getDefault());
+                if (value.hasDefault()) {
+                  literalMapBuilder.putLiterals(key, value.getDefault());
+                  return;
+                }
+                if (value.getRequired()) {
+                  var message = "LP inputs must have default values. Missing default value for key:" + key;
+                  LOG.error(message);
+                  throw new UnsupportedOperationException(message);
+                }
+                LOG.debug("Ignore key: {}", key);
                 return;
               }
               if (value.getVar().getType().getSimple() != DATETIME) {

--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
@@ -1,0 +1,84 @@
+/*-
+ * -\-\-
+ * Spotify Styx Flyte Client
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.flyte.client;
+
+import static flyteidl.core.Types.SimpleType.DATETIME_VALUE;
+
+import com.google.protobuf.Timestamp;
+import com.spotify.styx.util.ParameterUtil;
+import flyteidl.core.Interface;
+import flyteidl.core.Literals;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+
+
+public class FlyteInputsUtils {
+  private static final String PARAMETER_NAME = "parameter";
+
+  private FlyteInputsUtils() {
+    throw new UnsupportedOperationException();
+  }
+
+  static Literals.Literal buildLiteralForPartition(String value) {
+
+    var primitiveBuilderForString = Literals.Primitive.newBuilder().setDatetime(toTimestamp(value));
+    return Literals.Literal.newBuilder()
+        .setScalar(Literals.Scalar.newBuilder().setPrimitive(primitiveBuilderForString.build()).build())
+        .build();
+  }
+
+  static Literals.LiteralMap fillingParameterInInputs(Interface.ParameterMap parameterMap, String parameter) {
+    var literalMapBuilder = Literals.LiteralMap.newBuilder();
+    parameterMap
+        .getParametersMap()
+        .forEach(
+            (key, value) -> {
+              if (key.toLowerCase().equals(PARAMETER_NAME)) {
+                if (!value.getDefault().hasScalar()
+                    || !value.getDefault().getScalar().hasPrimitive()
+                    || value.getDefault().getScalar().getPrimitive().getValueCase().getNumber()
+                       != DATETIME_VALUE) {
+                  literalMapBuilder.putLiterals(key, value.getDefault());
+                } else {
+                  literalMapBuilder.putLiterals(key, buildLiteralForPartition(parameter));
+                }
+              } else {
+                literalMapBuilder.putLiterals(key, value.getDefault());
+              }
+            });
+
+    return literalMapBuilder.build();
+  }
+
+  private static Timestamp toTimestamp(String value) {
+    Instant instant;
+    try {
+      instant = ParameterUtil.parseDate(value);
+    } catch (DateTimeParseException ignored1) {
+      try {
+        instant = ParameterUtil.parseDateHour(value);
+      } catch (DateTimeParseException ignored2) {
+        instant = Instant.parse(value);
+      }
+    }
+    return Timestamp.newBuilder().setSeconds(instant.getEpochSecond()).build();
+  }
+}

--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
@@ -63,13 +63,9 @@ public class FlyteInputsUtils {
                   literalMapBuilder.putLiterals(key, value.getDefault());
                   return;
                 }
-                if (value.getRequired()) {
-                  var message = "LP inputs must have default values. Missing default value for key:" + key;
-                  LOG.error(message);
-                  throw new UnsupportedOperationException(message);
-                }
-                LOG.debug("Ignore key: {}", key);
-                return;
+                var message = "LP inputs must have default values. Missing default value for key:" + key;
+                LOG.error(message);
+                throw new UnsupportedOperationException(message);
               }
               if (value.getVar().getType().getSimple() != DATETIME) {
                 var message = PARAMETER_NAME + " should be of type DATETIME";

--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
@@ -39,13 +39,14 @@ public class FlyteInputsUtils {
 
   static Literals.Literal buildLiteralForPartition(String value) {
 
-    var primitiveBuilderForString = Literals.Primitive.newBuilder().setDatetime(toTimestamp(value));
+    var primitive =
+        Literals.Primitive.newBuilder().setDatetime(toTimestamp(value)).build();
     return Literals.Literal.newBuilder()
-        .setScalar(Literals.Scalar.newBuilder().setPrimitive(primitiveBuilderForString.build()).build())
+        .setScalar(Literals.Scalar.newBuilder().setPrimitive(primitive).build())
         .build();
   }
 
-  static Literals.LiteralMap fillingParameterInInputs(Interface.ParameterMap parameterMap, String parameter) {
+  static Literals.LiteralMap fillParameterInInputs(Interface.ParameterMap parameterMap, String parameter) {
     var literalMapBuilder = Literals.LiteralMap.newBuilder();
     parameterMap
         .getParametersMap()

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
@@ -49,11 +49,21 @@ public class FlyteAdminClientTest {
   static final String DOMAIN = "testing";
   static final String EXISTING_NAME = EXEC_NAME_PREFIX + 1;
   static final String NON_EXISTING_NAME = EXEC_NAME_PREFIX + 8;
+  static final String LP_NAME = "launch_plan_name";
   static final String LP_VERSION = "launch_plan_version_1";
+  static final IdentifierOuterClass.ResourceType LP_RESOURCE_TYPE = IdentifierOuterClass.ResourceType.LAUNCH_PLAN;
   static final String PARAMETER = Instant.now().toString();
   private FlyteAdminClient flyteAdminClient;
 
   @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private static final IdentifierOuterClass.Identifier LP_IDENTIFIER =
+      IdentifierOuterClass.Identifier.newBuilder()
+          .setResourceType(LP_RESOURCE_TYPE)
+          .setDomain(DOMAIN)
+          .setProject(PROJECT)
+          .setName(LP_NAME)
+          .setVersion(LP_VERSION).build();
 
   @Before
   public void setUp() throws IOException {
@@ -107,6 +117,17 @@ public class FlyteAdminClientTest {
     assertThat(workflowExecution.getId().getProject(), equalTo(PROJECT));
     assertThat(workflowExecution.getId().getDomain(), equalTo(DOMAIN));
     assertThat(workflowExecution.getId().getName(), equalTo(EXISTING_NAME));
+  }
+
+  @Test
+  public void shouldPropagateGetLaunchPlanToStub() {
+    var launchPlan =
+        flyteAdminClient.getLaunchPlan(LP_IDENTIFIER);
+    assertThat(LP_RESOURCE_TYPE, equalTo(launchPlan.getId().getResourceType()));
+    assertThat(PROJECT, equalTo(launchPlan.getId().getProject()));
+    assertThat(DOMAIN, equalTo(launchPlan.getId().getDomain()));
+    assertThat(LP_NAME, equalTo(launchPlan.getId().getName()));
+    assertThat(LP_VERSION, equalTo(launchPlan.getId().getVersion()));
   }
 
   @Test

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
@@ -38,6 +38,7 @@ import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.time.Instant;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,6 +50,7 @@ public class FlyteAdminClientTest {
   static final String EXISTING_NAME = EXEC_NAME_PREFIX + 1;
   static final String NON_EXISTING_NAME = EXEC_NAME_PREFIX + 8;
   static final String LP_VERSION = "launch_plan_version_1";
+  static final String PARAMETER = Instant.now().toString();
   private FlyteAdminClient flyteAdminClient;
 
   @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
@@ -78,7 +80,7 @@ public class FlyteAdminClientTest {
   public void shouldPropagateCreateExecutionToStub() {
     var workflowExecution =
         flyteAdminClient.createExecution(PROJECT, DOMAIN, NON_EXISTING_NAME, identifier(NON_EXISTING_NAME),
-            ExecutionMode.SCHEDULED, Map.of());
+            ExecutionMode.SCHEDULED, Map.of(), PARAMETER);
     assertThat(workflowExecution.getId().getProject(), equalTo(PROJECT));
     assertThat(workflowExecution.getId().getDomain(), equalTo(DOMAIN));
     assertThat(workflowExecution.getId().getName(), equalTo(NON_EXISTING_NAME));
@@ -92,7 +94,7 @@ public class FlyteAdminClientTest {
     );
     var workflowExecution =
         flyteAdminClient.createExecution(PROJECT, DOMAIN, NON_EXISTING_NAME, identifier(NON_EXISTING_NAME),
-            ExecutionMode.SCHEDULED, annotations);
+            ExecutionMode.SCHEDULED, annotations, PARAMETER);
     assertThat(workflowExecution, notNullValue());
 
     var retrievedExecution = flyteAdminClient.getExecution(PROJECT, DOMAIN, NON_EXISTING_NAME);

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
@@ -22,7 +22,7 @@ package com.spotify.styx.flyte.client;
 
 import static com.spotify.styx.flyte.client.FlyteInputsUtils.PARAMETER_NAME;
 import static com.spotify.styx.flyte.client.FlyteInputsUtils.buildLiteralForPartition;
-import static com.spotify.styx.flyte.client.FlyteInputsUtils.fillingParameterInInputs;
+import static com.spotify.styx.flyte.client.FlyteInputsUtils.fillParameterInInputs;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -40,7 +40,7 @@ public class FlyteInputsUtilsTest {
   static final String PARAMETER = INSTANT.toString();
 
   @Test
-  public void shouldFillingParameterToInputs() {
+  public void shouldFillParameterInInputs() {
     var parameterMap = Interface.ParameterMap.newBuilder()
         .putParameters(PARAMETER_NAME, Interface.Parameter.newBuilder()
             .setVar(Interface.Variable.newBuilder()
@@ -52,7 +52,7 @@ public class FlyteInputsUtilsTest {
             .build())
         .build();
 
-    var inputs = fillingParameterInInputs(parameterMap, PARAMETER);
+    var inputs = fillParameterInInputs(parameterMap, PARAMETER);
 
     assertThat(INSTANT.getEpochSecond(), equalTo(inputs.getLiteralsMap()
         .get(PARAMETER_NAME)
@@ -62,28 +62,33 @@ public class FlyteInputsUtilsTest {
   }
 
   @Test
-  public void shouldOnlyFillingParameterToInputs() {
-    var inputName = "xxx";
+  public void shouldOnlyFillParameterInInputs() {
+    var inputName = "key";
+    var inputValue = "value";
     var parameterMap = Interface.ParameterMap.newBuilder()
         .putParameters(inputName, Interface.Parameter.newBuilder()
             .setVar(Interface.Variable.newBuilder()
                 .setType(Types.LiteralType.newBuilder().
-                    setSimple(Types.SimpleType.DATETIME)
+                    setSimple(Types.SimpleType.STRING)
                     .build())
                 .build())
-            .setDefault(buildLiteralForPartition(PARAMETER))
+            .setDefault(Literals.Literal.newBuilder()
+                .setScalar(Literals.Scalar.newBuilder()
+                    .setPrimitive(Literals.Primitive.newBuilder().setStringValue(inputValue)
+                        .build()).build())
+                .build())
             .build())
         .build();
 
-    var inputs = fillingParameterInInputs(parameterMap, PARAMETER);
+    var inputs = fillParameterInInputs(parameterMap, PARAMETER);
 
     assertNull(inputs.getLiteralsMap()
         .get(PARAMETER_NAME));
-    assertThat(INSTANT.getEpochSecond(), equalTo(inputs.getLiteralsMap()
+    assertThat(inputValue, equalTo(inputs.getLiteralsMap()
         .get(inputName)
         .getScalar()
         .getPrimitive()
-        .getDatetime().getSeconds()));
+        .getStringValue()));
   }
 
   @Test

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
@@ -43,6 +43,8 @@ import org.junit.runner.RunWith;
 public class FlyteInputsUtilsTest {
   static final Instant INSTANT = Instant.now();
   static final String PARAMETER = INSTANT.toString();
+  private static final String KEY = "name";
+  private static final String EXCEPTION_MESSAGE = "LP inputs must have default values. Missing default value for key:" + KEY;
 
   @Test
   public void shouldFillParameterInInputs() {
@@ -98,9 +100,8 @@ public class FlyteInputsUtilsTest {
 
   @Test
   public void shouldThrowExceptionIfInputIsRequired() {
-    var key = "name";
     var parameterMap = Interface.ParameterMap.newBuilder()
-        .putParameters(key, Interface.Parameter.newBuilder()
+        .putParameters(KEY, Interface.Parameter.newBuilder()
             .setVar(Interface.Variable.newBuilder()
                 .setType(Types.LiteralType.newBuilder().
                     setSimple(Types.SimpleType.STRING)
@@ -114,16 +115,13 @@ public class FlyteInputsUtilsTest {
         UnsupportedOperationException.class,
         () -> fillParameterInInputs(parameterMap, PARAMETER)
     );
-
-    var msg = "LP inputs must have default values. Missing default value for key:" + key;
-    assertThat(exception.getMessage(), equalTo(msg));
+    assertThat(exception.getMessage(), equalTo(EXCEPTION_MESSAGE));
   }
 
   @Test
-  public void shouldIgnoreIfInputIsNotRequired() {
-    var key = "name";
+  public void shouldThrowExceptionIfInputIsNotRequired() {
     var parameterMap = Interface.ParameterMap.newBuilder()
-        .putParameters(key, Interface.Parameter.newBuilder()
+        .putParameters(KEY, Interface.Parameter.newBuilder()
             .setVar(Interface.Variable.newBuilder()
                 .setType(Types.LiteralType.newBuilder().
                     setSimple(Types.SimpleType.STRING)
@@ -133,17 +131,17 @@ public class FlyteInputsUtilsTest {
             .build())
         .build();
 
-    var inputs = fillParameterInInputs(parameterMap, PARAMETER);
-
-    assertNull(inputs.getLiteralsMap()
-        .get(key));
+    var exception = assertThrows(
+        UnsupportedOperationException.class,
+        () -> fillParameterInInputs(parameterMap, PARAMETER)
+    );
+    assertThat(exception.getMessage(), equalTo(EXCEPTION_MESSAGE));
   }
 
   @Test
-  public void shouldIgnoreIfInputHasNoDefault() {
-    var key = "name";
+  public void shouldThrowExceptionIfInputHasNoDefault() {
     var parameterMap = Interface.ParameterMap.newBuilder()
-        .putParameters(key, Interface.Parameter.newBuilder()
+        .putParameters(KEY, Interface.Parameter.newBuilder()
             .setVar(Interface.Variable.newBuilder()
                 .setType(Types.LiteralType.newBuilder().
                     setSimple(Types.SimpleType.STRING)
@@ -152,10 +150,12 @@ public class FlyteInputsUtilsTest {
             .build())
         .build();
 
-    var inputs = fillParameterInInputs(parameterMap, PARAMETER);
+    var exception = assertThrows(
+        UnsupportedOperationException.class,
+        () -> fillParameterInInputs(parameterMap, PARAMETER)
+    );
 
-    assertNull(inputs.getLiteralsMap()
-        .get(key));
+    assertThat(exception.getMessage(), equalTo(EXCEPTION_MESSAGE));
   }
 
   @Test

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
@@ -1,0 +1,65 @@
+/*-
+ * -\-\-
+ * Spotify Styx Flyte Client
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.flyte.client;
+
+import static com.spotify.styx.flyte.client.FlyteInputsUtils.buildLiteralForPartition;
+import static com.spotify.styx.flyte.client.FlyteInputsUtils.fillingParameterInInputs;
+import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import flyteidl.core.Interface;
+import flyteidl.core.Literals;
+import java.time.Instant;
+import org.junit.Test;
+
+
+public class FlyteInputsUtilsTest {
+  static final Instant INSTANT = Instant.now();
+  static final String PARAMETER = INSTANT.toString();
+
+  @Test
+  public void shouldFillingParameterToInputs() {
+    var parameterMap = Interface.ParameterMap.newBuilder()
+        .putParameters("parameter", Interface.Parameter.newBuilder()
+            .setDefault(buildLiteralForPartition("2020-09-15"))
+            .build())
+        .build();
+
+    var inputs = fillingParameterInInputs(parameterMap, PARAMETER);
+
+    assertThat(INSTANT.getEpochSecond(), equalTo(inputs.getLiteralsMap()
+        .get("parameter")
+        .getScalar()
+        .getPrimitive()
+        .getDatetime().getSeconds()));
+  }
+
+  @Test
+  public void shouldCreateLiteral() {
+    var parameter = buildLiteralForPartition(PARAMETER);
+    assertTrue(parameter.hasScalar());
+    assertTrue(parameter.getScalar().hasPrimitive());
+    assertTrue(parameter.getScalar().getPrimitive().getValueCase() == Literals.Primitive.ValueCase.DATETIME);
+    assertThat(INSTANT.getEpochSecond(), equalTo(parameter.getScalar().getPrimitive().getDatetime().getSeconds()));
+  }
+
+}

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
@@ -23,6 +23,7 @@ package com.spotify.styx.flyte.client;
 import static com.spotify.styx.flyte.client.FlyteInputsUtils.PARAMETER_NAME;
 import static com.spotify.styx.flyte.client.FlyteInputsUtils.buildLiteralForPartition;
 import static com.spotify.styx.flyte.client.FlyteInputsUtils.fillParameterInInputs;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -33,8 +34,12 @@ import flyteidl.core.Interface;
 import flyteidl.core.Literals;
 import flyteidl.core.Types;
 import java.time.Instant;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(JUnitParamsRunner.class)
 public class FlyteInputsUtilsTest {
   static final Instant INSTANT = Instant.now();
   static final String PARAMETER = INSTANT.toString();
@@ -188,4 +193,18 @@ public class FlyteInputsUtilsTest {
     assertThat(INSTANT.getEpochSecond(), equalTo(parameter.getScalar().getPrimitive().getDatetime().getSeconds()));
   }
 
+  @Test
+  @Parameters({
+      "2016-01-19, 2016-01-19T00:00:00Z",
+      "2016-01-19T09, 2016-01-19T09:00:00Z",
+      "2016-01, 2016-01-01T00:00:00Z",
+      "2016, 2016-01-01T00:00:00Z",
+      "2016-01-19T09:11:00Z, 2016-01-19T09:11:00Z",
+      "2016-01-19T09:11:01Z, 2016-01-19T09:11:01Z",
+  })
+  public void shouldConvertStringToTimeStamp(String string, String timestamp) {
+    long expected = Instant.parse(timestamp).getEpochSecond();
+    long result = FlyteInputsUtils.toTimestamp(string).getSeconds();
+    assertEquals(result, expected);
+  }
 }

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
@@ -92,6 +92,68 @@ public class FlyteInputsUtilsTest {
   }
 
   @Test
+  public void shouldThrowExceptionIfInputIsRequired() {
+    var key = "name";
+    var parameterMap = Interface.ParameterMap.newBuilder()
+        .putParameters(key, Interface.Parameter.newBuilder()
+            .setVar(Interface.Variable.newBuilder()
+                .setType(Types.LiteralType.newBuilder().
+                    setSimple(Types.SimpleType.STRING)
+                    .build())
+                .build())
+            .setRequired(true)
+            .build())
+        .build();
+
+    var exception = assertThrows(
+        UnsupportedOperationException.class,
+        () -> fillParameterInInputs(parameterMap, PARAMETER)
+    );
+
+    var msg = "LP inputs must have default values. Missing default value for key:" + key;
+    assertThat(exception.getMessage(), equalTo(msg));
+  }
+
+  @Test
+  public void shouldIgnoreIfInputIsNotRequired() {
+    var key = "name";
+    var parameterMap = Interface.ParameterMap.newBuilder()
+        .putParameters(key, Interface.Parameter.newBuilder()
+            .setVar(Interface.Variable.newBuilder()
+                .setType(Types.LiteralType.newBuilder().
+                    setSimple(Types.SimpleType.STRING)
+                    .build())
+                .build())
+            .setRequired(false)
+            .build())
+        .build();
+
+    var inputs = fillParameterInInputs(parameterMap, PARAMETER);
+
+    assertNull(inputs.getLiteralsMap()
+        .get(key));
+  }
+
+  @Test
+  public void shouldIgnoreIfInputHasNoDefault() {
+    var key = "name";
+    var parameterMap = Interface.ParameterMap.newBuilder()
+        .putParameters(key, Interface.Parameter.newBuilder()
+            .setVar(Interface.Variable.newBuilder()
+                .setType(Types.LiteralType.newBuilder().
+                    setSimple(Types.SimpleType.STRING)
+                    .build())
+                .build())
+            .build())
+        .build();
+
+    var inputs = fillParameterInInputs(parameterMap, PARAMETER);
+
+    assertNull(inputs.getLiteralsMap()
+        .get(key));
+  }
+
+  @Test
   public void shouldThrowExceptionIfParameterHasWrongType() {
     var parameterMap = Interface.ParameterMap.newBuilder()
         .putParameters(PARAMETER_NAME, Interface.Parameter.newBuilder()

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 import flyteidl.core.Interface;
 import flyteidl.core.Literals;
+import flyteidl.core.Types;
 import java.time.Instant;
 import org.junit.Test;
 
@@ -40,6 +41,11 @@ public class FlyteInputsUtilsTest {
   public void shouldFillingParameterToInputs() {
     var parameterMap = Interface.ParameterMap.newBuilder()
         .putParameters("parameter", Interface.Parameter.newBuilder()
+            .setVar(Interface.Variable.newBuilder()
+                .setType(Types.LiteralType.newBuilder().
+                    setSimple(Types.SimpleType.DATETIME)
+                    .build())
+                .build())
             .setDefault(buildLiteralForPartition("2020-09-15"))
             .build())
         .build();

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
@@ -20,8 +20,10 @@
 
 package com.spotify.styx.flyte.client;
 
+import static com.spotify.styx.flyte.client.FlyteInputsUtils.PARAMETER_NAME;
 import static com.spotify.styx.flyte.client.FlyteInputsUtils.buildLiteralForPartition;
 import static com.spotify.styx.flyte.client.FlyteInputsUtils.fillingParameterInInputs;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -40,7 +42,7 @@ public class FlyteInputsUtilsTest {
   @Test
   public void shouldFillingParameterToInputs() {
     var parameterMap = Interface.ParameterMap.newBuilder()
-        .putParameters("parameter", Interface.Parameter.newBuilder()
+        .putParameters(PARAMETER_NAME, Interface.Parameter.newBuilder()
             .setVar(Interface.Variable.newBuilder()
                 .setType(Types.LiteralType.newBuilder().
                     setSimple(Types.SimpleType.DATETIME)
@@ -53,7 +55,32 @@ public class FlyteInputsUtilsTest {
     var inputs = fillingParameterInInputs(parameterMap, PARAMETER);
 
     assertThat(INSTANT.getEpochSecond(), equalTo(inputs.getLiteralsMap()
-        .get("parameter")
+        .get(PARAMETER_NAME)
+        .getScalar()
+        .getPrimitive()
+        .getDatetime().getSeconds()));
+  }
+
+  @Test
+  public void shouldOnlyFillingParameterToInputs() {
+    var inputName = "xxx";
+    var parameterMap = Interface.ParameterMap.newBuilder()
+        .putParameters(inputName, Interface.Parameter.newBuilder()
+            .setVar(Interface.Variable.newBuilder()
+                .setType(Types.LiteralType.newBuilder().
+                    setSimple(Types.SimpleType.DATETIME)
+                    .build())
+                .build())
+            .setDefault(buildLiteralForPartition(PARAMETER))
+            .build())
+        .build();
+
+    var inputs = fillingParameterInInputs(parameterMap, PARAMETER);
+
+    assertNull(inputs.getLiteralsMap()
+        .get(PARAMETER_NAME));
+    assertThat(INSTANT.getEpochSecond(), equalTo(inputs.getLiteralsMap()
+        .get(inputName)
         .getScalar()
         .getPrimitive()
         .getDatetime().getSeconds()));

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
@@ -23,12 +23,12 @@ package com.spotify.styx.flyte.client;
 import static com.spotify.styx.flyte.client.FlyteAdminClientTest.DOMAIN;
 import static com.spotify.styx.flyte.client.FlyteAdminClientTest.PROJECT;
 import static java.util.stream.Collectors.toUnmodifiableList;
+import static com.spotify.styx.flyte.client.FlyteInputsUtils.PARAMETER_NAME;
 
 import flyteidl.admin.Common;
 import flyteidl.admin.ExecutionOuterClass;
 import flyteidl.admin.ExecutionOuterClass.Execution;
 import flyteidl.admin.ProjectOuterClass;
-import static com.spotify.styx.flyte.client.FlyteInputsUtils.buildLiteralForPartition;
 
 import flyteidl.admin.LaunchPlanOuterClass;
 import flyteidl.core.IdentifierOuterClass;
@@ -89,8 +89,8 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
         .setSpec(LaunchPlanOuterClass.LaunchPlanSpec
             .newBuilder()
             .setDefaultInputs(Interface.ParameterMap.newBuilder()
-                .putParameters("parameter", Interface.Parameter.newBuilder()
-                    .setDefault(buildLiteralForPartition("2020-09-21"))
+                .putParameters(PARAMETER_NAME, Interface.Parameter.newBuilder()
+                    .setRequired(true)
                     .build())
                 .build())
             .build())

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
@@ -28,7 +28,11 @@ import flyteidl.admin.Common;
 import flyteidl.admin.ExecutionOuterClass;
 import flyteidl.admin.ExecutionOuterClass.Execution;
 import flyteidl.admin.ProjectOuterClass;
+import static com.spotify.styx.flyte.client.FlyteInputsUtils.buildLiteralForPartition;
+
+import flyteidl.admin.LaunchPlanOuterClass;
 import flyteidl.core.IdentifierOuterClass;
+import flyteidl.core.Interface;
 import flyteidl.service.AdminServiceGrpc;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -71,6 +75,24 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
             .setDomain(request.getDomain())
             .setProject(request.getProject())
             .setName(request.getName())
+            .build())
+        .build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getLaunchPlan(final flyteidl.admin.Common.ObjectGetRequest request,
+                            final StreamObserver<LaunchPlanOuterClass.LaunchPlan> responseObserver) {
+    responseObserver.onNext(LaunchPlanOuterClass.LaunchPlan
+        .newBuilder()
+        .setId(request.getId())
+        .setSpec(LaunchPlanOuterClass.LaunchPlanSpec
+            .newBuilder()
+            .setDefaultInputs(Interface.ParameterMap.newBuilder()
+                .putParameters("parameter", Interface.Parameter.newBuilder()
+                    .setDefault(buildLiteralForPartition("2020-09-21"))
+                    .build())
+                .build())
             .build())
         .build());
     responseObserver.onCompleted();

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
@@ -33,6 +33,7 @@ import flyteidl.admin.ProjectOuterClass;
 import flyteidl.admin.LaunchPlanOuterClass;
 import flyteidl.core.IdentifierOuterClass;
 import flyteidl.core.Interface;
+import flyteidl.core.Types;
 import flyteidl.service.AdminServiceGrpc;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -90,6 +91,10 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
             .newBuilder()
             .setDefaultInputs(Interface.ParameterMap.newBuilder()
                 .putParameters(PARAMETER_NAME, Interface.Parameter.newBuilder()
+                    .setVar(Interface.Variable.newBuilder()
+                        .setType(Types.LiteralType.newBuilder().
+                            setSimple(Types.SimpleType.DATETIME).build())
+                        .build())
                     .setRequired(true)
                     .build())
                 .build())

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -73,6 +73,8 @@ public class FlyteAdminClientRunner implements FlyteRunner {
         .filter(mode -> mode != ExecutionMode.UNRECOGNIZED)
         .orElseThrow(() -> new CreateExecutionException("Missing trigger or unknown in StateData: " + runState.data()));
 
+    final var parameter = runState.workflowInstance().parameter();
+
     try {
       flyteAdminClient.createExecution(
           launchPlanIdentifier.project(),
@@ -86,7 +88,8 @@ public class FlyteAdminClientRunner implements FlyteRunner {
               .setVersion(launchPlanIdentifier.version())
               .build(),
           execMode,
-          annotations);
+          annotations,
+          parameter);
       return runnerId;
     } catch (StatusRuntimeException e) {
       switch (e.getStatus().getCode()) {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
@@ -191,7 +191,6 @@ public class FlyteAdminClientRunnerTest {
   public void testCreateExecutionForAlreadyExistsException() throws FlyteRunner.CreateExecutionException {
     doThrow(new StatusRuntimeException(Status.ALREADY_EXISTS))
         .when(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(), any());
-
     var runnerId = flyteRunner.createExecution(RUN_STATE, "exec", FLYTE_EXEC_CONF, ANNOTATIONS);
 
     assertThat(runnerId, is(RUNNER_ID));
@@ -204,7 +203,6 @@ public class FlyteAdminClientRunnerTest {
   public void testThrowsCreateExecutionExceptionForOtherCode() {
     doThrow(new StatusRuntimeException(Status.INTERNAL))
         .when(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(), any());
-
     assertThrows(
         FlyteRunner.CreateExecutionException.class,
         () -> flyteRunner.createExecution(RUN_STATE, "exec", FLYTE_EXEC_CONF, ANNOTATIONS));


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Passing the parameter (Aka. partition) to when creating a Flyte WF execution. It will fetch the launch plan from Flyte first to get all the default input. When it find a input parameter with name `parameter`, styx will replace this parameter with the real value from workflow instance.

## Motivation and Context

## Have you tested this? If so, how?

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
