### PR TITLE
Terminate dangling styx related executions

### DIFF
--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -26,8 +26,8 @@ import static com.spotify.styx.flyte.client.FlyteInputsUtils.fillParameterInInpu
 
 import flyteidl.admin.Common;
 import flyteidl.admin.ExecutionOuterClass;
-import flyteidl.admin.ProjectOuterClass;
 import flyteidl.admin.LaunchPlanOuterClass;
+import flyteidl.admin.ProjectOuterClass;
 import flyteidl.core.IdentifierOuterClass;
 import flyteidl.service.AdminServiceGrpc;
 import io.grpc.ManagedChannelBuilder;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -639,7 +639,7 @@ public class StyxScheduler implements AppInit {
     }
 
     var flyteAdminClient = getFlyteAdminClient(config, runnerId);
-    return new FlyteAdminClientRunner(runnerId, flyteAdminClient, stateManager);
+    return FlyteRunner.flyteAdmin(runnerId, flyteAdminClient, stateManager);
   }
 
   private static FlyteAdminClient getFlyteAdminClient(Config rootConfig, String runnerId) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -57,9 +57,8 @@ import com.spotify.styx.api.SchedulerResource;
 import com.spotify.styx.api.ServiceAccountUsageAuthorizer;
 import com.spotify.styx.api.WorkflowActionAuthorizer;
 import com.spotify.styx.docker.DockerRunner;
-import com.spotify.styx.docker.RunnerId;
 import com.spotify.styx.docker.Fabric8KubernetesClient;
-import com.spotify.styx.flyte.FlyteAdminClientRunner;
+import com.spotify.styx.docker.RunnerId;
 import com.spotify.styx.flyte.FlyteRunner;
 import com.spotify.styx.flyte.client.FlyteAdminClient;
 import com.spotify.styx.model.Event;
@@ -106,13 +105,10 @@ import com.spotify.styx.util.StorageFactory;
 import com.spotify.styx.util.Time;
 import com.spotify.styx.util.TriggerUtil;
 import com.typesafe.config.Config;
-import flyteidl.service.AdminServiceGrpc;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
@@ -649,15 +645,9 @@ public class StyxScheduler implements AppInit {
     }
 
     var config = flyteAdminRootConfig.getConfig(runnerId);
-    var builder =
-        ManagedChannelBuilder.forAddress(config.getString(FLYTEADMIN_HOST), config.getInt(FLYTEADMIN_PORT));
-    if (config.getBoolean(FLYTEADMIN_INSECURE)) {
-      builder.usePlaintext();
-    }
-    final ManagedChannel channel = builder.build();
-
-    var stub = AdminServiceGrpc.newBlockingStub(channel);
-    return new FlyteAdminClient(stub);
+    final var target = config.getString(FLYTEADMIN_HOST) + ":" + config.getInt(FLYTEADMIN_PORT);
+    final var insecure = config.getBoolean(FLYTEADMIN_INSECURE);
+    return FlyteAdminClient.create(target, insecure);
   }
 
   @VisibleForTesting

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/RoutingDockerRunner.java
@@ -20,7 +20,6 @@
 
 package com.spotify.styx.docker;
 
-import com.google.common.io.Closer;
 import com.spotify.styx.state.RunState;
 import java.io.IOException;
 import java.util.function.Function;
@@ -53,12 +52,5 @@ class RoutingDockerRunner extends AbstractRoutingRunner<DockerRunner>
     for (var v: runners.values()) {
       v.cleanup();
     }
-  }
-
-  @Override
-  public void close() throws IOException {
-    final Closer closer = Closer.create();
-    runners.values().forEach(closer::register);
-    closer.close();
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -168,6 +168,11 @@ public class FlyteAdminClientRunner implements FlyteRunner {
     return trigger.accept(TriggerToExecutionModeVisitor.INSTANCE);
   }
 
+  @Override
+  public void close() {
+    // Nothing to close... yet
+  }
+
   private static class TriggerToExecutionModeVisitor implements TriggerVisitor<ExecutionMode> {
     private static final TriggerToExecutionModeVisitor INSTANCE = new TriggerToExecutionModeVisitor();
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -221,7 +221,7 @@ public class FlyteAdminClientRunner implements FlyteRunner {
       // TODO: add tracing
       tryTerminateDanglingFlyteExecutions();
     } catch (Throwable t) {
-      LOG.warn("Error while terminating dangling flyte executions", t);
+      LOG.error("Error while terminating dangling flyte executions", t);
     }
 
   }
@@ -234,6 +234,8 @@ public class FlyteAdminClientRunner implements FlyteRunner {
       for (var domain : project.getDomainsList()) {
         String paginationToken = null;
         do {
+          //TODO: explore using filters for listing only running executions
+          // or at least listing only the ones newer than some threshold
           var executions =
               flyteAdminClient.listExecutions(project.getId(), domain.getId(), 100, paginationToken, "");
           executions.getExecutionsList().stream()

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteExecutionId.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteExecutionId.java
@@ -22,6 +22,7 @@ package com.spotify.styx.flyte;
 
 import com.google.common.base.Preconditions;
 import flyteidl.admin.ExecutionOuterClass;
+import flyteidl.core.IdentifierOuterClass;
 import io.norberg.automatter.AutoMatter;
 
 @AutoMatter
@@ -40,10 +41,14 @@ public interface FlyteExecutionId {
   }
 
   static FlyteExecutionId fromProto(ExecutionOuterClass.ExecutionCreateResponse response) {
+    return fromProto(response.getId());
+  }
+
+  static FlyteExecutionId fromProto(IdentifierOuterClass.WorkflowExecutionIdentifier identifier) {
     return newBuilder()
-        .project(response.getId().getProject())
-        .domain(response.getId().getDomain())
-        .name(response.getId().getName())
+        .project(identifier.getProject())
+        .domain(identifier.getDomain())
+        .name(identifier.getName())
         .build();
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
@@ -20,8 +20,10 @@
 
 package com.spotify.styx.flyte;
 
+import com.spotify.styx.flyte.client.FlyteAdminClient;
 import com.spotify.styx.model.FlyteExecConf;
 import com.spotify.styx.state.RunState;
+import com.spotify.styx.state.StateManager;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.function.Function;
@@ -41,6 +43,12 @@ public interface FlyteRunner extends Closeable {
 
   static FlyteRunner noop() {
     return new NoopFlyteRunner();
+  }
+
+  static FlyteRunner flyteAdmin(final String runnerId,
+                                final FlyteAdminClient flyteAdminClient,
+                                final StateManager stateManager) {
+    return new FlyteAdminClientRunner(runnerId, flyteAdminClient, stateManager);
   }
 
   /**

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
@@ -22,10 +22,11 @@ package com.spotify.styx.flyte;
 
 import com.spotify.styx.model.FlyteExecConf;
 import com.spotify.styx.state.RunState;
+import java.io.Closeable;
 import java.util.Map;
 import java.util.function.Function;
 
-public interface FlyteRunner {
+public interface FlyteRunner extends Closeable {
   default boolean isEnabled() {
     return true;
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
@@ -51,4 +51,9 @@ class NoopFlyteRunner implements FlyteRunner {
       throws PollingException {
     throw new PollingException("Cannot poll for execution: " + flyteExecutionId.toUrn());
   }
+
+  @Override
+  public void close() {
+    // nothing to close
+  }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -371,6 +371,11 @@ public class StyxSchedulerServiceFixture {
       public void poll(FlyteExecutionId flyteExecutionId, RunState runState) {
         // do nothing
       }
+
+      @Override
+      public void close() {
+        // do nothing
+      }
     };
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTerminateDanglingTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTerminateDanglingTest.java
@@ -1,0 +1,308 @@
+/*-
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2016 - 2020 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.flyte;
+
+import static com.spotify.styx.flyte.FlyteAdminClientRunner.STYX_EXECUTION_ID_ANNOTATION;
+import static com.spotify.styx.flyte.FlyteAdminClientRunner.STYX_WORKFLOW_INSTANCE_ANNOTATION;
+import static com.spotify.styx.flyte.FlyteAdminClientRunner.TERMINATE_CAUSE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.spotify.styx.QuietDeterministicScheduler;
+import com.spotify.styx.flyte.client.FlyteAdminClient;
+import com.spotify.styx.model.WorkflowId;
+import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.state.RunState;
+import com.spotify.styx.state.StateData;
+import com.spotify.styx.state.StateManager;
+import flyteidl.admin.Common;
+import flyteidl.admin.ExecutionOuterClass;
+import flyteidl.admin.ExecutionOuterClass.Execution;
+import flyteidl.admin.ProjectOuterClass;
+import flyteidl.core.Execution.WorkflowExecution.Phase;
+import flyteidl.core.IdentifierOuterClass;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import junitparams.JUnitParamsRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.verification.VerificationMode;
+
+@RunWith(JUnitParamsRunner.class)
+public class FlyteAdminClientRunnerTerminateDanglingTest {
+
+  private static final Duration TERMINATE_DANGLING_INTERVAL = Duration.ofSeconds(60);
+  private static final String PROJECT = "test-project";
+  private static final String DOMAIN = "production";
+
+  private static final String RUNNING_1 = "running-1";
+  private static final String RUNNING_2 = "running-2";
+  private static final String NON_RUNNING_1 = "non-running-1";
+  private static final String NON_RUNNING_2 = "non-running-2";
+  private static final String NON_STYX_1 = "non-styx-1";
+  private static final String NON_STYX_2 = "non-styx-2";
+  private static final String NA_DANGLING_1 = "na-dangling-1";
+  private static final String NA_DANGLING_2 = "na-dangling-2";
+  private static final String NIA_DANGLING_1 = "nia-dangling-1";
+  private static final String NIA_DANGLING_2 = "nia-dangling-2";
+  private static final String NIS_DANGLING_1 = "nis-dangling-1";
+  private static final String NIS_DANGLING_2 = "nis-dangling-2";
+  private static final String OA_DANGLING_1 = "oa-dangling-1";
+  private static final String OA_DANGLING_2 = "oa-dangling-2";
+
+  @Mock private StateManager stateManager;
+  @Mock private FlyteAdminClient adminClient;
+
+  private final QuietDeterministicScheduler executor = spy(new QuietDeterministicScheduler());
+  private final Set<WorkflowInstance> activeInstances = new LinkedHashSet<>();
+
+  private FlyteAdminClientRunner runner;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    runner = new FlyteAdminClientRunner("runnerId", adminClient, stateManager, TERMINATE_DANGLING_INTERVAL, executor);
+    when(adminClient.listProjects())
+        .thenReturn(ProjectOuterClass.Projects.newBuilder()
+            .addProjects(ProjectOuterClass.Project.newBuilder()
+                .setId(PROJECT)
+                .addDomains(ProjectOuterClass.Domain.newBuilder()
+                    .setId(DOMAIN)
+                    .build())
+                .build())
+            .build());
+
+    var nonActiveDangling = executions(this::nonActiveDanglingExecution, NA_DANGLING_1, NA_DANGLING_2);
+    var noIdInStateDangling = executions(this::noIdInStateDanglingExecution, NIS_DANGLING_1, NIS_DANGLING_2);
+    var noIdInAnnotationDangling = executions(this::noIdInAnnotationDanglingExecution, NIA_DANGLING_1, NIA_DANGLING_2);
+    var oldIdInAnnotationDangling = executions(this::oldIdInAnnotationDanglingExecution, OA_DANGLING_1, OA_DANGLING_2);
+    var running = executions(this::runningExecution, RUNNING_1, RUNNING_2);
+    var nonStyx = executions(this::runningNonStyxExecution, NON_STYX_1, NON_STYX_2);
+    var nonRunning = executions(this::nonRunningExecutions, NON_RUNNING_1, NON_RUNNING_2);
+    stubListExecutions(nonActiveDangling, noIdInStateDangling, noIdInAnnotationDangling, oldIdInAnnotationDangling,
+        running, nonStyx, nonRunning);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    runner.close();
+  }
+
+  @Test
+  public void shouldTerminateDanglingFlyteExecutionsWhenStateNotActiveAnymore() {
+    runner.terminateDanglingFlyteExecutions();
+
+    verifyTerminateExecution(times(1), NA_DANGLING_1);
+    verifyTerminateExecution(times(1), NA_DANGLING_2);
+  }
+
+  @Test
+  public void shouldTerminateDanglingFlyteExecutionsWhenStateHasNoStyxRunId() {
+    runner.terminateDanglingFlyteExecutions();
+
+    verifyTerminateExecution(times(1), NIS_DANGLING_1);
+    verifyTerminateExecution(times(1), NIS_DANGLING_2);
+  }
+
+  @Test
+  public void shouldTerminateDanglingFlyteExecutionsWhenNoIdInAnnotation() {
+    runner.terminateDanglingFlyteExecutions();
+
+    verifyTerminateExecution(times(1), NIA_DANGLING_1);
+    verifyTerminateExecution(times(1), NIA_DANGLING_2);
+  }
+
+  @Test
+  public void shouldTerminateDanglingFlyteExecutionsWhenOldIdInAnnotation() {
+    runner.terminateDanglingFlyteExecutions();
+
+    verifyTerminateExecution(times(1), OA_DANGLING_1);
+    verifyTerminateExecution(times(1), OA_DANGLING_2);
+  }
+
+  @Test
+  public void shouldNotTerminateActiveStyxRunningFlyteExecutions() {
+    runner.terminateDanglingFlyteExecutions();
+
+    verifyTerminateExecution(never(), RUNNING_1);
+    verifyTerminateExecution(never(), RUNNING_2);
+  }
+
+  @Test
+  public void shouldNotTerminateNonStyxFlyteExecutions() {
+    runner.terminateDanglingFlyteExecutions();
+
+    verifyTerminateExecution(never(), NON_STYX_1);
+    verifyTerminateExecution(never(), NON_STYX_2);
+  }
+
+  @Test
+  public void shouldNotTerminateFlyteExecutionsInTerminalPhase() {
+    runner.terminateDanglingFlyteExecutions();
+
+    verifyTerminateExecution(never(), NON_RUNNING_1);
+    verifyTerminateExecution(never(), NON_RUNNING_2);
+  }
+
+  @Test
+  public void shouldScheduleTerminationOnInit() {
+    runner.init();
+    executor.tick(TERMINATE_DANGLING_INTERVAL.getSeconds() * 2, TimeUnit.SECONDS);
+
+    verify(adminClient, atLeastOnce()).listProjects();
+  }
+
+  @Test
+  public void shouldCloseExecutorOnClose() throws IOException {
+    runner.close();
+
+    verify(executor).shutdown();
+  }
+
+  private void verifyTerminateExecution(VerificationMode mode, String name) {
+    verify(adminClient, mode).terminateExecution(PROJECT, DOMAIN, name, TERMINATE_CAUSE);
+  }
+
+  public List<Execution> executions(Function<String, Execution> execFactory, String... execNames) {
+    return Arrays.stream(execNames).map(execFactory).collect(Collectors.toList());
+  }
+
+  @SafeVarargs
+  private void stubListExecutions(List<Execution>... executions) {
+    when(adminClient.listExecutions(any(), any(), anyInt(), any(), any()))
+        .thenReturn(ExecutionOuterClass.ExecutionList.newBuilder()
+            .addAllExecutions(Arrays.stream(executions).flatMap(Collection::stream).collect(Collectors.toList()))
+            .build());
+    when(stateManager.listActiveInstances()).thenReturn(activeInstances);
+  }
+
+  private Execution nonRunningExecutions(String name) {
+    return execution(name, styxAnnotations(name, workflowInstance(name)), Phase.SUCCEEDED);
+  }
+
+  private Execution noIdInStateDanglingExecution(String name) {
+    final var workflowInstance = workflowInstance(name);
+    addToActiveStates(workflowInstance, StateData.newBuilder().build());
+    return execution(name, styxAnnotations(name, workflowInstance), Phase.RUNNING);
+  }
+
+  private Execution oldIdInAnnotationDanglingExecution(String name) {
+    final var workflowInstance = workflowInstance(name);
+    addToActiveStates(workflowInstance, StateData.newBuilder().executionId(name).build());
+    return execution(name, oldRunIdStyxAnnotation(name, workflowInstance), Phase.RUNNING);
+  }
+
+  private Execution noIdInAnnotationDanglingExecution(String name) {
+    final var workflowInstance = workflowInstance(name);
+    addToActiveStates(workflowInstance, StateData.newBuilder().executionId(name).build());
+    return execution(name, noRunIdStyxAnnotation(workflowInstance), Phase.RUNNING);
+  }
+
+  private Execution runningExecution(String name) {
+    final var workflowInstance = workflowInstance(name);
+    addToActiveStates(workflowInstance, StateData.newBuilder().executionId(name).build());
+    return execution(name, styxAnnotations(name, workflowInstance), Phase.RUNNING);
+  }
+
+  private void addToActiveStates(WorkflowInstance workflowInstance, StateData state) {
+    activeInstances.add(workflowInstance);
+    when(stateManager.getActiveState(workflowInstance))
+        .thenReturn(Optional.of(
+            RunState.create(
+                workflowInstance,
+                RunState.State.RUNNING,
+                state)));
+  }
+
+  private Execution nonActiveDanglingExecution(String name) {
+    return execution(name, styxAnnotations(name, workflowInstance(name)), Phase.RUNNING);
+  }
+
+  private Execution runningNonStyxExecution(String name) {
+    return execution(name, emptyAnnotations(), Phase.RUNNING);
+  }
+
+  private Execution execution(String name, Common.Annotations annotations, Phase phase) {
+    return Execution.newBuilder()
+        .setId(IdentifierOuterClass.WorkflowExecutionIdentifier.newBuilder()
+            .setProject(PROJECT)
+            .setDomain(DOMAIN)
+            .setName(name)
+            .build())
+        .setSpec(ExecutionOuterClass.ExecutionSpec.newBuilder()
+            .setAnnotations(annotations)
+            .build())
+        .setClosure(ExecutionOuterClass.ExecutionClosure.newBuilder()
+            .setPhase(phase)
+            .build())
+        .build();
+  }
+
+  private Common.Annotations styxAnnotations(String name, WorkflowInstance workflowInstance) {
+    return Common.Annotations.newBuilder()
+        .putValues(STYX_WORKFLOW_INSTANCE_ANNOTATION, workflowInstance.toKey())
+        .putValues(STYX_EXECUTION_ID_ANNOTATION, name)
+        .build();
+  }
+
+  private Common.Annotations noRunIdStyxAnnotation(WorkflowInstance workflowInstance) {
+    return Common.Annotations.newBuilder()
+        .putValues(STYX_WORKFLOW_INSTANCE_ANNOTATION, workflowInstance.toKey())
+        .build();
+  }
+
+  private Common.Annotations oldRunIdStyxAnnotation(String name, WorkflowInstance workflowInstance) {
+    return Common.Annotations.newBuilder()
+        .putValues(STYX_WORKFLOW_INSTANCE_ANNOTATION, workflowInstance.toKey())
+        .putValues(STYX_EXECUTION_ID_ANNOTATION, "old" + name)
+        .build();
+  }
+
+  private Common.Annotations emptyAnnotations() {
+    return Common.Annotations.getDefaultInstance();
+  }
+
+  private WorkflowInstance workflowInstance(String name) {
+    return WorkflowInstance.create(
+        WorkflowId.create("component", name),
+        "2020-10-24"
+    );
+  }
+}

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteExecutionIdTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteExecutionIdTest.java
@@ -34,8 +34,8 @@ import org.junit.rules.ExpectedException;
 public class FlyteExecutionIdTest {
 
   @Test
-  public void testFromProto() {
-    final ExecutionOuterClass.ExecutionCreateResponse response =
+  public void testFromProtoResponse() {
+    var response =
         ExecutionOuterClass.ExecutionCreateResponse
             .newBuilder()
             .setId(IdentifierOuterClass.WorkflowExecutionIdentifier
@@ -45,7 +45,22 @@ public class FlyteExecutionIdTest {
                 .setName("test-from-proto-creation")
                 .build())
             .build();
-    final FlyteExecutionId flyteExecutionId = FlyteExecutionId.fromProto(response);
+    var flyteExecutionId = FlyteExecutionId.fromProto(response);
+    assertThat(flyteExecutionId.project(), is("flyte-test"));
+    assertThat(flyteExecutionId.domain(), is("testing"));
+    assertThat(flyteExecutionId.name(), is("test-from-proto-creation"));
+    assertThat(flyteExecutionId.toUrn(), is("ex:flyte-test:testing:test-from-proto-creation"));
+  }
+
+  @Test
+  public void testFromProtoIdentifier() {
+    var identifier = IdentifierOuterClass.WorkflowExecutionIdentifier
+        .newBuilder()
+        .setProject("flyte-test")
+        .setDomain("testing")
+        .setName("test-from-proto-creation")
+        .build();
+    var flyteExecutionId = FlyteExecutionId.fromProto(identifier);
     assertThat(flyteExecutionId.project(), is("flyte-test"));
     assertThat(flyteExecutionId.domain(), is("testing"));
     assertThat(flyteExecutionId.name(), is("test-from-proto-creation"));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/NoopFlyteRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/NoopFlyteRunnerTest.java
@@ -68,4 +68,9 @@ public class NoopFlyteRunnerTest {
         () -> runner.poll(FLYTE_EXECUTION_ID, null)
     );
   }
+
+  @Test
+  public void testCloseDoesNotThrowsExeption() {
+    runner.close();
+  }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/RoutingFlyteRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/RoutingFlyteRunnerTest.java
@@ -92,6 +92,20 @@ public class RoutingFlyteRunnerTest extends AbstractRoutingRunnerTest<FlyteRunne
     assertThatCreateCountersContains("id-1", "id-2");
   }
 
+  @Test
+  public void testCreatedRunnersAreClosed() throws Exception {
+    when(runnerId.apply(runState)).thenReturn("id-1", "id-2");
+
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
+    flyteRunner.close();
+
+    assertThatCreateCountersContains("id-1", "id-2");
+    for (var runner : createdRunners.values()) {
+      verify(runner).close();
+    }
+  }
+
   @Override
   protected FlyteRunner mockRunner() {
     return mock(FlyteRunner.class);


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Terminate dangling styx related executions. A dangling executions is one running in Flyte with styx annotation
whose RunState is not longer active in Styx.

## Motivation and Context
A user could emit a halt command and force a RunState being on Error and it won't be active.

## Have you tested this? If so, how?
I have included unit tests. Will test in staging.
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
