### PR TITLE
Redo labels and annotations on FlyteAdminClientRunner

### DIFF
--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -67,6 +67,7 @@ public class FlyteAdminClient {
       String name,
       IdentifierOuterClass.Identifier launchPlanId,
       ExecutionOuterClass.ExecutionMetadata.ExecutionMode executionMode,
+      Map<String, String> labels,
       Map<String, String> annotations,
       Map<String, String> extraDefaultInputs) {
     LOG.debug("createExecution {} {} {}", project, domain, launchPlanId);
@@ -86,6 +87,9 @@ public class FlyteAdminClient {
         ExecutionOuterClass.ExecutionSpec.newBuilder()
             .setLaunchPlan(launchPlanId)
             .setMetadata(metadata)
+            .setLabels(Common.Labels.newBuilder()
+                .putAllValues(labels)
+                .build())
             .setAnnotations(Common.Annotations.newBuilder()
                 .putAllValues(annotations)
                 .build())

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
@@ -54,6 +54,8 @@ public class FlyteAdminClientTest {
   static final String LP_NAME = "launch_plan_name";
   static final String LP_VERSION = "launch_plan_version_1";
   static final IdentifierOuterClass.ResourceType LP_RESOURCE_TYPE = IdentifierOuterClass.ResourceType.LAUNCH_PLAN;
+  static final Map<String, String> LABELS = ImmutableMap.of("label-key", "id");
+  static final Map<String, String> ANNOTATIONS = ImmutableMap.of("annotation-key", "value");
   static final Map<String, String> EXTRA_DEFAULT_INPUTS = ImmutableMap.of(TestAdminService.EXTRA_PARAMETER_NAME, Instant.now().toString());
   private FlyteAdminClient flyteAdminClient;
 
@@ -92,25 +94,22 @@ public class FlyteAdminClientTest {
   public void shouldPropagateCreateExecutionToStub() {
     var workflowExecution =
         flyteAdminClient.createExecution(PROJECT, DOMAIN, NON_EXISTING_NAME, identifier(NON_EXISTING_NAME),
-            ExecutionMode.SCHEDULED, Map.of(), EXTRA_DEFAULT_INPUTS);
+            ExecutionMode.SCHEDULED, Map.of(), Map.of(), EXTRA_DEFAULT_INPUTS);
     assertThat(workflowExecution.getId().getProject(), equalTo(PROJECT));
     assertThat(workflowExecution.getId().getDomain(), equalTo(DOMAIN));
     assertThat(workflowExecution.getId().getName(), equalTo(NON_EXISTING_NAME));
   }
 
   @Test
-  public void shouldPropagateAnnotationsOnCreateExecutionToStub() {
-    final Map<String, String> annotations = Map.of(
-        "Frodo", "Baggins",
-        "Sam", "Gamgee"
-    );
+  public void shouldPropagateLabelsAndAnnotationsOnCreateExecutionToStub() {
     var workflowExecution =
         flyteAdminClient.createExecution(PROJECT, DOMAIN, NON_EXISTING_NAME, identifier(NON_EXISTING_NAME),
-            ExecutionMode.SCHEDULED, annotations, EXTRA_DEFAULT_INPUTS);
+            ExecutionMode.SCHEDULED, LABELS, ANNOTATIONS, EXTRA_DEFAULT_INPUTS);
     assertThat(workflowExecution, notNullValue());
 
     var retrievedExecution = flyteAdminClient.getExecution(PROJECT, DOMAIN, NON_EXISTING_NAME);
-    assertThat(retrievedExecution.getSpec().getAnnotations().getValuesMap(), equalTo(annotations));
+    assertThat(retrievedExecution.getSpec().getLabels().getValuesMap(), equalTo(LABELS));
+    assertThat(retrievedExecution.getSpec().getAnnotations().getValuesMap(), equalTo(ANNOTATIONS));
   }
 
   @Test

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/TestAdminService.java
@@ -176,15 +176,17 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
   }
 
   private Execution execution(ExecutionOuterClass.ExecutionCreateRequest request) {
+    final var spec = request.getSpec();
     return execution(request.getProject(), request.getDomain(), request.getName(),
-        request.getSpec().getAnnotations().getValuesMap());
+        spec.getLabels().getValuesMap(), spec.getAnnotations().getValuesMap());
   }
 
   private static Execution execution(String execName) {
-    return execution(FlyteAdminClientTest.PROJECT, FlyteAdminClientTest.DOMAIN, execName, Map.of());
+    return execution(FlyteAdminClientTest.PROJECT, FlyteAdminClientTest.DOMAIN, execName, Map.of(), Map.of());
   }
 
-  private static Execution execution(String project, String domain, String execName, Map<String, String> annotations) {
+  private static Execution execution(String project, String domain, String execName, Map<String, String> labels,
+                                     Map<String, String> annotations) {
     return Execution
         .newBuilder()
         .setId(IdentifierOuterClass.WorkflowExecutionIdentifier
@@ -194,6 +196,9 @@ public class TestAdminService extends AdminServiceGrpc.AdminServiceImplBase  {
             .setName(execName)
             .build())
         .setSpec(ExecutionOuterClass.ExecutionSpec.newBuilder()
+            .setLabels(Common.Labels.newBuilder()
+                .putAllValues(labels)
+                .build())
             .setAnnotations(Common.Annotations.newBuilder()
                 .putAllValues(annotations)
                 .build())

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LabelValue.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LabelValue.java
@@ -43,6 +43,20 @@ final public class LabelValue {
   private static final BaseEncoding BASE16_ENCODING_LOWER_CASE = BaseEncoding.base16().lowerCase();
 
   /**
+   * Verifies if the label value complies with Kubernetes restrictions as described by:
+   * https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+   *
+   * Note that this verification implements a subset of the restriction, e.g. lower case only, no `.`.
+   *
+   * @param value value of the label to verify.
+   *
+   * @return true if value is a normalized value, false otherwise.
+   */
+  public static boolean isNormalized(String value) {
+    return value.isEmpty() || VALID.matcher(value).matches();
+  }
+
+  /**
    * Cleanup the label value to comply with Kubernetes restrictions as described by:
    * https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
    * 
@@ -53,7 +67,7 @@ final public class LabelValue {
    * @return normalized value, might contain less information than input.
    */
   public static String normalize(String value) {
-    if (value.isEmpty() || VALID.matcher(value).matches()) {
+    if (isNormalized(value)) {
       return value;
     }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LabelValue.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/LabelValue.java
@@ -28,7 +28,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-final class LabelValue {
+final public class LabelValue {
 
   private static final int KUBERNETES_LABEL_MAX_LENGTH = 63;
   private static final int DIGEST_SUFFIX_LENGTH = 7;

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -22,7 +22,6 @@ package com.spotify.styx.flyte;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.spotify.styx.ScheduledExecutionUtil.scheduleWithJitter;
-import static com.spotify.styx.docker.LabelValue.normalize;
 import static com.spotify.styx.flyte.FlyteEventTranslator.translate;
 import static com.spotify.styx.util.CloserUtil.register;
 import static com.spotify.styx.util.GrpcContextUtil.currentContextExecutorService;
@@ -155,7 +154,8 @@ public class FlyteAdminClientRunner implements FlyteRunner {
         .map(FlyteAdminClientRunner::getFilteredTriggerParams)
         .orElseGet(Map::of);
 
-    var labels = Map.of(STYX_EXECUTION_ID, normalize(styxVariables.get(STYX_EXECUTION_ID)));
+    // labels values should be normalized calling LabelValue::normalize, but styx execution ids are normalized already
+    var labels = Map.of(STYX_EXECUTION_ID, styxVariables.get(STYX_EXECUTION_ID));
     final var annotations = ImmutableMap.<String, String>builder()
         .putAll(styxVariables)
         // just to keep compatibility with removing dangling executions

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -61,6 +61,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -381,7 +382,7 @@ public class FlyteAdminClientRunner implements FlyteRunner {
   // returns trigger parameters but avoid any STYX_XXX ones to prevent collisions
   private static Map<String, String> getFilteredTriggerParams(TriggerParameters triggerParameters) {
     return triggerParameters.env().entrySet().stream()
-                .filter(entry -> !entry.getKey().startsWith("STYX_"))
+                .filter(entry -> !entry.getKey().toLowerCase(Locale.ROOT).startsWith("styx_"))
                 .collect(toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
@@ -25,7 +25,6 @@ import com.spotify.styx.model.FlyteExecConf;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
 import java.io.Closeable;
-import java.util.Map;
 import java.util.function.Function;
 
 public interface FlyteRunner extends Closeable {
@@ -33,7 +32,7 @@ public interface FlyteRunner extends Closeable {
     return true;
   }
 
-  String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf, Map<String, String> annotations)
+  String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf)
       throws CreateExecutionException;
 
   void terminateExecution(RunState runState, FlyteExecutionId flyteExecutionId);

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/NoopFlyteRunner.java
@@ -23,7 +23,6 @@ package com.spotify.styx.flyte;
 import com.google.common.annotations.VisibleForTesting;
 import com.spotify.styx.model.FlyteExecConf;
 import com.spotify.styx.state.RunState;
-import java.util.Map;
 
 /**
  * No-op {@code FlyteRunner} meant to be used when Flyte is disabled or not available.
@@ -37,8 +36,7 @@ public class NoopFlyteRunner implements FlyteRunner {
   }
 
   @Override
-  public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf,
-                                Map<String, String> annotations)
+  public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf)
       throws CreateExecutionException {
     throw new CreateExecutionException("Cannot create execution for: " + flyteExecConf);
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/RoutingFlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/RoutingFlyteRunner.java
@@ -23,7 +23,6 @@ package com.spotify.styx.flyte;
 import com.spotify.styx.docker.AbstractRoutingRunner;
 import com.spotify.styx.model.FlyteExecConf;
 import com.spotify.styx.state.RunState;
-import java.util.Map;
 import java.util.function.Function;
 
 public class RoutingFlyteRunner extends AbstractRoutingRunner<FlyteRunner>
@@ -37,10 +36,9 @@ public class RoutingFlyteRunner extends AbstractRoutingRunner<FlyteRunner>
 
 
   @Override
-  public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf,
-                                Map<String, String> annotations)
+  public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf)
       throws CreateExecutionException {
-    return runner(runState).createExecution(runState, name, flyteExecConf, annotations);
+    return runner(runState).createExecution(runState, name, flyteExecConf);
   }
 
   @Override

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/FlyteRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/FlyteRunnerHandler.java
@@ -29,7 +29,6 @@ import com.spotify.styx.model.FlyteExecConf;
 import com.spotify.styx.state.EventRouter;
 import com.spotify.styx.state.OutputHandler;
 import com.spotify.styx.state.RunState;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,15 +79,12 @@ public class FlyteRunnerHandler extends AbstractRunnerHandler {
     final FlyteExecConf flyteExecConf = state.data().executionDescription().orElseThrow().flyteExecConf().orElseThrow();
     final String executionId = state.data().executionId().orElseThrow();
     final String execName = state.data().executionDescription().orElseThrow().flyteExecutionId().orElseThrow();
-    var annotations = Map.of(
-        STYX_WORKFLOW_INSTANCE_ANNOTATION, state.workflowInstance().toString(),
-        STYX_EXECUTION_ID_ANNOTATION, state.data().executionId().orElseThrow());
 
     final String runnerId;
     try {
-      LOG.info("running:{}, conf:{}, state:{}, flyte exec name:{}, annotations:{}",
-          state.workflowInstance(), flyteExecConf, state, execName, annotations);
-      runnerId = flyteRunner.createExecution(state, execName, flyteExecConf, annotations);
+      LOG.info("running:{}, conf:{}, state:{}, flyte exec name:{}",
+          state.workflowInstance(), flyteExecConf, state, execName);
+      runnerId = flyteRunner.createExecution(state, execName, flyteExecConf);
     } catch (Exception e) {
       final var errMessage = "Failed to start execution for " + state.workflowInstance();
       LOG.error(errMessage, e);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -59,7 +59,6 @@ import com.spotify.styx.util.TriggerInstantSpec;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -93,21 +92,21 @@ public class StyxSchedulerServiceFixture {
 
   @Rule public final DatastoreEmulator datastoreEmulator = new DatastoreEmulator();
 
-  private Time time = () -> now;
+  private final Time time = () -> now;
 
-  private Connection bigtable = setupBigTableMockTable(0);
+  private final Connection bigtable = setupBigTableMockTable(0);
   protected AggregateStorage storage;
-  private DeterministicScheduler executor = new QuietDeterministicScheduler();
-  private Set<String> resourceIdsToDecorateWith = Sets.newHashSet();
+  private final DeterministicScheduler executor = new QuietDeterministicScheduler();
+  private final Set<String> resourceIdsToDecorateWith = Sets.newHashSet();
 
   // circumstantial fields, set by test cases
 
-  private List<Tuple2<SequenceEvent, RunState.State>> transitionedEvents = Lists.newArrayList();
+  private final List<Tuple2<SequenceEvent, RunState.State>> transitionedEvents = Lists.newArrayList();
 
   // captured fields from fakes
-  private Queue<Tuple2<RunState, RunSpec>> dockerRuns = new ConcurrentLinkedQueue<>();
-  Queue<RunState> dockerPolls = new ConcurrentLinkedQueue<>();
-  Queue<FlyteExecutionId> flyteExecCreations = new ConcurrentLinkedQueue<>();
+  private final Queue<Tuple2<RunState, RunSpec>> dockerRuns = new ConcurrentLinkedQueue<>();
+  final Queue<RunState> dockerPolls = new ConcurrentLinkedQueue<>();
+  final Queue<FlyteExecutionId> flyteExecCreations = new ConcurrentLinkedQueue<>();
 
   // service and helper
   private StyxScheduler styxScheduler;
@@ -354,8 +353,7 @@ public class StyxSchedulerServiceFixture {
   private FlyteRunner fakeFlyteRunner() {
     return new FlyteRunner() {
       @Override
-      public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf,
-                                    Map<String, String> annotations) {
+      public String createExecution(RunState runState, String name, FlyteExecConf flyteExecConf) {
         final FlyteExecutionId response = FlyteExecutionId.create(flyteExecConf.referenceId().project(),
                 flyteExecConf.referenceId().domain(), name);
         flyteExecCreations.add(response);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/LabelValueTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/LabelValueTest.java
@@ -21,6 +21,8 @@ package com.spotify.styx.docker;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.spotify.styx.util.ClassEnforcer;
 import junitparams.JUnitParamsRunner;
@@ -104,6 +106,26 @@ public class LabelValueTest {
   @Test
   public void shouldNotBeConstructable() throws ReflectiveOperationException {
     assertThat(ClassEnforcer.assertNotInstantiable(LabelValue.class), is(true));
+  }
+
+  @Test
+  @Parameters({
+      "",
+      "a",
+      "test-value_including-0-and-9",
+  })
+  public void testIsNormalizedShouldAcceptConformingValues(String value) {
+    assertTrue(LabelValue.isNormalized(value));
+  }
+
+  @Test
+  @Parameters({
+      "UPPER",
+      "-dashes",
+      "unsupported#chars",
+  })
+  public void testIsNormalizedShouldRejectNonConformingValues(String value) {
+    assertFalse(LabelValue.isNormalized(value));
   }
 
   private static String repeat(String a, int count) {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
@@ -500,23 +500,21 @@ public class FlyteAdminClientRunnerTest {
     final var execName = "test-create-execution";
     stubAdminClientCreateExec(execName);
 
-    flyteRunner.createExecution(runState(ImmutableMap.of("HADES_OVERWRITE", "true")), execName, FLYTE_EXEC_CONF);
-
-    final var expectedExtraInputs = ImmutableMap.<String, String>builder()
-        .put("STYX_COMPONENT_ID", "id")
-        .put("STYX_EXECUTION_ID", "exec-id")
-        .put("STYX_PARAMETER", "2016-03-14")
-        .put("STYX_TRIGGER_ID", "natural-trigger")
-        .put("STYX_TRIGGER_TYPE", "natural")
-        .put("STYX_WORKFLOW_ID", "styx.TestEndpoint")
-        .build();
+    var triggeredParams = Map.of(
+        "STYX_EXECUTION_ID", "foo",
+        "styx_parameter", "bar"
+    );
+    flyteRunner.createExecution(runState(triggeredParams), execName, FLYTE_EXEC_CONF);
 
     ArgumentCaptor<Map<String, String>> argCaptor = ArgumentCaptor.forClass(Map.class);
     verify(flyteAdminClient).createExecution(any(), any(), any(), any(), any(),
         any(), any(), argCaptor.capture());
+
     assertThat(argCaptor.getValue(), allOf(
         not(hasEntry("STYX_EXECUTION_ID", "foo")),
-        hasEntry("STYX_EXECUTION_ID", "exec-id")
+        not(hasEntry("styx_parameter", "bar")),
+        hasEntry("STYX_EXECUTION_ID", "exec-id"),
+        hasEntry("STYX_PARAMETER", "2016-03-14")
     ));
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/NoopFlyteRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/NoopFlyteRunnerTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertThrows;
 
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.testdata.TestData;
-import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -49,7 +48,7 @@ public class NoopFlyteRunnerTest {
   public void testCreateExecutionThrowsException() {
     assertThrows(
         FlyteRunner.CreateExecutionException.class,
-        () -> runner.createExecution(runState, "name", TestData.FLYTE_EXEC_CONF, Map.of())
+        () -> runner.createExecution(runState, "name", TestData.FLYTE_EXEC_CONF)
     );
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/RoutingFlyteRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/RoutingFlyteRunnerTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 
 import com.spotify.styx.docker.AbstractRoutingRunnerTest;
 import com.spotify.styx.model.FlyteExecConf;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,7 +36,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class RoutingFlyteRunnerTest extends AbstractRoutingRunnerTest<FlyteRunner> {
 
   private static final String EXEC_NAME = "exec-name";
-  private static final Map<String, String> ANNOTATIONS = Map.of("foo", "bar");
 
   @Mock private FlyteExecutionId executionId;
   @Mock private FlyteExecConf execConf;
@@ -52,10 +50,10 @@ public class RoutingFlyteRunnerTest extends AbstractRoutingRunnerTest<FlyteRunne
 
   @Test
   public void shouldCreateRunnerOnCreateExecution() throws FlyteRunner.CreateExecutionException {
-    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
 
     assertThatCreateCountersContains("default");
-    verify(createdRunners.get("default")).createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
+    verify(createdRunners.get("default")).createExecution(runState, EXEC_NAME, execConf);
   }
 
   @Test
@@ -76,8 +74,8 @@ public class RoutingFlyteRunnerTest extends AbstractRoutingRunnerTest<FlyteRunne
 
   @Test
   public void testCreatesOnlyOneRunnerPerRunnerId() throws Exception {
-    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
-    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
 
     assertThatCreateCountersContains("default");
   }
@@ -86,8 +84,8 @@ public class RoutingFlyteRunnerTest extends AbstractRoutingRunnerTest<FlyteRunne
   public void testSwitchesRunners() throws Exception {
     when(runnerId.apply(runState)).thenReturn("id-1", "id-2");
 
-    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
-    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
 
     assertThatCreateCountersContains("id-1", "id-2");
   }
@@ -96,8 +94,8 @@ public class RoutingFlyteRunnerTest extends AbstractRoutingRunnerTest<FlyteRunne
   public void testCreatedRunnersAreClosed() throws Exception {
     when(runnerId.apply(runState)).thenReturn("id-1", "id-2");
 
-    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
-    flyteRunner.createExecution(runState, EXEC_NAME, execConf, ANNOTATIONS);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
+    flyteRunner.createExecution(runState, EXEC_NAME, execConf);
     flyteRunner.close();
 
     assertThatCreateCountersContains("id-1", "id-2");

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
@@ -80,14 +80,14 @@ public class FlyteRunnerHandlerTest {
 
   @Test
   public void shouldTransitionIntoSubmitted() throws Exception {
-    when(flyteRunner.createExecution(any(), any(), any(), any())).thenReturn("runnerId");
+    when(flyteRunner.createExecution(any(), any(), any())).thenReturn("runnerId");
     RunState runState = RunState.create(WORKFLOW_INSTANCE, RunState.State.SUBMITTING, StateData.newBuilder()
         .executionId(EXECUTION_ID)
         .executionDescription(FLYTE_EXECUTION_DESCRIPTION)
         .build());
 
     flyteRunnerHandler.transitionInto(runState, eventRouter);
-    verify(flyteRunner).createExecution(runState, TestData.FLYTE_EXECUTION_ID, FLYTE_EXEC_CONF, ANNOTATIONS);
+    verify(flyteRunner).createExecution(runState, TestData.FLYTE_EXECUTION_ID, FLYTE_EXEC_CONF);
     verify(eventRouter,  timeout(60_000)).receiveIgnoreClosed(Event.submitted(WORKFLOW_INSTANCE, EXECUTION_ID, "runnerId"),
         runState.counter());
   }
@@ -110,7 +110,7 @@ public class FlyteRunnerHandlerTest {
   @Test
   public void shouldReportRunErrorIfCatchCreateExecutionException() throws Exception {
     doThrow(new FlyteRunner.CreateExecutionException("Houston we have a problem", null))
-        .when(flyteRunner).createExecution(any(), any(), any(), any());
+        .when(flyteRunner).createExecution(any(), any(), any());
     RunState runState = RunState.create(WORKFLOW_INSTANCE, RunState.State.SUBMITTING, StateData.newBuilder()
         .executionId(EXECUTION_ID)
         .executionDescription(FLYTE_EXECUTION_DESCRIPTION)
@@ -118,7 +118,7 @@ public class FlyteRunnerHandlerTest {
 
     flyteRunnerHandler.transitionInto(runState, eventRouter);
 
-    verify(flyteRunner).createExecution(runState, TestData.FLYTE_EXECUTION_ID, FLYTE_EXEC_CONF, ANNOTATIONS);
+    verify(flyteRunner).createExecution(runState, TestData.FLYTE_EXECUTION_ID, FLYTE_EXEC_CONF);
     verify(eventRouter,  timeout(60_000)).receiveIgnoreClosed(Event.runError(WORKFLOW_INSTANCE, "Houston we have a problem"),
         runState.counter());
   }
@@ -134,7 +134,7 @@ public class FlyteRunnerHandlerTest {
 
     flyteRunnerHandler.transitionInto(runState, eventRouter);
 
-    verify(flyteRunner, never()).createExecution(any(), any(), any(), any());
+    verify(flyteRunner, never()).createExecution(any(), any(), any());
     verify(eventRouter,  timeout(60_000)).receiveIgnoreClosed(Event.halt(WORKFLOW_INSTANCE), runState.counter());
   }
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Now we send STYX_EXECUTION_ID in labels but also send styx
variables also parts of annotations

## Motivation and Context
In kubernetes world, Labels are meant for identifier info so STYX_EXECUTION_ID seems appropriate for that. 
However labels impose constrains not only on the key but also in the value. 

On the other hand. Annotations are mean to be used for user/tool specific metadata and also do not impose 
restriction on value format. So it seems appropriate to set all this STYX related variables.

## Have you tested this? If so, how?
I have included unit tests.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
