### PR TITLE
Dequeue older partition first

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -324,10 +324,10 @@ public class Scheduler {
    */
   @VisibleForTesting
   List<WorkflowInstance> shuffleInstances(Set<WorkflowInstance> activeInstances) {
-    var groups = activeInstances
+    final Map<WorkflowId, SortedSet<WorkflowInstance>> groups = activeInstances
         .stream()
         .collect(groupingBy(WorkflowInstance::workflowId, LinkedHashMap::new,
-            toCollection(() -> (SortedSet<WorkflowInstance>) new TreeSet<>(comparing(WorkflowInstance::parameter)))));
+            toCollection(() -> new TreeSet<>(comparing(WorkflowInstance::parameter)))));
 
     return merge(groups.values(), activeInstances.size());
   }
@@ -351,7 +351,7 @@ public class Scheduler {
     var merged = new WorkflowInstance[size];
 
     var from = 0;
-    for (SortedSet<WorkflowInstance> group : instanceGroups) {
+    for (var group : instanceGroups) {
       var subIndices = indices.subList(from, from + group.size()).stream().sorted().collect(toList());
       var j = 0;
       for (var instance : group) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -321,7 +321,8 @@ public class Scheduler {
   /**
    * Shuffle instances. For the same workflow ID, older instances will be appear early in the list.
    */
-  private List<WorkflowInstance> shuffleInstances(Set<WorkflowInstance> activeInstances) {
+  @VisibleForTesting
+  List<WorkflowInstance> shuffleInstances(Set<WorkflowInstance> activeInstances) {
     var groups = activeInstances
         .stream()
         .collect(groupingBy(WorkflowInstance::workflowId,

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -67,6 +67,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -326,12 +327,9 @@ public class Scheduler {
     var groups = activeInstances
         .stream()
         .collect(groupingBy(WorkflowInstance::workflowId, LinkedHashMap::new,
-            toCollection(() -> new TreeSet<>(comparing(WorkflowInstance::parameter)))));
+            toCollection(() -> (SortedSet<WorkflowInstance>) new TreeSet<>(comparing(WorkflowInstance::parameter)))));
 
-    var shuffledGroups = new ArrayList<SortedSet<WorkflowInstance>>(groups.values());
-    shuffler.shuffle(shuffledGroups);
-
-    return merge(shuffledGroups, activeInstances.size());
+    return merge(groups.values(), activeInstances.size());
   }
 
   /**
@@ -346,7 +344,7 @@ public class Scheduler {
    * 3. For each set, take a sorted sublist of the shuffled indices; and insert each item into the indices
    * specified by the sublist
    */
-  private List<WorkflowInstance> merge(List<SortedSet<WorkflowInstance>> instanceGroups, int size) {
+  private List<WorkflowInstance> merge(Collection<SortedSet<WorkflowInstance>> instanceGroups, int size) {
     var indices = IntStream.range(0, size).boxed().collect(toCollection(ArrayList::new));
     shuffler.shuffle(indices);
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -326,6 +326,7 @@ public class Scheduler {
   List<WorkflowInstance> shuffleInstances(Set<WorkflowInstance> activeInstances) {
     final Map<WorkflowId, SortedSet<WorkflowInstance>> groups = activeInstances
         .stream()
+        // Using LinkedHashMap to have predictable iteration to simplify test
         .collect(groupingBy(WorkflowInstance::workflowId, LinkedHashMap::new,
             toCollection(() -> new TreeSet<>(comparing(WorkflowInstance::parameter)))));
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/Scheduler.java
@@ -319,7 +319,7 @@ public class Scheduler {
   }
 
   /**
-   * Shuffle instances. For the same workflow ID, older instances will be appear early in the list.
+   * Shuffle instances. For the same workflow ID, older instances will appear early in the list.
    */
   @VisibleForTesting
   List<WorkflowInstance> shuffleInstances(Set<WorkflowInstance> activeInstances) {


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Dequeue older partition of the same workflow first.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently dequeue order is completely shuffled without respecting partition age. This PR keeps shuffling as much as possible while prioritising older partition of the same workflow.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit test

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
