### PR TITLE
Read key after creating

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/ServiceAccountKeyManager.java
@@ -81,9 +81,15 @@ public class ServiceAccountKeyManager {
   private ServiceAccountKey createKey(
       String serviceAccount,
       CreateServiceAccountKeyRequest request) throws IOException {
-    return iam.projects().serviceAccounts().keys()
+    final ServiceAccountKey key = iam.projects().serviceAccounts().keys()
         .create("projects/-/serviceAccounts/" + serviceAccount, request)
         .execute();
+    try {
+      keyExists(key.getName());
+    } catch (Exception e) {
+      LOG.info("Got exception when checking key existence {}", key.getName(), e);
+    }
+    return key;
   }
 
   public void tryDeleteKey(String keyName) {


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
I had a theory that the first read of the key after creating make encounter some issue but subsequent reads all worked. This is a hypothesis when experimenting with key creating and validation in my local setup as only the first reads has some chance to fail. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
