### PR TITLE
Use grpc transparent retries

### DIFF
--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -55,7 +55,7 @@ public class FlyteAdminClient {
       builder.usePlaintext();
     }
 
-    var channel = builder.build();
+    var channel = builder.enableRetry().maxRetryAttempts(0).build();
 
     return new FlyteAdminClient(AdminServiceGrpc.newBlockingStub(channel));
   }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Use grpc transparent retires for flyte admin client.

## Motivation and Context
Use grpc transparent retires for flyte admin client.

## Have you tested this? If so, how?
As it is just a configuration change for the grpc client, no test added for it.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
