### PR TITLE
Propagate trigger params to flyte executions

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -349,6 +349,12 @@ public class FlyteAdminClientRunner implements FlyteRunner {
     stateData.executionId().ifPresent(value -> mapBuilder.put("STYX_EXECUTION_ID", value));
     triggerId.ifPresent(value -> mapBuilder.put("STYX_TRIGGER_ID", value));
     triggerType.ifPresent(value -> mapBuilder.put("STYX_TRIGGER_TYPE", value));
+    // add trigger parameters but avoid any STYX_XXX ones to prevent collisions
+    stateData.triggerParameters().ifPresent(triggerParameters ->
+        triggerParameters.env().entrySet().stream()
+            .filter(entry -> !entry.getKey().startsWith("STYX_"))
+            .forEach(entry -> mapBuilder.put(entry.getKey(), entry.getValue()))
+    );
 
     return mapBuilder.build();
   }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Add any trigger-specific env variables Flyte launch plan default inputs. This completes #918 

## Have you tested this? If so, how?
I added unit test for that.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
