### PR TITLE
Close storage last

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -173,6 +173,7 @@ public class StyxScheduler implements AppInit {
   private static final int DEFAULT_KUBERNETES_REQUEST_TIMEOUT_MILLIS = 60_000;
 
   private static final Logger LOG = LoggerFactory.getLogger(StyxScheduler.class);
+  private static final int CLOSING_STATE_PROCESSING_TIMEOUT = 5;
 
   private final String serviceName;
   private final Time time;
@@ -372,7 +373,8 @@ public class StyxScheduler implements AppInit {
 
     var stateProcessingExecutor = Executors.newWorkStealingPool(
         optionalInt(config, STYX_STATE_PROCESSING_THREADS).orElse(DEFAULT_STYX_STATE_PROCESSING_THREADS));
-    closer.register(closeable(stateProcessingExecutor, "state-processing", Duration.ofSeconds(1)));
+    closer.register(closeable(stateProcessingExecutor, "state-processing", Duration.ofSeconds(
+        CLOSING_STATE_PROCESSING_TIMEOUT)));
     final ExecutorService eventConsumerExecutor = Executors.newSingleThreadExecutor();
     closer.register(closeable(eventConsumerExecutor, "event-consumer", Duration.ofSeconds(1)));
     final ExecutorService schedulerExecutor = Executors.newWorkStealingPool(


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Close the storage by reordering how the get register on the closer. Closer is a stack so 
being the first to register will make the last to close. 
Also increase the timeout for shutting down the threadpool of the persist manager.

## Motivation and Context
Styx sometimes missed a Terminated event. Looking on one of the occurrences we found
failures to persist to bigtable after the change to datastore succeded. Ideally we would have some recovery for this missing event (or two phase commit that works for datastore and bigtable ;)).
The failure to write to bigtable happened in this case because we closed the storage (bigtable and datastore) before closing the thread pool of executors. So this PR is to fix that.


## Have you tested this? If so, how?
No unit test, but will try on staging

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
