### PR TITLE
Remove dead code trying to terminate executions

### DIFF
--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -150,12 +150,16 @@ public class FlyteAdminClient {
             .setDomain(domain)
             .build())
         .setLimit(limit)
-        .setToken(token)
-        .setFilters(filters)
+        .setToken(emptyIfNull(token))
+        .setFilters(emptyIfNull(filters))
         // TODO: .setSortBy()
         .build();
 
     return stub.listExecutions(request);
+  }
+
+  private String emptyIfNull(String str) {
+    return (str == null) ? "" : str;
   }
 
   public ProjectOuterClass.Projects listProjects() {
@@ -163,5 +167,4 @@ public class FlyteAdminClient {
 
     return stub.listProjects(ProjectOuterClass.ProjectListRequest.getDefaultInstance());
   }
-
 }

--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx.flyte.client;
 
+import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.base.Verify.verifyNotNull;
 
 import flyteidl.admin.Common;
@@ -150,16 +151,12 @@ public class FlyteAdminClient {
             .setDomain(domain)
             .build())
         .setLimit(limit)
-        .setToken(emptyIfNull(token))
-        .setFilters(emptyIfNull(filters))
+        .setToken(nullToEmpty(token))
+        .setFilters(nullToEmpty(filters))
         // TODO: .setSortBy()
         .build();
 
     return stub.listExecutions(request);
-  }
-
-  private String emptyIfNull(String str) {
-    return (str == null) ? "" : str;
   }
 
   public ProjectOuterClass.Projects listProjects() {

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
@@ -152,4 +152,14 @@ public class FlyteAdminClientTest {
         .collect(Collectors.toUnmodifiableList());
     assertThat(executionNames, hasItems(EXEC_NAME_PREFIX + 1, EXEC_NAME_PREFIX + 3));
   }
+
+  @Test
+  public void shouldPropagateListProjectsToStub() {
+    var listProjectsResponse =
+        flyteAdminClient.listProjects();
+
+    assertThat(listProjectsResponse.getProjectsList(), hasSize(1));
+    assertThat(listProjectsResponse.getProjectsList().get(0).getId(), equalTo(PROJECT));
+    assertThat(listProjectsResponse.getProjectsList().get(0).getDomains(0).getId(), equalTo(DOMAIN));
+  }
 }

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
@@ -113,11 +113,7 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
     responseObserver.onCompleted();
   }
 
-  private boolean isEvenExecId(String execName) {
-    return Integer.parseInt(execName.substring(EXEC_NAME_PREFIX.length())) % 2 == 0;
-  }
-
-  public static ExecutionOuterClass.Execution execution(String project, String domain, String execName1) {
+  private static ExecutionOuterClass.Execution execution(String project, String domain, String execName1) {
     return ExecutionOuterClass.Execution
         .newBuilder()
         .setId(IdentifierOuterClass.WorkflowExecutionIdentifier

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
@@ -35,6 +35,7 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
 
   private static final String EXEC_NAME_1 = "exec_name_1";
   private static final String EXEC_NAME_2 = "exec_name_2";
+  private Common.ResourceListRequest lastExecutionRequest;
 
   @Override
   public void createExecution(final ExecutionOuterClass.ExecutionCreateRequest request,
@@ -76,6 +77,7 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
   @Override
   public void listExecutions(final Common.ResourceListRequest request,
                              final StreamObserver<ExecutionOuterClass.ExecutionList> responseObserver) {
+    lastExecutionRequest = request;
     final var executions = List.of(
         ExecutionOuterClass.Execution
             .newBuilder()
@@ -117,5 +119,9 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
         .build();
     responseObserver.onNext(projects);
     responseObserver.onCompleted();
+  }
+
+  Common.ResourceListRequest getLastExecutionRequest() {
+    return lastExecutionRequest;
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/AbstractRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/AbstractRunnerHandler.java
@@ -33,8 +33,8 @@ import org.slf4j.LoggerFactory;
 /**
  * An abstract {@link OutputHandler} that verify that {@link RunState} contains {@code executionId} and
  * {@code executionDescription} for the {@link RunState#state()}s: {@link RunState.State#SUBMITTING},
- * {@link RunState.State#SUBMITTED}, {@link RunState.State#RUNNING}, {@link RunState.State#FAILED}
- * and {@link RunState.State#ERROR}, before delegating transitioning to sub-classes.
+ * {@link RunState.State#SUBMITTED}, {@link RunState.State#RUNNING} and {@link RunState.State#FAILED},
+ * before delegating transitioning to sub-classes.
  */
 abstract class AbstractRunnerHandler implements OutputHandler {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractRunnerHandler.class);
@@ -72,7 +72,6 @@ abstract class AbstractRunnerHandler implements OutputHandler {
         break;
 
       case FAILED:
-      case ERROR:
         if (maybeExecutionId.isEmpty()
             || maybeExecutionDescription.isEmpty()
             || !applicableFn.test(maybeExecutionDescription.orElseThrow())) {
@@ -84,7 +83,7 @@ abstract class AbstractRunnerHandler implements OutputHandler {
 
       default:
         // Any other state we just return as RunnerHandlers only care about:
-        // SUBMITTING, SUBMITTED, RUNNING, FAILED and ERROR
+        // SUBMITTING, SUBMITTED, RUNNING and FAILED
     }
   }
 
@@ -92,7 +91,7 @@ abstract class AbstractRunnerHandler implements OutputHandler {
    * Same as {@link #transitionInto(RunState, EventRouter)} but subclasses can trust that {@link RunState}'s
    * {@link StateData#executionId()} and {@link StateData#executionDescription()} are both present when
    * {@link RunState#state()} is {@link RunState.State#SUBMITTING}, {@link RunState.State#SUBMITTED},
-   * {@link RunState.State#RUNNING}, {@link RunState.State#FAILED} or {@link RunState.State#ERROR}.
+   * {@link RunState.State#RUNNING} or {@link RunState.State#FAILED}
    */
   protected abstract void safeTransitionInto(RunState state, EventRouter eventRouter);
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/FlyteRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/FlyteRunnerHandler.java
@@ -73,8 +73,8 @@ public class FlyteRunnerHandler extends AbstractRunnerHandler {
         pollingExecution(state, eventRouter);
         break;
       case FAILED:
-      case ERROR:
         cleanUpExecution(state);
+        break;
       default:
         // do nothing
     }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/AbstractRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/AbstractRunnerHandlerTest.java
@@ -128,10 +128,7 @@ public class AbstractRunnerHandlerTest {
   private static RunState.State[] relevantRunnerHandlerStates() {
     return Stream.concat(
         Arrays.stream(execRunnerHandlerStates()),
-        Stream.of(
-            RunState.State.FAILED,
-            RunState.State.ERROR
-        )
+        Stream.of(RunState.State.FAILED)
     ).toArray(RunState.State[]::new);
   }
 
@@ -142,6 +139,7 @@ public class AbstractRunnerHandlerTest {
         RunState.State.QUEUED,
         RunState.State.PREPARE,
         RunState.State.TERMINATED,
+        RunState.State.ERROR,
         RunState.State.DONE
     };
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
@@ -193,9 +193,8 @@ public class FlyteRunnerHandlerTest {
   }
 
   @Test
-  @Parameters({"FAILED", "ERROR"})
-  public void shouldTerminateExecutionsOnFailedAndErrorState(State state) {
-    RunState runState = RunState.create(WORKFLOW_INSTANCE, state, StateData.newBuilder()
+  public void shouldTerminateExecutionsOnFailedState() {
+    RunState runState = RunState.create(WORKFLOW_INSTANCE, State.FAILED, StateData.newBuilder()
         .executionId(EXECUTION_ID)
         .executionDescription(FLYTE_EXECUTION_DESCRIPTION)
         .build());


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Remove dead code trying to terminate executions on ERROR state.

## Motivation and Context
Once RuneState reach ERROR it won't be active neither passed through the handlers, so any code in the Handler 
for reacting to ERROR is futile and wont be ever run.

## Have you tested this? If so, how?
I have included unit tests.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
