### PR TITLE
Add pod mutator and default noop impl

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/DockerRunner.java
@@ -111,12 +111,13 @@ public interface DockerRunner extends Closeable {
                                  ServiceAccountKeyManager serviceAccountKeyManager,
                                  Debug debug,
                                  String styxEnvironment,
-                                 Set<String> secretWhitelist) {
+                                 Set<String> secretWhitelist,
+                                 PodMutator podMutator) {
     final KubernetesGCPServiceAccountSecretManager serviceAccountSecretManager =
         new KubernetesGCPServiceAccountSecretManager(kubernetesClient, serviceAccountKeyManager, stats);
     final KubernetesDockerRunner dockerRunner =
         new KubernetesDockerRunner(id, kubernetesClient, stateManager, stats,
-            serviceAccountSecretManager, debug, styxEnvironment, secretWhitelist);
+            serviceAccountSecretManager, debug, styxEnvironment, secretWhitelist, podMutator);
 
     dockerRunner.init();
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/PodMutator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/PodMutator.java
@@ -1,0 +1,31 @@
+/*
+ * -\-\-
+ * Spotify Styx Scheduler Service
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.styx.docker;
+
+import com.spotify.styx.model.WorkflowInstance;
+import io.fabric8.kubernetes.api.model.Pod;
+
+public interface PodMutator {
+
+  PodMutator NOOP = (workflowInstance, runSpec, styxEnvironment, pod) -> pod;
+
+  Pod mutate(WorkflowInstance workflowInstance, DockerRunner.RunSpec runSpec, String styxEnvironment, Pod pod);
+}

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -139,7 +139,7 @@ public class StyxSchedulerServiceFixture {
     StyxScheduler.ExecutorFactory executorFactory = (ts, tf) -> executor;
     StyxScheduler.PublisherFactory publisherFactory = (env) -> Publisher.NOOP;
     StyxScheduler.DockerRunnerFactory dockerRunnerFactory =
-        (id, env, states, stats, debug, secretWhitelist, time) -> fakeDockerRunner();
+        (id, env, states, stats, debug, secretWhitelist, podMutator, time) -> fakeDockerRunner();
     StyxScheduler.FlyteRunnerFactory flyteRunnerFactory =
         (id, config, stateManager) -> fakeFlyteRunner();
     WorkflowResourceDecorator resourceDecorator = (rs, cfg, res) ->

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -24,8 +24,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.spotify.styx.docker.KubernetesDockerRunner.KubernetesSecretSpec;
@@ -100,7 +100,7 @@ public class KubernetesDockerRunnerPodPollerTest {
     when(k8sClient.listPods()).thenReturn(podList);
 
     kdr = new KubernetesDockerRunner("test", k8sClient, stateManager, stats, serviceAccountSecretManager,
-        debug, STYX_ENVIRONMENT, Set.of());
+        debug, STYX_ENVIRONMENT, Set.of(), PodMutator.NOOP);
   }
 
   @Test
@@ -141,7 +141,7 @@ public class KubernetesDockerRunnerPodPollerTest {
 
     kdr.tryCleanupPods();
 
-    verifyZeroInteractions(stateManager);
+    verifyNoInteractions(stateManager);
   }
 
   @Test
@@ -233,6 +233,6 @@ public class KubernetesDockerRunnerPodPollerTest {
                                DockerRunner.RunSpec runSpec,
                                KubernetesSecretSpec secretSpec) {
     return KubernetesDockerRunner
-        .createPod(workflowInstance, runSpec, secretSpec, STYX_ENVIRONMENT);
+        .createPod(workflowInstance, runSpec, secretSpec, STYX_ENVIRONMENT, PodMutator.NOOP);
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodResourceTest.java
@@ -267,10 +267,10 @@ public class KubernetesDockerRunnerPodResourceTest {
     assertThat(envVars, hasItem(envVar(LOGGING, "structured")));
   }
 
-  private static Pod createPod(WorkflowInstance workflowInstance,
+  private Pod createPod(WorkflowInstance workflowInstance,
                                DockerRunner.RunSpec runSpec,
                                KubernetesSecretSpec secretSpec) {
     return KubernetesDockerRunner
-        .createPod(workflowInstance, runSpec, secretSpec, STYX_ENVIRONMENT);
+        .createPod(workflowInstance, runSpec, secretSpec, STYX_ENVIRONMENT, PodMutator.NOOP);
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -23,9 +23,9 @@ package com.spotify.styx.docker;
 import static com.spotify.styx.docker.KubernetesDockerRunner.KEEPALIVE_CONTAINER_NAME;
 import static com.spotify.styx.docker.KubernetesDockerRunner.MAIN_CONTAINER_NAME;
 import static com.spotify.styx.docker.KubernetesPodEventTranslator.translate;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertThat;
 
 import com.spotify.styx.docker.KubernetesDockerRunner.KubernetesSecretSpec;
 import com.spotify.styx.model.Event;
@@ -63,7 +63,7 @@ public class KubernetesPodEventTranslatorTest {
 
   private static final String STYX_ENVIRONMENT = "testing";
 
-  private Pod pod = KubernetesDockerRunner.createPod(WFI, RUN_SPEC, SECRET_SPEC, STYX_ENVIRONMENT);
+  private final Pod pod = KubernetesDockerRunner.createPod(WFI, RUN_SPEC, SECRET_SPEC, STYX_ENVIRONMENT, PodMutator.NOOP);
 
   @Test
   public void terminateOnSuccessfulTermination() {
@@ -426,6 +426,7 @@ public class KubernetesPodEventTranslatorTest {
             .imageName("busybox")
             .terminationLogging(true).build(),
         SECRET_SPEC,
-        STYX_ENVIRONMENT);
+        STYX_ENVIRONMENT,
+        PodMutator.NOOP);
   }
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Add pod mutator and default noop impl.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This enables injecting a meaningful pod mutator to change pod definition, such as adding resource requests/limits.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit test.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
