### PR TITLE
Get rid of deprecated import

### DIFF
--- a/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/AdHocTriggeringIT.java
+++ b/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/AdHocTriggeringIT.java
@@ -45,7 +45,7 @@ public class AdHocTriggeringIT extends EndToEndTestBase {
         "schedule", "daily",
         "flyte_exec_conf", FLYTE_EXEC_CONF_MAP));
 
-    testAdhocTriggering(workflowJson);
+    doTestAdhocTriggering(workflowJson);
   }
 
   @Test
@@ -59,10 +59,10 @@ public class AdHocTriggeringIT extends EndToEndTestBase {
         "docker_image", "busybox",
         "docker_args", List.of("echo", "hello world")));
 
-    testAdhocTriggering(workflowJson);
+    doTestAdhocTriggering(workflowJson);
   }
 
-  private void testAdhocTriggering(String workflowJson) throws Exception {
+  private void doTestAdhocTriggering(String workflowJson) throws Exception {
     var workflowJsonFile = temporaryFolder.newFile().toPath();
     Files.writeString(workflowJsonFile, workflowJson);
 

--- a/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/BackfillIT.java
+++ b/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/BackfillIT.java
@@ -51,7 +51,7 @@ public class BackfillIT extends EndToEndTestBase {
         "service_account", workflowServiceAccount.getEmail(),
         "docker_image", "busybox",
         "docker_args", List.of("echo", "{}")));
-    testBackfill(workflowJson);
+    doTestBackfill(workflowJson);
   }
 
   @Test
@@ -61,10 +61,10 @@ public class BackfillIT extends EndToEndTestBase {
         "id", workflowId1,
         "schedule", "daily",
         "flyte_exec_conf", FLYTE_EXEC_CONF_MAP));
-    testBackfill(workflowJson);
+    doTestBackfill(workflowJson);
   }
 
-  private void testBackfill(String workflowJson) throws Exception {
+  private void doTestBackfill(String workflowJson) throws Exception {
     var workflowJsonFile = temporaryFolder.newFile().toPath();
     Files.writeString(workflowJsonFile, workflowJson);
 

--- a/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/BackfillIT.java
+++ b/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/BackfillIT.java
@@ -23,8 +23,8 @@ package com.spotify.styx.e2e_tests;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.toList;
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.auto.service.AutoService;

--- a/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/CreateDeleteWorkflowIT.java
+++ b/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/CreateDeleteWorkflowIT.java
@@ -48,7 +48,7 @@ public class CreateDeleteWorkflowIT extends EndToEndTestBase {
         .dockerArgs(List.of("echo", "hello world"))
         .serviceAccount(workflowServiceAccount.getEmail())
         .build();
-    testCreateDeleteWorkflow(workflowConfiguration);
+    doTestCreateDeleteWorkflow(workflowConfiguration);
   }
 
   @Test
@@ -59,10 +59,10 @@ public class CreateDeleteWorkflowIT extends EndToEndTestBase {
         .flyteExecConf(
             OBJECT_MAPPER.readValue(OBJECT_MAPPER.writeValueAsBytes(FLYTE_EXEC_CONF_MAP), FlyteExecConf.class))
         .build();
-    testCreateDeleteWorkflow(workflowConfiguration);
+    doTestCreateDeleteWorkflow(workflowConfiguration);
   }
 
-  private void testCreateDeleteWorkflow(WorkflowConfiguration workflowConfiguration) throws Exception {
+  private void doTestCreateDeleteWorkflow(WorkflowConfiguration workflowConfiguration) throws Exception {
     var workflow = Workflow.create(component1, workflowConfiguration);
     var workflowJson = OBJECT_MAPPER.writeValueAsString(workflowConfiguration);
     var workflowJsonFile = temporaryFolder.newFile().toPath();

--- a/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/DummyTest.java
+++ b/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/DummyTest.java
@@ -20,8 +20,8 @@
 
 package com.spotify.styx.e2e_tests;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import com.spotify.styx.util.ClassEnforcer;
 import org.junit.Test;

--- a/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/ScheduledTriggeringIT.java
+++ b/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/ScheduledTriggeringIT.java
@@ -48,7 +48,7 @@ public class ScheduledTriggeringIT extends EndToEndTestBase {
                 "schedule", "* * * * *",
                 "flyte_exec_conf", FLYTE_EXEC_CONF_MAP));
 
-    scheduledTriggering(workflowJson);
+    doTestscheduledTriggering(workflowJson);
   }
 
   @Test
@@ -61,10 +61,10 @@ public class ScheduledTriggeringIT extends EndToEndTestBase {
         "docker_image", "busybox",
         "docker_args", List.of("echo", "{}")));
 
-    scheduledTriggering(workflowJson);
+    doTestscheduledTriggering(workflowJson);
   }
 
-  private void scheduledTriggering(String workflowJson) throws Exception {
+  private void doTestscheduledTriggering(String workflowJson) throws Exception {
 
     var workflowJsonFile = temporaryFolder.newFile().toPath();
     Files.writeString(workflowJsonFile, workflowJson);

--- a/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/ScheduledTriggeringIT.java
+++ b/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/ScheduledTriggeringIT.java
@@ -22,8 +22,8 @@ package com.spotify.styx.e2e_tests;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.auto.service.AutoService;

--- a/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/TestNamespacesTest.java
+++ b/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/TestNamespacesTest.java
@@ -20,8 +20,8 @@
 
 package com.spotify.styx.e2e_tests;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.time.Instant;
 import org.junit.Test;


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Get rid of deprecated import.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`assertThat` from `junit` has been deprecated for long. This PR fixes `styx-e2e-test` module.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
