### PR TITLE
Retry by next tick for execution poll error

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -221,9 +221,7 @@ public class FlyteAdminClientRunner implements FlyteRunner {
       return;
     }
 
-    if (execution != null) {
-      emitFlyteEvents(execution, runState);
-    }
+    emitFlyteEvents(execution, runState);
   }
 
   void init() {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -204,11 +204,11 @@ public class FlyteAdminClientRunner implements FlyteRunner {
   public void poll(FlyteExecutionId flyteExecutionId, RunState runState) {
     requireNonNull(flyteExecutionId, "flyteExecutionId");
     requireNonNull(runState, "runState");
+    final ExecutionOuterClass.Execution execution;
     try {
-      final ExecutionOuterClass.Execution execution =
+      execution =
           flyteAdminClient.getExecution(flyteExecutionId.project(),
               flyteExecutionId.domain(), flyteExecutionId.name());
-      emitFlyteEvents(execution, runState);
     } catch (StatusRuntimeException e) {
       LOG.warn("Failed to poll flyte execution {}", flyteExecutionId, e);
 
@@ -217,7 +217,11 @@ public class FlyteAdminClientRunner implements FlyteRunner {
             Event.runError(runState.workflowInstance(), "Could not find execution: " + flyteExecutionId.toUrn()),
             runState.counter());
       }
+
+      return;
     }
+
+    emitFlyteEvents(execution, runState);
   }
 
   void init() {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -221,7 +221,9 @@ public class FlyteAdminClientRunner implements FlyteRunner {
       return;
     }
 
-    emitFlyteEvents(execution, runState);
+    if (execution != null) {
+      emitFlyteEvents(execution, runState);
+    }
   }
 
   void init() {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
@@ -39,7 +39,7 @@ public interface FlyteRunner extends Closeable {
   void terminateExecution(RunState runState, FlyteExecutionId flyteExecutionId);
 
   void poll(FlyteExecutionId flyteExecutionId, RunState runState)
-      throws PollingException;
+      throws ExecutionNotFoundException;
 
   static FlyteRunner noop() {
     return new NoopFlyteRunner();
@@ -87,21 +87,7 @@ public interface FlyteRunner extends Closeable {
     }
   }
 
-  class PollingException extends Exception {
-    public PollingException(FlyteExecutionId id, Throwable cause) {
-      super("Could not poll for execution: " + id.toUrn(), cause);
-    }
-
-    public PollingException(String message) {
-      super(message);
-    }
-
-    public PollingException(String message, Throwable cause) {
-      super(message, cause);
-    }
-  }
-
-  class ExecutionNotFoundException extends PollingException {
+  class ExecutionNotFoundException extends Exception {
     public ExecutionNotFoundException(FlyteExecutionId id, Throwable cause) {
       super("Could not find execution: " + id.toUrn(), cause);
     }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
@@ -38,8 +38,7 @@ public interface FlyteRunner extends Closeable {
 
   void terminateExecution(RunState runState, FlyteExecutionId flyteExecutionId);
 
-  void poll(FlyteExecutionId flyteExecutionId, RunState runState)
-      throws ExecutionNotFoundException;
+  void poll(FlyteExecutionId flyteExecutionId, RunState runState);
 
   static FlyteRunner noop() {
     return new NoopFlyteRunner();
@@ -84,12 +83,6 @@ public interface FlyteRunner extends Closeable {
   class LaunchPlanNotFound extends CreateExecutionException {
     public LaunchPlanNotFound(FlyteExecConf conf, Throwable cause) {
       super("Launch plan not found: " + conf.referenceId(), cause);
-    }
-  }
-
-  class ExecutionNotFoundException extends Exception {
-    public ExecutionNotFoundException(FlyteExecutionId id, Throwable cause) {
-      super("Could not find execution: " + id.toUrn(), cause);
     }
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
@@ -48,7 +48,7 @@ class NoopFlyteRunner implements FlyteRunner {
 
   @Override
   public void poll(final FlyteExecutionId flyteExecutionId, final RunState runState) {
-    // noop
+    throw new IllegalStateException("Cannot poll execution : " + flyteExecutionId);
   }
 
   @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx.flyte;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.spotify.styx.model.FlyteExecConf;
 import com.spotify.styx.state.RunState;
 import java.util.Map;
@@ -27,7 +28,8 @@ import java.util.Map;
 /**
  * No-op {@code FlyteRunner} meant to be used when Flyte is disabled or not available.
  */
-class NoopFlyteRunner implements FlyteRunner {
+@VisibleForTesting
+public class NoopFlyteRunner implements FlyteRunner {
 
   @Override
   public boolean isEnabled() {
@@ -48,7 +50,7 @@ class NoopFlyteRunner implements FlyteRunner {
 
   @Override
   public void poll(final FlyteExecutionId flyteExecutionId, final RunState runState) {
-    throw new IllegalStateException("Cannot poll execution : " + flyteExecutionId);
+    // noop
   }
 
   @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
@@ -47,13 +47,12 @@ class NoopFlyteRunner implements FlyteRunner {
   }
 
   @Override
-  public void poll(final FlyteExecutionId flyteExecutionId, final RunState runState)
-      throws PollingException {
-    throw new PollingException("Cannot poll for execution: " + flyteExecutionId.toUrn());
+  public void poll(final FlyteExecutionId flyteExecutionId, final RunState runState) {
+    // noop
   }
 
   @Override
   public void close() {
-    // nothing to close
+    // noop
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/RoutingFlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/RoutingFlyteRunner.java
@@ -49,7 +49,7 @@ public class RoutingFlyteRunner extends AbstractRoutingRunner<FlyteRunner>
   }
 
   @Override
-  public void poll(FlyteExecutionId flyteExecutionId, RunState runState) throws PollingException {
+  public void poll(FlyteExecutionId flyteExecutionId, RunState runState) {
     runner(runState).poll(flyteExecutionId, runState);
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
@@ -45,7 +45,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.RateLimiter;
 import com.spotify.styx.StyxScheduler.KubernetesClientFactory;
-import com.spotify.styx.flyte.FlyteExecutionId;
 import com.spotify.styx.flyte.FlyteRunner;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowConfiguration;
@@ -281,7 +280,6 @@ public class StyxSchedulerTest {
     assertThat(flyteRunner, notNullValue());
     assertThat(flyteRunner.isEnabled(), is(false));
     assertThrows(FlyteRunner.CreateExecutionException.class, () -> flyteRunner.createExecution(null, null, null, null));
-    assertThrows(FlyteRunner.PollingException.class, () -> flyteRunner.poll(FlyteExecutionId.create("flyte-test","testing","test"), null));
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
@@ -24,6 +24,7 @@ import static com.spotify.styx.model.Schedule.DAYS;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.theInstance;
@@ -46,6 +47,7 @@ import com.google.common.io.Resources;
 import com.google.common.util.concurrent.RateLimiter;
 import com.spotify.styx.StyxScheduler.KubernetesClientFactory;
 import com.spotify.styx.flyte.FlyteRunner;
+import com.spotify.styx.flyte.NoopFlyteRunner;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowId;
@@ -277,9 +279,7 @@ public class StyxSchedulerTest {
     var config = ConfigFactory.parseMap(configMap.build());
     final FlyteRunner flyteRunner = StyxScheduler.createFlyteRunner("runnerId", config, stateManager);
 
-    assertThat(flyteRunner, notNullValue());
-    assertThat(flyteRunner.isEnabled(), is(false));
-    assertThrows(FlyteRunner.CreateExecutionException.class, () -> flyteRunner.createExecution(null, null, null, null));
+    assertThat(flyteRunner, instanceOf(NoopFlyteRunner.class));
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
@@ -378,7 +378,7 @@ public class FlyteAdminClientRunnerTest {
 
     flyteRunner.poll(FLYTE_EXECUTION_ID, RUN_STATE);
     verify(stateManager).receiveIgnoreClosed(
-        Event.runError(WORKFLOW_INSTANCE, "Could not find execution: " + FLYTE_EXECUTION_ID.toUrn()),-1);
+        Event.runError(WORKFLOW_INSTANCE, "Could not find execution: " + FLYTE_EXECUTION_ID.toUrn()), -1);
   }
 
   @Test
@@ -387,16 +387,6 @@ public class FlyteAdminClientRunnerTest {
         .when(flyteAdminClient).getExecution(anyString(), anyString(), anyString());
     flyteRunner.poll(FLYTE_EXECUTION_ID, RUN_STATE);
     verifyNoInteractions(stateManager);
-  }
-
-  @Test
-  public void testPollingException() {
-    doThrow(new RuntimeException())
-        .when(flyteAdminClient).getExecution(anyString(), anyString(), anyString());
-
-    assertThrows(
-        RuntimeException.class,
-        () -> flyteRunner.poll(FLYTE_EXECUTION_ID, RUN_STATE));
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
@@ -376,19 +376,17 @@ public class FlyteAdminClientRunnerTest {
     doThrow(new StatusRuntimeException(Status.NOT_FOUND))
         .when(flyteAdminClient).getExecution(anyString(), anyString(), anyString());
 
-    assertThrows(
-        FlyteRunner.ExecutionNotFoundException.class,
-        () -> flyteRunner.poll(FLYTE_EXECUTION_ID, RUN_STATE));
+    flyteRunner.poll(FLYTE_EXECUTION_ID, RUN_STATE);
+    verify(stateManager).receiveIgnoreClosed(
+        Event.runError(WORKFLOW_INSTANCE, "Could not find execution: " + FLYTE_EXECUTION_ID.toUrn()),-1);
   }
 
   @Test
   public void testPollingExceptionFlyteAdminClientExecution() {
     doThrow(new StatusRuntimeException(Status.INTERNAL))
         .when(flyteAdminClient).getExecution(anyString(), anyString(), anyString());
-
-    assertThrows(
-        FlyteRunner.PollingException.class,
-        () -> flyteRunner.poll(FLYTE_EXECUTION_ID, RUN_STATE));
+    flyteRunner.poll(FLYTE_EXECUTION_ID, RUN_STATE);
+    verifyNoInteractions(stateManager);
   }
 
   @Test
@@ -397,7 +395,7 @@ public class FlyteAdminClientRunnerTest {
         .when(flyteAdminClient).getExecution(anyString(), anyString(), anyString());
 
     assertThrows(
-        FlyteRunner.PollingException.class,
+        RuntimeException.class,
         () -> flyteRunner.poll(FLYTE_EXECUTION_ID, RUN_STATE));
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/NoopFlyteRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/NoopFlyteRunnerTest.java
@@ -62,14 +62,6 @@ public class NoopFlyteRunnerTest {
   }
 
   @Test
-  public void testPollingThrowsException() {
-    assertThrows(
-        IllegalStateException.class,
-        () -> runner.poll(FLYTE_EXECUTION_ID, null)
-    );
-  }
-
-  @Test
   public void testCloseDoesNotThrowsExeption() {
     runner.close();
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/NoopFlyteRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/NoopFlyteRunnerTest.java
@@ -64,7 +64,7 @@ public class NoopFlyteRunnerTest {
   @Test
   public void testPollingThrowsException() {
     assertThrows(
-        FlyteRunner.PollingException.class,
+        IllegalStateException.class,
         () -> runner.poll(FLYTE_EXECUTION_ID, null)
     );
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/RoutingFlyteRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/RoutingFlyteRunnerTest.java
@@ -67,7 +67,7 @@ public class RoutingFlyteRunnerTest extends AbstractRoutingRunnerTest<FlyteRunne
   }
 
   @Test
-  public void testUsesCreatesRunnerOnPoll() throws FlyteRunner.PollingException {
+  public void testUsesCreatesRunnerOnPoll() {
     flyteRunner.poll(executionId, runState);
 
     assertThatCreateCountersContains("default");

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
@@ -177,7 +177,7 @@ public class FlyteRunnerHandlerTest {
   }
 
   @Test
-  public void shouldReportRunErrorWhenCatchingExceptionDuringPolling()
+  public void shouldNotReportWhenCatchingExceptionDuringPolling()
       throws FlyteRunner.PollingException, IsClosedException {
     RunState runState = RunState.create(WORKFLOW_INSTANCE, State.RUNNING, StateData.newBuilder()
         .executionId(EXECUTION_ID)
@@ -189,10 +189,7 @@ public class FlyteRunnerHandlerTest {
 
     flyteRunnerHandler.transitionInto(runState, eventRouter);
 
-    final var errMessage = "Test polling exception";
-
-    verify(eventRouter,  timeout(60_000)).receive(Event.runError(WORKFLOW_INSTANCE, errMessage),
-        runState.counter());
+    verifyNoInteractions(eventRouter);
   }
 
   @Test

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
@@ -152,7 +152,7 @@ public class FlyteRunnerHandlerTest {
   }
 
   @Test
-  public void shouldPollInRunning() throws FlyteRunner.PollingException {
+  public void shouldPollInRunning() {
     RunState runState = RunState.create(WORKFLOW_INSTANCE, State.RUNNING, StateData.newBuilder()
         .executionId(EXECUTION_ID)
         .executionDescription(FLYTE_EXECUTION_DESCRIPTION)
@@ -164,7 +164,7 @@ public class FlyteRunnerHandlerTest {
   }
 
   @Test
-  public void shouldPollInSubmitted() throws FlyteRunner.PollingException {
+  public void shouldPollInSubmitted() {
     RunState runState = RunState.create(WORKFLOW_INSTANCE, State.SUBMITTED, StateData.newBuilder()
         .executionId(EXECUTION_ID)
         .executionDescription(FLYTE_EXECUTION_DESCRIPTION)
@@ -177,13 +177,12 @@ public class FlyteRunnerHandlerTest {
   }
 
   @Test
-  public void shouldNotReportWhenCatchingExceptionDuringPolling()
-      throws FlyteRunner.PollingException, IsClosedException {
+  public void shouldNotReportWhenCatchingExceptionDuringPolling() {
     RunState runState = RunState.create(WORKFLOW_INSTANCE, State.RUNNING, StateData.newBuilder()
         .executionId(EXECUTION_ID)
         .executionDescription(FLYTE_EXECUTION_DESCRIPTION)
         .build());
-    doThrow(new FlyteRunner.PollingException("Test polling exception"))
+    doThrow(new Exception("Test polling exception"))
         .when(flyteRunner)
         .poll(any(), any());
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
@@ -88,7 +88,7 @@ public class FlyteRunnerHandlerTest {
 
     flyteRunnerHandler.transitionInto(runState, eventRouter);
     verify(flyteRunner).createExecution(runState, TestData.FLYTE_EXECUTION_ID, FLYTE_EXEC_CONF, ANNOTATIONS);
-    verify(eventRouter,  timeout(60_000)).receive(Event.submitted(WORKFLOW_INSTANCE, EXECUTION_ID, "runnerId"),
+    verify(eventRouter,  timeout(60_000)).receiveIgnoreClosed(Event.submitted(WORKFLOW_INSTANCE, EXECUTION_ID, "runnerId"),
         runState.counter());
   }
 
@@ -119,7 +119,7 @@ public class FlyteRunnerHandlerTest {
     flyteRunnerHandler.transitionInto(runState, eventRouter);
 
     verify(flyteRunner).createExecution(runState, TestData.FLYTE_EXECUTION_ID, FLYTE_EXEC_CONF, ANNOTATIONS);
-    verify(eventRouter,  timeout(60_000)).receive(Event.runError(WORKFLOW_INSTANCE, "Houston we have a problem"),
+    verify(eventRouter,  timeout(60_000)).receiveIgnoreClosed(Event.runError(WORKFLOW_INSTANCE, "Houston we have a problem"),
         runState.counter());
   }
 
@@ -174,21 +174,6 @@ public class FlyteRunnerHandlerTest {
 
     verify(flyteRunner).poll(getFlyteExecutionId(FLYTE_EXECUTION_DESCRIPTION,
         TestData.FLYTE_EXECUTION_ID), runState);
-  }
-
-  @Test
-  public void shouldNotReportWhenCatchingExceptionDuringPolling() {
-    RunState runState = RunState.create(WORKFLOW_INSTANCE, State.RUNNING, StateData.newBuilder()
-        .executionId(EXECUTION_ID)
-        .executionDescription(FLYTE_EXECUTION_DESCRIPTION)
-        .build());
-    doThrow(new Exception("Test polling exception"))
-        .when(flyteRunner)
-        .poll(any(), any());
-
-    flyteRunnerHandler.transitionInto(runState, eventRouter);
-
-    verifyNoInteractions(eventRouter);
   }
 
   @Test


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Retry by next tick for execution poll error. Do nothing when execution polling failed as in real life, there should always be an execution in Flyte. We don't use the grpc retries because it would block the thread for a while. 
## Motivation and Context


## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
