### PR TITLE
Force delete pod when finishedAt is not usable

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -482,14 +482,14 @@ class KubernetesDockerRunner implements DockerRunner {
   private PodDeletionDecision isTimeToDeletePossiblyForce(ContainerStatus cs) {
     final ContainerStateTerminated t = cs.getState().getTerminated();
     if (t.getFinishedAt() == null) {
-      return PodDeletionDecision.DELETE;
+      return PodDeletionDecision.FORCE_DELETE;
     }
     final Instant finishedAt;
     try {
       finishedAt = Instant.parse(t.getFinishedAt());
     } catch (DateTimeParseException e) {
       LOG.warn("Failed to parse container state terminated finishedAt: '{}'", t.getFinishedAt(), e);
-      return PodDeletionDecision.DELETE;
+      return PodDeletionDecision.FORCE_DELETE;
     }
     final Instant deletionDeadline = time.get().minus(podDeletionDelay);
     final Instant forceDeletionDeadline = deletionDeadline.minus(POD_FORCE_DELETION_TOLERATION);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -372,7 +372,7 @@ public class KubernetesDockerRunnerTest {
   }
 
   @Test
-  public void shouldCleanupPodWhenMissingFinishedAt() {
+  public void shouldForceDeletePodWhenMissingFinishedAt() {
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(List.of(containerStatus, keepaliveContainerStatus));
@@ -382,11 +382,11 @@ public class KubernetesDockerRunnerTest {
 
     var runState = RunState.create(WORKFLOW_INSTANCE, State.TERMINATED);
     var shouldDelete = kdr.shouldDeletePodWithRunState(WORKFLOW_INSTANCE, createdPod, runState);
-    assertThat(shouldDelete, is(PodDeletionDecision.DELETE));
+    assertThat(shouldDelete, is(PodDeletionDecision.FORCE_DELETE));
   }
 
   @Test
-  public void shouldCleanupPodWhenFailedToParseFinishedAt() {
+  public void shouldForceDeletePodWhenFailedToParseFinishedAt() {
     // inject mock status in real instance
     createdPod.setStatus(podStatus);
     when(podStatus.getContainerStatuses()).thenReturn(List.of(containerStatus, keepaliveContainerStatus));
@@ -397,7 +397,7 @@ public class KubernetesDockerRunnerTest {
 
     var runState = RunState.create(WORKFLOW_INSTANCE, State.TERMINATED);
     var shouldDelete = kdr.shouldDeletePodWithRunState(WORKFLOW_INSTANCE, createdPod, runState);
-    assertThat(shouldDelete, is(PodDeletionDecision.DELETE));
+    assertThat(shouldDelete, is(PodDeletionDecision.FORCE_DELETE));
   }
 
   @Test


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Force delete pod when `finishedAt` is not usable: not exist or could not be parsed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There could be cases where k8s returns container status without `finishedAt` (this is confirmed) or wrong format (not seen yet), and coincidentally the same pod gets stuck in `terminating` state. Force delete when `finishedAt` is not usable will immediately delete the pod without grace period.

This PR can be treated as continuation of #911.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit test

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
