### PR TITLE
Adding ActionAuhoriser class

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -132,6 +132,7 @@ public final class WorkflowResource {
           throw new ResponseException(response);
         }
         var workflow = workflowOpt.orElseThrow();
+        workflowActionAuthorizer.authorizeDeleteWorkflowAction(workflow);
         workflowActionAuthorizer.authorizeWorkflowAction(ac, workflow);
         tx.deleteWorkflow(workflowId);
         return workflow;
@@ -161,6 +162,7 @@ public final class WorkflowResource {
 
     final Workflow workflow = Workflow.create(componentId, workflowConfig);
 
+    workflowActionAuthorizer.authorizeCreateOrUpdateWorkflowAction(workflow);
     workflowActionAuthorizer.authorizeWorkflowAction(ac, workflow);
 
     var errors = workflowValidator.validateWorkflow(workflow);
@@ -214,6 +216,7 @@ public final class WorkflowResource {
     }
 
     final WorkflowId workflowId = WorkflowId.create(componentId, id);
+    workflowActionAuthorizer.authorizePatchStateWorkflowAction(workflowId);
     workflowActionAuthorizer.authorizeWorkflowAction(ac, workflowId);
 
     final WorkflowState patchState;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -30,6 +30,7 @@ import com.google.cloud.datastore.Datastore;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.spotify.apollo.test.ServiceHelper;
+import com.spotify.styx.api.ActionAuthorizer;
 import com.spotify.styx.api.Authenticator;
 import com.spotify.styx.api.AuthenticatorFactory;
 import com.spotify.styx.api.ServiceAccountUsageAuthorizer;
@@ -150,6 +151,7 @@ public class StyxSchedulerServiceFixture {
 
     final ServiceAccountUsageAuthorizer.Factory serviceAccountUsageAuthorizerFactory =
         (cfg, name) -> ServiceAccountUsageAuthorizer.nop();
+    final ActionAuthorizer actionAuthorizer = ActionAuthorizer.create();
     styxScheduler = StyxScheduler.newBuilder()
         .setTime(time)
         .setStorageFactory(storageFactory)
@@ -162,6 +164,7 @@ public class StyxSchedulerServiceFixture {
         .setEventConsumerFactory(eventConsumerFactory)
         .setAuthenticatorFactory(authenticatorFactory)
         .setServiceAccountUsageAuthorizerFactory(serviceAccountUsageAuthorizerFactory)
+        .setActionAuthorizer(actionAuthorizer)
         .build();
 
     serviceHelper = ServiceHelper.create(styxScheduler, StyxScheduler.SERVICE_NAME)

--- a/styx-service-common/src/main/java/com/spotify/styx/api/ActionAuthorizer.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/ActionAuthorizer.java
@@ -1,0 +1,84 @@
+/*-
+ * -\-\-
+ * Spotify Styx API Service
+ * --
+ * Copyright (C) 2016 - 2021 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+
+package com.spotify.styx.api;
+
+import com.spotify.styx.model.Workflow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Action Authorizer can be used to implement an extra authorization system for destructive action perform on workflow though POST, DELETE AND PATCH api
+ * commands.
+ */
+public interface ActionAuthorizer {
+
+  Logger LOG = LoggerFactory.getLogger(ActionAuthorizer.class);
+
+  static ActionAuthorizer nop() {
+    return ActionAuthorizer.Nop.INSTANCE;
+  }
+
+  static ActionAuthorizer create() {
+    return ActionAuthorizer.nop();
+  }
+
+  /**
+   * Authorize a workflow to be created or updated
+   *
+   * @throws ResponseException if not authorized.
+   */
+  void authorizeCreateOrUpdateWorkflowAction(final Workflow workflow);
+
+  /**
+   * Authorize a workflow to be deleted
+   *
+   * @throws ResponseException if not authorized.
+   */
+  void authorizeDeleteWorkflowAction(final Workflow workflow);
+
+  /**
+   * Authorize a workflow to be patched
+   *
+   * @throws ResponseException if not authorized.
+   */
+  void authorizePatchStateWorkflowAction(final Workflow workflow);
+
+  class Nop implements ActionAuthorizer {
+
+    static final Nop INSTANCE = new Nop();
+
+    @Override
+    public void authorizeCreateOrUpdateWorkflowAction(final Workflow workflow) {
+      // nop
+    }
+
+    @Override
+    public void authorizeDeleteWorkflowAction(final Workflow workflow) {
+      // nop
+    }
+
+    @Override
+    public void authorizePatchStateWorkflowAction(final Workflow workflow) {
+      // nop
+    }
+  }
+}

--- a/styx-service-common/src/test/java/com/spotify/styx/api/WorkflowActionAuthorizerTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/WorkflowActionAuthorizerTest.java
@@ -128,4 +128,20 @@ public class WorkflowActionAuthorizerTest {
         WORKFLOW.id(), WORKFLOW.configuration().serviceAccount().orElseThrow(), idToken);
     assertThat(invocation.getCause(), is(cause));
   }
+
+  @Test
+  public void authorizePatchStateWorkflowActionWithIdShouldFailIfWorkflowNotFound() throws IOException {
+    when(storage.workflow(any())).thenReturn(Optional.empty());
+    exception.expect(ResponseException.class);
+    sut.authorizePatchStateWorkflowAction(WORKFLOW.id());
+  }
+
+  @Test
+  public void authorizePatchStateWorkflowActionWithIdShouldFailIfStorageReadFails() throws IOException {
+    final IOException cause = new IOException();
+    when(storage.workflow(any())).thenThrow(cause);
+    exception.expect(RuntimeException.class);
+    exception.expectCause(is(cause));
+    sut.authorizePatchStateWorkflowAction(WORKFLOW.id());
+  }
 }

--- a/styx-service-common/src/test/java/com/spotify/styx/api/WorkflowActionAuthorizerTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/WorkflowActionAuthorizerTest.java
@@ -58,6 +58,7 @@ public class WorkflowActionAuthorizerTest {
 
   @Mock private Storage storage;
   @Mock private ServiceAccountUsageAuthorizer authorizer;
+  @Mock private ActionAuthorizer actionAuthorizer;
   @Mock private Middlewares.AuthContext ac;
   @Mock private GoogleIdToken idToken;
 
@@ -65,7 +66,7 @@ public class WorkflowActionAuthorizerTest {
 
   @Before
   public void setUp() throws Exception {
-    sut = new WorkflowActionAuthorizer(storage, authorizer);
+    sut = new WorkflowActionAuthorizer(storage, authorizer, actionAuthorizer);
   }
 
   @Test


### PR DESCRIPTION
This pull requests adds an ActionAuthorizer class that can be used to implement an extra authorization system for destructive action perform on workflow though POST, DELETE AND PATCH api commands.
The default class provides a NOP class that does... well... nothing as expected but allow users to provide their own implementation for it.