### PR TITLE
More threads

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -364,9 +364,7 @@ public class StyxScheduler implements AppInit {
     final Publisher publisher = publisherFactory.apply(environment);
     closer.register(publisher);
 
-    // TODO: is the shutdown timeout of 1 second here sane?
-    final ScheduledExecutorService tickExecutor = executorFactory.create(3, tickTf);
-    closer.register(closeable(tickExecutor, "tick-executor", Duration.ofSeconds(1)));
+
     var stateProcessingExecutor = Executors.newWorkStealingPool(
         optionalInt(config, STYX_STATE_PROCESSING_THREADS).orElse(DEFAULT_STYX_STATE_PROCESSING_THREADS));
     closer.register(closeable(stateProcessingExecutor, "state-processing", Duration.ofSeconds(1)));
@@ -459,6 +457,10 @@ public class StyxScheduler implements AppInit {
 
     final Duration stateManagerTickInterval = get(config, config::getDuration, STYX_STATE_MANAGER_TICK_INTERVAL)
         .orElse(DEFAULT_STATE_MANAGER_TICK_INTERVAL);
+
+    // TODO: is the shutdown timeout of 1 second here sane?
+    final ScheduledExecutorService tickExecutor = executorFactory.create(3, tickTf);
+    closer.register(closeable(tickExecutor, "tick-executor", Duration.ofSeconds(1)));
 
     startTriggerManager(triggerManager, tickExecutor, triggerTickInterval);
     startBackfillTriggerManager(backfillTriggerManager, tickExecutor, triggerTickInterval);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -459,7 +459,7 @@ public class StyxScheduler implements AppInit {
         .orElse(DEFAULT_STATE_MANAGER_TICK_INTERVAL);
 
     // TODO: is the shutdown timeout of 1 second here sane?
-    final ScheduledExecutorService tickExecutor = executorFactory.create(3, tickTf);
+    final ScheduledExecutorService tickExecutor = executorFactory.create(6, tickTf);
     closer.register(closeable(tickExecutor, "tick-executor", Duration.ofSeconds(1)));
 
     startTriggerManager(triggerManager, tickExecutor, triggerTickInterval);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -364,7 +364,6 @@ public class StyxScheduler implements AppInit {
     final Publisher publisher = publisherFactory.apply(environment);
     closer.register(publisher);
 
-
     var stateProcessingExecutor = Executors.newWorkStealingPool(
         optionalInt(config, STYX_STATE_PROCESSING_THREADS).orElse(DEFAULT_STYX_STATE_PROCESSING_THREADS));
     closer.register(closeable(stateProcessingExecutor, "state-processing", Duration.ofSeconds(1)));


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
One thread for each scheduled tick method. The previous number made sense when we had less scheduled services. With too few threads they may compete to execute and cause performance problems.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
