### PR TITLE
Retry up to 3 times calls to flyteadmin

### DIFF
--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.base.Verify.verifyNotNull;
 import static com.spotify.styx.flyte.client.FlyteInputsUtils.fillParameterInInputs;
 
+import com.google.common.annotations.VisibleForTesting;
 import flyteidl.admin.Common;
 import flyteidl.admin.ExecutionOuterClass;
 import flyteidl.admin.LaunchPlanOuterClass;
@@ -41,10 +42,12 @@ public class FlyteAdminClient {
   private static final Logger LOG = LoggerFactory.getLogger(FlyteAdminClient.class);
   private static final String TRIGGERING_PRINCIPAL = "styx";
   private static final int USER_TRIGGERED_EXECUTION_NESTING = 0;
+  private static final int MAX_RETRY_ATTEMPTS = 3;
 
   private final AdminServiceGrpc.AdminServiceBlockingStub stub;
 
-  public FlyteAdminClient(AdminServiceGrpc.AdminServiceBlockingStub stub) {
+  @VisibleForTesting
+  FlyteAdminClient(AdminServiceGrpc.AdminServiceBlockingStub stub) {
     this.stub = Objects.requireNonNull(stub, "stub");
   }
 
@@ -56,7 +59,7 @@ public class FlyteAdminClient {
     }
     // Enable transparent retries:
     // https://github.com/grpc/proposal/blob/master/A6-client-retries.md#transparent-retries
-    var channel = builder.enableRetry().maxRetryAttempts(0).build();
+    var channel = builder.enableRetry().maxRetryAttempts(MAX_RETRY_ATTEMPTS).build();
 
     return new FlyteAdminClient(AdminServiceGrpc.newBlockingStub(channel));
   }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Retry up to 3 times calls to flyteadmin

## Motivation and Context
No retry was configured, actually it was configured to retry 0 times, This cause that polling flyte executions could fail and a styx retry will happen.

## Have you tested this? If so, how?
No covered by unit test but covered by integration tests.

## Checklist for PR author(s)
- [ ] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
