### PR TITLE
Support Optional token and filter in FlyteAdminClient.listExecutions

### DIFF
--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -150,12 +150,16 @@ public class FlyteAdminClient {
             .setDomain(domain)
             .build())
         .setLimit(limit)
-        .setToken(token)
-        .setFilters(filters)
+        .setToken(emptyIfNull(token))
+        .setFilters(emptyIfNull(filters))
         // TODO: .setSortBy()
         .build();
 
     return stub.listExecutions(request);
+  }
+
+  private String emptyIfNull(String str) {
+    return (str == null) ? "" : str;
   }
 
   public ProjectOuterClass.Projects listProjects() {
@@ -163,5 +167,4 @@ public class FlyteAdminClient {
 
     return stub.listProjects(ProjectOuterClass.ProjectListRequest.getDefaultInstance());
   }
-
 }

--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx.flyte.client;
 
+import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.base.Verify.verifyNotNull;
 
 import flyteidl.admin.Common;
@@ -150,16 +151,12 @@ public class FlyteAdminClient {
             .setDomain(domain)
             .build())
         .setLimit(limit)
-        .setToken(emptyIfNull(token))
-        .setFilters(emptyIfNull(filters))
+        .setToken(nullToEmpty(token))
+        .setFilters(nullToEmpty(filters))
         // TODO: .setSortBy()
         .build();
 
     return stub.listExecutions(request);
-  }
-
-  private String emptyIfNull(String str) {
-    return (str == null) ? "" : str;
   }
 
   public ProjectOuterClass.Projects listProjects() {

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
@@ -152,4 +152,14 @@ public class FlyteAdminClientTest {
         .collect(Collectors.toUnmodifiableList());
     assertThat(executionNames, hasItems(EXEC_NAME_PREFIX + 1, EXEC_NAME_PREFIX + 3));
   }
+
+  @Test
+  public void shouldPropagateListProjectsToStub() {
+    var listProjectsResponse =
+        flyteAdminClient.listProjects();
+
+    assertThat(listProjectsResponse.getProjectsList(), hasSize(1));
+    assertThat(listProjectsResponse.getProjectsList().get(0).getId(), equalTo(PROJECT));
+    assertThat(listProjectsResponse.getProjectsList().get(0).getDomains(0).getId(), equalTo(DOMAIN));
+  }
 }

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
@@ -113,11 +113,7 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
     responseObserver.onCompleted();
   }
 
-  private boolean isEvenExecId(String execName) {
-    return Integer.parseInt(execName.substring(EXEC_NAME_PREFIX.length())) % 2 == 0;
-  }
-
-  public static ExecutionOuterClass.Execution execution(String project, String domain, String execName1) {
+  private static ExecutionOuterClass.Execution execution(String project, String domain, String execName1) {
     return ExecutionOuterClass.Execution
         .newBuilder()
         .setId(IdentifierOuterClass.WorkflowExecutionIdentifier

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
@@ -35,6 +35,7 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
 
   private static final String EXEC_NAME_1 = "exec_name_1";
   private static final String EXEC_NAME_2 = "exec_name_2";
+  private Common.ResourceListRequest lastExecutionRequest;
 
   @Override
   public void createExecution(final ExecutionOuterClass.ExecutionCreateRequest request,
@@ -76,6 +77,7 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
   @Override
   public void listExecutions(final Common.ResourceListRequest request,
                              final StreamObserver<ExecutionOuterClass.ExecutionList> responseObserver) {
+    lastExecutionRequest = request;
     final var executions = List.of(
         ExecutionOuterClass.Execution
             .newBuilder()
@@ -117,5 +119,9 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
         .build();
     responseObserver.onNext(projects);
     responseObserver.onCompleted();
+  }
+
+  Common.ResourceListRequest getLastExecutionRequest() {
+    return lastExecutionRequest;
   }
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Support Optional token and filter in FlyteAdminClient.listExecutions

## Motivation and Context
Paginated request to listExecutions follow this format
```
token = null
do:
  response = listExecutions(token)
  token = response.token
while(token != null)
```
We need to make sure that FlyteAdminClient accepts null tokens, the ones used for the first call instead of throwing an exception

## Have you tested this? If so, how?
I have included unit tests.
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
