### PR TITLE
Force delete if pod in terminating for long

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/Fabric8KubernetesClient.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/Fabric8KubernetesClient.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.api.model.SecretList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.Deletable;
 import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -45,7 +46,7 @@ public interface Fabric8KubernetesClient {
 
   Pod createPod(Pod pod);
 
-  boolean deletePod(String name);
+  boolean deletePod(String name, boolean force);
 
   Watch watchPods(Watcher<Pod> watcher);
 
@@ -112,8 +113,15 @@ public interface Fabric8KubernetesClient {
     }
 
     @Override
-    public boolean deletePod(String name) {
-      return Optional.ofNullable(client.pods().withName(name).delete()).orElse(false);
+    public boolean deletePod(String name, boolean force) {
+      var pod = client.pods().withName(name);
+      final Deletable<Boolean> deletablePod;
+      if (force) {
+        deletablePod = pod.withGracePeriod(0L);
+      } else {
+        deletablePod = pod;
+      }
+      return Optional.ofNullable(deletablePod.delete()).orElse(false);
     }
   }
 }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -400,7 +400,9 @@ class KubernetesDockerRunner implements DockerRunner {
     if (isTerminated(containerStatus.get())) {
       return shouldDeletePodIfNonDeletePeriodExpired(workflowInstance, pod);
     } else if (imageError(containerStatus.get()).isPresent()) {
-      return PodDeletionDecision.newBuilder().delete(shouldDeletePod(workflowInstance, pod, "Pull image error")).build();
+      return PodDeletionDecision.newBuilder()
+          .delete(shouldDeletePod(workflowInstance, pod, "Pull image error"))
+          .build();
     }
     return PodDeletionDecision.DO_NOT_DELETE;
   }
@@ -439,7 +441,8 @@ class KubernetesDockerRunner implements DockerRunner {
     var pod = podOpt.orElseThrow();
     // if not terminated, delete directly
     if (!isTerminated(pod)) {
-      return PodDeletionDecision.newBuilder().delete(shouldDeletePod(workflowInstance, pod, "No RunState, not terminated"))
+      return PodDeletionDecision.newBuilder()
+          .delete(shouldDeletePod(workflowInstance, pod, "No RunState, not terminated"))
           .build();
     }
     return PodDeletionDecision.DO_NOT_DELETE;
@@ -567,11 +570,11 @@ class KubernetesDockerRunner implements DockerRunner {
       return;
     }
     var runState = stateManager.getActiveState(workflowInstance.orElseThrow());
-    var shouldDelete = runState.isPresent() && isPodRunState(pod, runState.orElseThrow())
+    var podDeletionDecision = runState.isPresent() && isPodRunState(pod, runState.orElseThrow())
                        ? shouldDeletePodWithRunState(workflowInstance.orElseThrow(), pod, runState.orElseThrow())
                        : shouldDeletePodWithoutRunState(workflowInstance.orElseThrow(), pod);
-    if (shouldDelete.delete()) {
-      client.deletePod(pod.getMetadata().getName(), shouldDelete.force());
+    if (podDeletionDecision.delete()) {
+      client.deletePod(pod.getMetadata().getName(), podDeletionDecision.force());
     }
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -863,7 +863,7 @@ class KubernetesDockerRunner implements DockerRunner {
 
     boolean delete();
 
-    // Whether to force delete a pod; only application when delete() returns true
+    // Whether to force delete a pod; only applicable when delete() returns true
     boolean force();
 
     PodDeletionDecisionBuilder builder();

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -21,6 +21,8 @@
 package com.spotify.styx.docker;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -162,8 +164,8 @@ public class KubernetesDockerRunnerPodPollerTest {
 
     kdr.tryCleanupPods();
 
-    verify(k8sClient).deletePod(createdPod1.getMetadata().getName());
-    verify(k8sClient).deletePod(createdPod2.getMetadata().getName());
+    verify(k8sClient).deletePod(createdPod1.getMetadata().getName(), false);
+    verify(k8sClient).deletePod(createdPod2.getMetadata().getName(), false);
   }
 
   @Test
@@ -181,7 +183,7 @@ public class KubernetesDockerRunnerPodPollerTest {
 
     kdr.tryCleanupPods();
 
-    verify(k8sClient, never()).deletePod(any());
+    verify(k8sClient, never()).deletePod(any(), anyBoolean());
   }
 
   @Test
@@ -196,7 +198,7 @@ public class KubernetesDockerRunnerPodPollerTest {
 
     kdr.tryCleanupPods();
 
-    verify(k8sClient, never()).deletePod(any());
+    verify(k8sClient, never()).deletePod(any(), anyBoolean());
   }
 
   @Test
@@ -212,7 +214,7 @@ public class KubernetesDockerRunnerPodPollerTest {
 
     kdr.tryCleanupPods();
 
-    verify(k8sClient, never()).deletePod(any());
+    verify(k8sClient, never()).deletePod(any(), eq(false));
   }
 
   private Map<WorkflowInstance, RunState> setupActiveInstances(RunState.State state, String podName1, String podName2) {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -22,7 +22,6 @@ package com.spotify.styx.docker;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -214,7 +213,7 @@ public class KubernetesDockerRunnerPodPollerTest {
 
     kdr.tryCleanupPods();
 
-    verify(k8sClient, never()).deletePod(any(), eq(false));
+    verify(k8sClient, never()).deletePod(any(), anyBoolean());
   }
 
   private Map<WorkflowInstance, RunState> setupActiveInstances(RunState.State state, String podName1, String podName2) {


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Force delete a pod by setting grace period to `0` when calling k8s API.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Due to known bugs of k8s, which were only fixed in later version of k8s, we force delete a pod if it has been in terminating (possibly other states as well) for long (>= 30 minutes + 2 minutes).

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [x] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
