### PR TITLE
Annotate Flyte executions

### DIFF
--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -29,6 +29,7 @@ import flyteidl.admin.ProjectOuterClass;
 import flyteidl.core.IdentifierOuterClass;
 import flyteidl.service.AdminServiceGrpc;
 import io.grpc.ManagedChannelBuilder;
+import java.util.Map;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +63,8 @@ public class FlyteAdminClient {
       String domain,
       String name,
       IdentifierOuterClass.Identifier launchPlanId,
-      ExecutionOuterClass.ExecutionMetadata.ExecutionMode executionMode) {
+      ExecutionOuterClass.ExecutionMetadata.ExecutionMode executionMode,
+      Map<String, String> annotations) {
     log.debug("createExecution {} {} {}", project, domain, launchPlanId);
 
     var metadata =
@@ -76,6 +78,9 @@ public class FlyteAdminClient {
         ExecutionOuterClass.ExecutionSpec.newBuilder()
             .setLaunchPlan(launchPlanId)
             .setMetadata(metadata)
+            .setAnnotations(Common.Annotations.newBuilder()
+                .putAllValues(annotations)
+                .build())
             .build();
 
     var response =

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
@@ -36,6 +36,7 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Rule;
@@ -76,10 +77,26 @@ public class FlyteAdminClientTest {
   @Test
   public void shouldPropagateCreateExecutionToStub() {
     var workflowExecution =
-        flyteAdminClient.createExecution(PROJECT, DOMAIN, NON_EXISTING_NAME, identifier(NON_EXISTING_NAME), ExecutionMode.SCHEDULED);
+        flyteAdminClient.createExecution(PROJECT, DOMAIN, NON_EXISTING_NAME, identifier(NON_EXISTING_NAME),
+            ExecutionMode.SCHEDULED, Map.of());
     assertThat(workflowExecution.getId().getProject(), equalTo(PROJECT));
     assertThat(workflowExecution.getId().getDomain(), equalTo(DOMAIN));
     assertThat(workflowExecution.getId().getName(), equalTo(NON_EXISTING_NAME));
+  }
+
+  @Test
+  public void shouldPropagateAnnotationsOnCreateExecutionToStub() {
+    final Map<String, String> annotations = Map.of(
+        "Frodo", "Baggins",
+        "Sam", "Gamgee"
+    );
+    var workflowExecution =
+        flyteAdminClient.createExecution(PROJECT, DOMAIN, NON_EXISTING_NAME, identifier(NON_EXISTING_NAME),
+            ExecutionMode.SCHEDULED, annotations);
+    assertThat(workflowExecution, notNullValue());
+
+    var retrievedExecution = flyteAdminClient.getExecution(PROJECT, DOMAIN, NON_EXISTING_NAME);
+    assertThat(retrievedExecution.getSpec().getAnnotations().getValuesMap(), equalTo(annotations));
   }
 
   @Test

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -38,6 +38,7 @@ import flyteidl.core.IdentifierOuterClass;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,11 +60,13 @@ public class FlyteAdminClientRunner implements FlyteRunner {
   }
 
   @Override
-  public String createExecution(RunState runState, final String execName, final FlyteExecConf flyteExecConf)
+  public String createExecution(final RunState runState, final String execName, final FlyteExecConf flyteExecConf,
+                                final Map<String, String> annotations)
       throws CreateExecutionException {
     requireNonNull(runState, "runState");
     requireNonNull(execName, "name");
     requireNonNull(flyteExecConf, "flyteExecConf");
+    requireNonNull(annotations, "annotations");
     final var launchPlanIdentifier = flyteExecConf.referenceId();
     final var execMode = runState.data().trigger()
         .map(this::toFlyteExecutionMode)
@@ -82,7 +85,8 @@ public class FlyteAdminClientRunner implements FlyteRunner {
               .setResourceType(IdentifierOuterClass.ResourceType.LAUNCH_PLAN)
               .setVersion(launchPlanIdentifier.version())
               .build(),
-          execMode);
+          execMode,
+          annotations);
       return runnerId;
     } catch (StatusRuntimeException e) {
       switch (e.getStatus().getCode()) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
@@ -22,6 +22,7 @@ package com.spotify.styx.flyte;
 
 import com.spotify.styx.model.FlyteExecConf;
 import com.spotify.styx.state.RunState;
+import java.util.Map;
 import java.util.function.Function;
 
 public interface FlyteRunner {
@@ -29,7 +30,7 @@ public interface FlyteRunner {
     return true;
   }
 
-  String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf)
+  String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf, Map<String, String> annotations)
       throws CreateExecutionException;
 
   void terminateExecution(RunState runState, FlyteExecutionId flyteExecutionId);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
@@ -22,6 +22,7 @@ package com.spotify.styx.flyte;
 
 import com.spotify.styx.model.FlyteExecConf;
 import com.spotify.styx.state.RunState;
+import java.util.Map;
 
 /**
  * No-op {@code FlyteRunner} meant to be used when Flyte is disabled or not available.
@@ -34,7 +35,8 @@ class NoopFlyteRunner implements FlyteRunner {
   }
 
   @Override
-  public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf)
+  public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf,
+                                Map<String, String> annotations)
       throws CreateExecutionException {
     throw new CreateExecutionException("Cannot create execution for: " + flyteExecConf);
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/RoutingFlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/RoutingFlyteRunner.java
@@ -23,6 +23,7 @@ package com.spotify.styx.flyte;
 import com.spotify.styx.docker.AbstractRoutingRunner;
 import com.spotify.styx.model.FlyteExecConf;
 import com.spotify.styx.state.RunState;
+import java.util.Map;
 import java.util.function.Function;
 
 public class RoutingFlyteRunner extends AbstractRoutingRunner<FlyteRunner>
@@ -36,9 +37,10 @@ public class RoutingFlyteRunner extends AbstractRoutingRunner<FlyteRunner>
 
 
   @Override
-  public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf)
+  public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf,
+                                Map<String, String> annotations)
       throws CreateExecutionException {
-    return runner(runState).createExecution(runState, name, flyteExecConf);
+    return runner(runState).createExecution(runState, name, flyteExecConf, annotations);
   }
 
   @Override

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -59,6 +59,7 @@ import com.spotify.styx.util.TriggerInstantSpec;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -353,7 +354,8 @@ public class StyxSchedulerServiceFixture {
   private FlyteRunner fakeFlyteRunner() {
     return new FlyteRunner() {
       @Override
-      public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf) {
+      public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf,
+                                    Map<String, String> annotations) {
         final FlyteExecutionId response = FlyteExecutionId.create(flyteExecConf.referenceId().project(),
                 flyteExecConf.referenceId().domain(), name);
         flyteExecCreations.add(response);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
@@ -280,7 +280,7 @@ public class StyxSchedulerTest {
 
     assertThat(flyteRunner, notNullValue());
     assertThat(flyteRunner.isEnabled(), is(false));
-    assertThrows(FlyteRunner.CreateExecutionException.class, () -> flyteRunner.createExecution(null, null, null));
+    assertThrows(FlyteRunner.CreateExecutionException.class, () -> flyteRunner.createExecution(null, null, null, null));
     assertThrows(FlyteRunner.PollingException.class, () -> flyteRunner.poll(FlyteExecutionId.create("flyte-test","testing","test"), null));
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/NoopFlyteRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/NoopFlyteRunnerTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.testdata.TestData;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -48,7 +49,7 @@ public class NoopFlyteRunnerTest {
   public void testCreateExecutionThrowsException() {
     assertThrows(
         FlyteRunner.CreateExecutionException.class,
-        () -> runner.createExecution(runState, "name", TestData.FLYTE_EXEC_CONF)
+        () -> runner.createExecution(runState, "name", TestData.FLYTE_EXEC_CONF, Map.of())
     );
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/RoutingFlyteRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/RoutingFlyteRunnerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import com.spotify.styx.docker.AbstractRoutingRunnerTest;
 import com.spotify.styx.model.FlyteExecConf;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,6 +37,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class RoutingFlyteRunnerTest extends AbstractRoutingRunnerTest<FlyteRunner> {
 
   private static final String EXEC_NAME = "exec-name";
+  private static final Map<String, String> ANNOTATIONS = Map.of("foo", "bar");
 
   @Mock private FlyteExecutionId executionId;
   @Mock private FlyteExecConf execConf;
@@ -50,10 +52,10 @@ public class RoutingFlyteRunnerTest extends AbstractRoutingRunnerTest<FlyteRunne
 
   @Test
   public void shouldCreateRunnerOnCreateExecution() throws FlyteRunner.CreateExecutionException {
-    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
 
     assertThatCreateCountersContains("default");
-    verify(createdRunners.get("default")).createExecution(runState, EXEC_NAME, execConf);
+    verify(createdRunners.get("default")).createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
   }
 
   @Test
@@ -74,8 +76,8 @@ public class RoutingFlyteRunnerTest extends AbstractRoutingRunnerTest<FlyteRunne
 
   @Test
   public void testCreatesOnlyOneRunnerPerRunnerId() throws Exception {
-    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
-    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
 
     assertThatCreateCountersContains("default");
   }
@@ -84,8 +86,8 @@ public class RoutingFlyteRunnerTest extends AbstractRoutingRunnerTest<FlyteRunne
   public void testSwitchesRunners() throws Exception {
     when(runnerId.apply(runState)).thenReturn("id-1", "id-2");
 
-    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
-    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
 
     assertThatCreateCountersContains("id-1", "id-2");
   }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Annotate executions on creation. Executions are annotated with:
- styx workflow instance
- styx execution id

## Motivation and Context
In order to know what execution we need to terminate after a user halt command, 
we need a way to tie an execution back to the originating styx workflow. 
Flyte execution annotation offers a nice way to do that.

## Have you tested this? If so, how?
I have included unit tests and I will test it on the staging environment once this is merged.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
