### PR TITLE
[Hotfix] Temporarily disable key deletion

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
@@ -157,12 +157,7 @@ class KubernetesGCPServiceAccountSecretManager {
             p12KeyName, secretName, workflowId);
       }
 
-
-      deleteSecret(existingSecret);
-
-      // Delete secret and any lingering key before creating new keys
-      keyManager.deleteKey(jsonKeyName);
-      keyManager.deleteKey(p12KeyName);
+      return secretName;
     }
 
     // Create service account keys and secret

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
@@ -147,16 +147,17 @@ class KubernetesGCPServiceAccountSecretManager {
       final String jsonKeyName = annotations.get(STYX_WORKFLOW_SA_JSON_KEY_NAME_ANNOTATION);
       final String p12KeyName = annotations.get(STYX_WORKFLOW_SA_P12_KEY_NAME_ANNOTATION);
 
-      if (keyExists(jsonKeyName) && keyExists(p12KeyName)) {
-        return secretName;
+      if (!keyExists(jsonKeyName)) {
+        LOG.warn("[AUDIT] Service account JSON key does not exist or cannot be verified, {} in {} for workflow {}",
+            jsonKeyName, secretName, workflowId);
       }
 
-      LOG.info("[AUDIT] Service account keys have been deleted for {}, recreating", serviceAccount);
+      if (!keyExists(p12KeyName)) {
+        LOG.warn("[AUDIT] Service account P12 key does not exist or cannot be verified, {} in {} for workflow {}",
+            p12KeyName, secretName, workflowId);
+      }
 
-      // Delete secret and any lingering key before creating new keys
-      keyManager.deleteKey(jsonKeyName);
-      keyManager.deleteKey(p12KeyName);
-      deleteSecret(existingSecret);
+      return secretName;
     }
 
     // Create service account keys and secret

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
@@ -77,6 +77,7 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -459,6 +460,7 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
   }
 
   @Test
+  @Ignore
   public void shouldCreateNewServiceAccountKeysIfKeysAreDeleted() throws IOException {
 
     final ObjectMeta metadata = new ObjectMeta();
@@ -503,6 +505,45 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
     assertThat(createdSecret.getMetadata().getAnnotations(), hasEntry("styx-wf-sa", SERVICE_ACCOUNT));
     assertThat(createdSecret.getData(), hasEntry("styx-wf-sa.json", newJsonKey.getPrivateKeyData()));
     assertThat(createdSecret.getData(), hasEntry("styx-wf-sa.p12", newP12Key.getPrivateKeyData()));
+  }
+
+  @Test
+  public void shouldNotCreateNewServiceAccountKeysIfKeysAreDeleted() throws IOException {
+
+    final ObjectMeta metadata = new ObjectMeta();
+    metadata.setAnnotations(Map.of("styx-wf-sa", SERVICE_ACCOUNT));
+
+    final String jsonKeyId = "json-key";
+    final String p12KeyId = "p12-key";
+    final String newJsonKeyId = "new-json-key";
+    final String newP12KeyId = "new-p12-key";
+
+    final String creationTimestamp = CLOCK.instant().minus(Duration.ofDays(1)).toString();
+    final Secret secret = fakeServiceAccountKeySecret(
+        SERVICE_ACCOUNT, SECRET_EPOCH, jsonKeyId, p12KeyId, creationTimestamp);
+
+    final ServiceAccountKey newJsonKey = new ServiceAccountKey()
+        .setName(newJsonKeyId)
+        .setPrivateKeyData("new-json-private-key-data");
+
+    final ServiceAccountKey newP12Key = new ServiceAccountKey()
+        .setName(newP12KeyId)
+        .setPrivateKeyData("new-p12-private-key-data");
+
+    when(serviceAccountKeyManager.serviceAccountExists(SERVICE_ACCOUNT)).thenReturn(true);
+    when(serviceAccountKeyManager.keyExists(keyName(SERVICE_ACCOUNT, jsonKeyId))).thenReturn(false);
+    when(serviceAccountKeyManager.keyExists(keyName(SERVICE_ACCOUNT, p12KeyId))).thenReturn(false);
+
+    when(k8sClient.getSecret(secret.getMetadata().getName())).thenReturn(Optional.of(secret));
+
+    sut.ensureServiceAccountKeySecret(WORKFLOW_INSTANCE.workflowId().toString(), SERVICE_ACCOUNT);
+
+    verify(serviceAccountKeyManager, never()).deleteKey(keyName(SERVICE_ACCOUNT, jsonKeyId));
+    verify(serviceAccountKeyManager, never()).deleteKey(keyName(SERVICE_ACCOUNT, p12KeyId));
+    verify(serviceAccountKeyManager, never()).createJsonKey(SERVICE_ACCOUNT);
+    verify(serviceAccountKeyManager, never()).createP12Key(SERVICE_ACCOUNT);
+    verify(k8sClient, never()).deleteSecret(secret.getMetadata().getName());
+    verify(k8sClient, never()).createSecret(secretCaptor.capture());
   }
 
   /**


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
This PR temporarily disables key deletion when the key(s) are found in k8s secret but cannot verified to exist in GCP.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a hotfix to work around a possible issue. **Note** that this PR should be reverted later.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit test

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
