### PR TITLE
Add listProjects to FlyteAdminClient

### DIFF
--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Verify.verifyNotNull;
 
 import flyteidl.admin.Common;
 import flyteidl.admin.ExecutionOuterClass;
+import flyteidl.admin.ProjectOuterClass;
 import flyteidl.core.IdentifierOuterClass;
 import flyteidl.service.AdminServiceGrpc;
 import io.grpc.ManagedChannelBuilder;
@@ -155,6 +156,12 @@ public class FlyteAdminClient {
         .build();
 
     return stub.listExecutions(request);
+  }
+
+  public ProjectOuterClass.Projects listProjects() {
+    log.debug("listProjects");
+
+    return stub.listProjects(ProjectOuterClass.ProjectListRequest.getDefaultInstance());
   }
 
 }

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
@@ -22,6 +22,7 @@ package com.spotify.styx.flyte.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
 import flyteidl.admin.ExecutionOuterClass;
@@ -43,7 +44,6 @@ public class FlyteAdminClientTest {
   static final String LP_NAME = "launch_plan_1";
   static final String LP_VERSION = "launch_plan_version_1";
   private FlyteAdminClient flyteAdminClient;
-  private TestAdminService testAdminService;
 
   @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
   private static final IdentifierOuterClass.Identifier LP_IDENTIFIER =
@@ -56,7 +56,7 @@ public class FlyteAdminClientTest {
 
   @Before
   public void setUp() throws IOException {
-    testAdminService = new TestAdminService();
+    final TestAdminService testAdminService = new TestAdminService();
     var serverName = InProcessServerBuilder.generateName();
     var server = InProcessServerBuilder
         .forName(serverName)
@@ -113,5 +113,15 @@ public class FlyteAdminClientTest {
         }
     );
     assertThat(2, equalTo(listExecutions.getExecutionsCount()));
+  }
+
+  @Test
+  public void shouldPropagateListProjectsToStub() {
+    var listProjectsResponse =
+        flyteAdminClient.listProjects();
+
+    assertThat(listProjectsResponse.getProjectsList(), hasSize(1));
+    assertThat(listProjectsResponse.getProjectsList().get(0).getId(), equalTo(PROJECT));
+    assertThat(listProjectsResponse.getProjectsList().get(0).getDomains(0).getId(), equalTo(DOMAIN));
   }
 }

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
@@ -25,6 +25,7 @@ import static com.spotify.styx.flyte.client.FlyteAdminClientTest.PROJECT;
 
 import flyteidl.admin.Common;
 import flyteidl.admin.ExecutionOuterClass;
+import flyteidl.admin.ProjectOuterClass;
 import flyteidl.core.IdentifierOuterClass;
 import flyteidl.service.AdminServiceGrpc;
 import io.grpc.stub.StreamObserver;
@@ -99,6 +100,22 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
         .addAllExecutions(executions)
         .build();
     responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void listProjects(ProjectOuterClass.ProjectListRequest request,
+                           StreamObserver<ProjectOuterClass.Projects> responseObserver) {
+    final var projects = ProjectOuterClass.Projects.newBuilder()
+        .addProjects(ProjectOuterClass.Project.newBuilder()
+            .setId(PROJECT)
+            .setDescription("")
+            .addDomains(ProjectOuterClass.Domain.newBuilder()
+                .setId(DOMAIN)
+                .build())
+            .build())
+        .build();
+    responseObserver.onNext(projects);
     responseObserver.onCompleted();
   }
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Add `listProjects` to `FlyteAdminClient`.

## Motivation and Context
This change is needed for cleaning up flyte executions whose styx executions are not active anymore.
```
We will need to retrieve all the project/domains
for every project/domain:
  if execution was trigger by styx and styx workflow is no more then
    terminate execution
```
## Have you tested this? If so, how?
I have included unit tests for propagating flyte executiions

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
