### PR TITLE
Add a config item to disable early caching

### DIFF
--- a/styx-e2e-test/src/test/resources/reference.conf
+++ b/styx-e2e-test/src/test/resources/reference.conf
@@ -38,6 +38,10 @@ styx.secret-whitelist = [
   # "bar-secret",
 ]
 
+# A flag to disable the warmup of resource IDs cache used for authentication and only fill in cache when needed.
+# Default to false
+styx.authentication.disable-resource-id-cache-warmup = true
+
 # A white list of domains whose users should be granted access to perform non-GET requests against the Styx API.
 styx.authentication.domain-whitelist = [
   "spotify.com",

--- a/styx-service-common/src/main/java/com/spotify/styx/api/AuthenticatorConfiguration.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/AuthenticatorConfiguration.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 @AutoMatter
 public interface AuthenticatorConfiguration {
 
+  boolean disableResourceIdCacheWarmup();
   Set<String> domainWhitelist();
   Set<ResourceId> resourceWhitelist();
   String service();
@@ -43,12 +44,15 @@ public interface AuthenticatorConfiguration {
 
   static AuthenticatorConfiguration fromConfig(Config config, String serviceName) {
 
+    final String disableResourceIdCacheWarmupKey = "styx.authentication.disable-resource-id-cache-warmup";
     final String domainWhitelistKey = "styx.authentication.domain-whitelist";
     final String resourceWhitelistKey = "styx.authentication.resource-whitelist";
     final String allowedAudiencesKey = "styx.authentication.allowed-audiences";
 
     final AuthenticatorConfigurationBuilder builder = AuthenticatorConfiguration.builder()
         .service(serviceName);
+
+    get(config, config::getBoolean, disableResourceIdCacheWarmupKey).ifPresent(builder::disableResourceIdCacheWarmup);
 
     get(config, config::getStringList, domainWhitelistKey).ifPresent(builder::domainWhitelist);
 

--- a/styx-service-common/src/main/java/com/spotify/styx/api/AuthenticatorFactory.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/AuthenticatorFactory.java
@@ -95,10 +95,12 @@ public interface AuthenticatorFactory extends Function<AuthenticatorConfiguratio
 
       final Authenticator validator =
           new Authenticator(googleIdTokenVerifier, cloudResourceManager, iam, configuration);
-      try {
-        validator.cacheResources();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
+      if (!configuration.disableResourceIdCacheWarmup()) {
+        try {
+          validator.cacheResources();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
       }
       return validator;
     }

--- a/styx-service-common/src/test/java/com/spotify/styx/api/AuthenticatorConfigurationTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/AuthenticatorConfigurationTest.java
@@ -21,8 +21,8 @@
 package com.spotify.styx.api;
 
 import static com.spotify.styx.api.Authenticator.resourceId;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -37,6 +37,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class AuthenticatorConfigurationTest {
 
+  private static final String DISABLE_RESOURCE_ID_CACHE_WARMUP_KEY =
+      "styx.authentication.disable-resource-id-cache-warmup";
   private static final String DOMAIN_WHITELIST_KEY = "styx.authentication.domain-whitelist";
   private static final String RESOURCE_WHITELIST_KEY = "styx.authentication.resource-whitelist";
 
@@ -57,15 +59,18 @@ public class AuthenticatorConfigurationTest {
     final List<? extends Config> resourceWhitelist = List.of(resourceConfig1,
         resourceConfig2);
     
+    when(config.hasPath(DISABLE_RESOURCE_ID_CACHE_WARMUP_KEY)).thenReturn(true);
     when(config.hasPath(DOMAIN_WHITELIST_KEY)).thenReturn(true);
     when(config.hasPath(RESOURCE_WHITELIST_KEY)).thenReturn(true);
-    
+
+    when(config.getBoolean(DISABLE_RESOURCE_ID_CACHE_WARMUP_KEY)).thenReturn(true);
     when(config.getStringList(DOMAIN_WHITELIST_KEY)).thenReturn(domainWhitelist);
     doReturn(resourceWhitelist).when(config).getConfigList(RESOURCE_WHITELIST_KEY);
 
     final AuthenticatorConfiguration configuration =
         AuthenticatorConfiguration.fromConfig(config, "foo");
 
+    assertThat(configuration.disableResourceIdCacheWarmup(), is(true));
     assertThat(configuration.domainWhitelist(), is(ImmutableSet.copyOf(domainWhitelist)));
     assertThat(configuration.resourceWhitelist(), is(ImmutableSet
         .of(resourceId(resourceConfig1.getString("type"), resourceConfig1.getString("id")),
@@ -78,6 +83,7 @@ public class AuthenticatorConfigurationTest {
     final AuthenticatorConfiguration configuration =
         AuthenticatorConfiguration.fromConfig(config, "foo");
 
+    assertThat(configuration.disableResourceIdCacheWarmup(), is(false));
     assertThat(configuration.domainWhitelist(), is(ImmutableSet.of()));
     assertThat(configuration.resourceWhitelist(), is(ImmutableSet.of()));
     assertThat(configuration.service(), is("foo"));

--- a/styx-service-common/src/test/java/com/spotify/styx/api/AuthenticatorFactoryTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/AuthenticatorFactoryTest.java
@@ -20,12 +20,13 @@
 
 package com.spotify.styx.api;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -105,6 +106,17 @@ public class AuthenticatorFactoryTest {
     final AuthenticatorConfiguration configuration = AuthenticatorConfiguration.builder().service("test").build();
     assertThat(authenticatorFactory.apply(configuration), is(notNullValue()));
     verify(projectsList).execute();
+  }
+
+  @Test
+  public void shouldCreateAuthenticatorWithoutEarlyCaching() throws IOException {
+    final AuthenticatorConfiguration configuration =
+        AuthenticatorConfiguration.builder()
+            .service("test")
+            .disableResourceIdCacheWarmup(true)
+            .build();
+    assertThat(authenticatorFactory.apply(configuration), is(notNullValue()));
+    verify(projectsList, never()).execute();
   }
   
   @Test

--- a/styx-standalone-service/src/main/resources/styx-standalone.conf
+++ b/styx-standalone-service/src/main/resources/styx-standalone.conf
@@ -42,6 +42,10 @@ styx.secret-whitelist = [
   # "bar-secret",
 ]
 
+# A flag to disable the warmup of resource IDs cache used for authentication and only fill in cache when needed.
+# Default to false
+styx.authentication.disable-resource-id-cache-warmup = false
+
 # A white list of domains whose users should be granted access to perform non-GET requests against the Styx API.
 styx.authentication.domain-whitelist = [
   # "foo.com",


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Add a config item to disable early caching

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This early caching slows down integration test quite a bit which is
unnecessary.

This doesn't change production behaviour if left configured.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit test and e2e test.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
