### PR TITLE
Add meter for key creation and deletion

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -650,7 +650,7 @@ public class StyxScheduler implements AppInit {
 
     final String styxEnvironment = config.getString(STYX_ENVIRONMENT);
     final NamespacedKubernetesClient kubernetes = closer.register(getKubernetesClient(config, id));
-    final ServiceAccountKeyManager serviceAccountKeyManager = createServiceAccountKeyManager();
+    final ServiceAccountKeyManager serviceAccountKeyManager = createServiceAccountKeyManager(stats);
     var fabric8Client = TracingProxy.instrument(Fabric8KubernetesClient.class,
         MeteredFabric8KubernetesClientProxy.instrument(
             Fabric8KubernetesClient.of(kubernetes), stats, time));
@@ -699,7 +699,7 @@ public class StyxScheduler implements AppInit {
     }
   }
 
-  private static ServiceAccountKeyManager createServiceAccountKeyManager() {
+  private static ServiceAccountKeyManager createServiceAccountKeyManager(Stats stats) {
     try {
       final HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
       final JsonFactory jsonFactory = Utils.getDefaultJsonFactory();
@@ -710,7 +710,7 @@ public class StyxScheduler implements AppInit {
           httpTransport, jsonFactory, credential)
           .setApplicationName(SERVICE_NAME)
           .build();
-      return new ServiceAccountKeyManager(iam);
+      return new ServiceAccountKeyManager(iam, stats);
     } catch (GeneralSecurityException | IOException e) {
       throw new RuntimeException(e);
     }

--- a/styx-service-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
@@ -181,6 +181,12 @@ public final class MetricsStats implements Stats {
   static final MetricId SERVICE_ACCOUNT_CLEANUP_RATE = BASE
       .tagged("what", "service-account-cleanup-rate");
 
+  static final MetricId KEY_CREATION_RATE = BASE
+      .tagged("what", "key-creation-rate");
+
+  static final MetricId KEY_DELETION_RATE = BASE
+      .tagged("what", "key-deletion-rate");
+
   private static final String STATUS = "status";
   private static final String COUNTER_CACHE_RESULT = "result";
   private static final String COUNTER_CACHE_HIT = "hit";
@@ -199,6 +205,8 @@ public final class MetricsStats implements Stats {
   private final Meter counterCacheHitMeter;
   private final Meter counterCacheMissMeter;
   private final Meter serviceAccountCleanupMeter;
+  private final Meter keyCreationMeter;
+  private final Meter keyDeletionMeter;
   private final ConcurrentMap<String, Histogram> storageOperationHistograms;
   private final ConcurrentMap<String, Meter> storageOperationMeters;
   private final ConcurrentMap<String, Histogram> dockerOperationHistograms;
@@ -240,6 +248,8 @@ public final class MetricsStats implements Stats {
     this.counterCacheHitMeter = registry.meter(COUNTER_CACHE_RATE.tagged(COUNTER_CACHE_RESULT, COUNTER_CACHE_HIT));
     this.counterCacheMissMeter = registry.meter(COUNTER_CACHE_RATE.tagged(COUNTER_CACHE_RESULT, COUNTER_CACHE_MISS));
     this.serviceAccountCleanupMeter = registry.meter(SERVICE_ACCOUNT_CLEANUP_RATE);
+    this.keyCreationMeter = registry.meter(KEY_CREATION_RATE);
+    this.keyDeletionMeter = registry.meter(KEY_DELETION_RATE);
     this.storageOperationHistograms = new ConcurrentHashMap<>();
     this.storageOperationMeters = new ConcurrentHashMap<>();
     this.dockerOperationHistograms = new ConcurrentHashMap<>();
@@ -425,6 +435,16 @@ public final class MetricsStats implements Stats {
   @Override
   public void recordServiceAccountCleanup() {
     serviceAccountCleanupMeter.mark();
+  }
+
+  @Override
+  public void recordKeyCreation() {
+    keyCreationMeter.mark();
+  }
+
+  @Override
+  public void recordKeyDeletion() {
+    keyDeletionMeter.mark();
   }
 
   @Override

--- a/styx-service-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
@@ -183,6 +183,16 @@ final class NoopStats implements Stats {
   }
 
   @Override
+  public void recordKeyCreation() {
+    // nop
+  }
+
+  @Override
+  public void recordKeyDeletion() {
+    // nop
+  }
+
+  @Override
   public void recordKubernetesOperation(String operation, long durationMillis, String status) {
     // nop
   }

--- a/styx-service-common/src/main/java/com/spotify/styx/monitoring/Stats.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/monitoring/Stats.java
@@ -93,6 +93,10 @@ public interface Stats {
 
   void recordServiceAccountCleanup();
 
+  void recordKeyCreation();
+
+  void recordKeyDeletion();
+
   void recordKubernetesOperation(String operation, long durationMillis, String status);
 
   void recordKubernetesOperationError(String operation, String type, int code);

--- a/styx-service-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
@@ -31,6 +31,8 @@ import static com.spotify.styx.monitoring.MetricsStats.EVENT_CONSUMER_RATE;
 import static com.spotify.styx.monitoring.MetricsStats.EXIT_CODE_MISMATCH;
 import static com.spotify.styx.monitoring.MetricsStats.EXIT_CODE_RATE;
 import static com.spotify.styx.monitoring.MetricsStats.HISTOGRAM;
+import static com.spotify.styx.monitoring.MetricsStats.KEY_CREATION_RATE;
+import static com.spotify.styx.monitoring.MetricsStats.KEY_DELETION_RATE;
 import static com.spotify.styx.monitoring.MetricsStats.KUBERNETES_DURATION;
 import static com.spotify.styx.monitoring.MetricsStats.KUBERNETES_ERROR_RATE;
 import static com.spotify.styx.monitoring.MetricsStats.KUBERNETES_RATE;
@@ -111,6 +113,8 @@ public class MetricsStatsTest {
     when(registry.meter(COUNTER_CACHE_RATE.tagged("result", "miss"))).thenReturn(meter);
     when(registry.meter(COUNTER_CACHE_RATE.tagged("result", "hit"))).thenReturn(meter);
     when(registry.meter(SERVICE_ACCOUNT_CLEANUP_RATE)).thenReturn(meter);
+    when(registry.meter(KEY_CREATION_RATE)).thenReturn(meter);
+    when(registry.meter(KEY_DELETION_RATE)).thenReturn(meter);
     stats = new MetricsStats(registry, time);
   }
 
@@ -364,5 +368,17 @@ public class MetricsStatsTest {
     final Histogram histogram = HISTOGRAM.newMetric();
     assertThat(histogram, is(not(nullValue())));
     assertThat(HISTOGRAM.isInstance(histogram), is(true));
+  }
+
+  @Test
+  public void shouldRecordKeyCreation() {
+    stats.recordKeyCreation();
+    verify(meter).mark();
+  }
+
+  @Test
+  public void shouldRecordKeyDeletion() {
+    stats.recordKeyDeletion();
+    verify(meter).mark();
   }
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Add metrics to Styx to measure the number of service accounts keys created/deleted

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
