### PR TITLE
Add MeteredActionAuthorizer

### DIFF
--- a/styx-service-common/src/main/java/com/spotify/styx/api/MeteredActionAuthorizer.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/MeteredActionAuthorizer.java
@@ -1,0 +1,46 @@
+package com.spotify.styx.api;
+
+import com.spotify.styx.model.Workflow;
+import com.spotify.styx.monitoring.Stats;
+import com.spotify.styx.util.Time;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+public class MeteredActionAuthorizer implements ActionAuthorizer {
+
+  private final ActionAuthorizer actionAuthorizer;
+  private final Stats stats;
+  private final Time time;
+
+  public MeteredActionAuthorizer(ActionAuthorizer actionAuthorizer, Stats stats, Time time) {
+    this.actionAuthorizer = Objects.requireNonNull(actionAuthorizer);
+    this.stats = Objects.requireNonNull(stats);
+    this.time = Objects.requireNonNull(time);
+  }
+
+  @Override
+  public void authorizeCreateOrUpdateWorkflowAction(Workflow workflow) {
+    authorizeWorkflowAction(workflow, "create-or-update");
+  }
+
+  @Override
+  public void authorizeDeleteWorkflowAction(Workflow workflow) {
+    authorizeWorkflowAction(workflow, "delete");
+  }
+
+  @Override
+  public void authorizePatchStateWorkflowAction(Workflow workflow) {
+    authorizeWorkflowAction(workflow, "patch");
+  }
+
+  private void authorizeWorkflowAction(Workflow workflow, String operation) {
+    Instant t0 = time.get();
+    try {
+      actionAuthorizer.authorizePatchStateWorkflowAction(workflow);
+    } finally {
+      final long durationMillis = t0.until(time.get(), ChronoUnit.MILLIS);
+      stats.recordActionAuthorizationDuration(operation, durationMillis);
+    }
+  }
+}

--- a/styx-service-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
@@ -201,4 +201,9 @@ final class NoopStats implements Stats {
   public void recordKubernetesOperationError(String operation, String type, int code) {
     // nop
   }
+
+  @Override
+  public void recordActionAuthorizationDuration(String operation, long durationMillis) {
+    // nop
+  }
 }

--- a/styx-service-common/src/main/java/com/spotify/styx/monitoring/Stats.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/monitoring/Stats.java
@@ -100,4 +100,6 @@ public interface Stats {
   void recordKubernetesOperation(String operation, long durationMillis, String status);
 
   void recordKubernetesOperationError(String operation, String type, int code);
+
+  void recordActionAuthorizationDuration(String operation, long durationMillis);
 }

--- a/styx-service-common/src/test/java/com/spotify/styx/api/MeteredActionAuthorizerTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/MeteredActionAuthorizerTest.java
@@ -1,0 +1,63 @@
+package com.spotify.styx.api;
+
+import com.spotify.styx.model.Workflow;
+import com.spotify.styx.monitoring.Stats;
+import com.spotify.styx.util.Time;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.LinkedList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MeteredActionAuthorizerTest {
+
+  @Mock private Stats stats;
+  @Mock private ActionAuthorizer actionAuthorizer = new ActionAuthorizer.Nop();
+  @Mock private Workflow workflow;
+
+  private Instant now = Instant.now();
+  private Instant later = now.plusMillis(123);
+  private Queue<Instant> times;
+  private Time time = () -> times.poll();
+
+  private ActionAuthorizer meteredActionAuthorizer;
+
+  @Before
+  public void setUp() {
+    times = new LinkedList<>(Arrays.asList(now, later));
+    meteredActionAuthorizer = new MeteredActionAuthorizer(actionAuthorizer, stats, time);
+  }
+
+  @Test
+  public void authorizeCreateOrUpdateWorkflowAction() {
+    meteredActionAuthorizer.authorizeCreateOrUpdateWorkflowAction(workflow);
+    verify(stats).recordActionAuthorizationDuration("create-or-update", 123);
+  }
+
+  @Test
+  public void authorizeDeleteWorkflowAction() {
+    meteredActionAuthorizer.authorizeDeleteWorkflowAction(workflow);
+    verify(stats).recordActionAuthorizationDuration("delete", 123);
+  }
+
+  @Test
+  public void authorizePatchStateWorkflowAction() {
+    meteredActionAuthorizer.authorizePatchStateWorkflowAction(workflow);
+    verify(stats).recordActionAuthorizationDuration("patch", 123);
+  }
+
+  @Test
+  public void updateMetricsWhenUnauthorized() {
+    doThrow(ResponseException.class).when(actionAuthorizer).authorizePatchStateWorkflowAction(workflow);
+    meteredActionAuthorizer.authorizePatchStateWorkflowAction(workflow);
+    verify(stats).recordActionAuthorizationDuration("patch", 123);
+  }
+}

--- a/styx-service-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/monitoring/MetricsStatsTest.java
@@ -20,6 +20,7 @@
 
 package com.spotify.styx.monitoring;
 
+import static com.spotify.styx.monitoring.MetricsStats.ACTION_AUTHORIZER_DURATION;
 import static com.spotify.styx.monitoring.MetricsStats.ACTIVE_STATES_PER_RUNSTATE_PER_TRIGGER;
 import static com.spotify.styx.monitoring.MetricsStats.COUNTER_CACHE_RATE;
 import static com.spotify.styx.monitoring.MetricsStats.DATASTORE_OPERATION_RATE;
@@ -343,6 +344,14 @@ public class MetricsStatsTest {
     when(registry.meter(DATASTORE_OPERATION_RATE.tagged("operation", "query", "kind", "foobar"))).thenReturn(meter);
     stats.recordDatastoreQueries("foobar", 17);
     verify(meter).mark(17);
+  }
+
+  @Test
+  public void shouldRecordActionAuthorizerDuration() {
+    String type = "delete";
+    when(registry.getOrAdd(ACTION_AUTHORIZER_DURATION.tagged("type", type), HISTOGRAM)).thenReturn(histogram);
+    stats.recordActionAuthorizationDuration(type, 100L);
+    verify(histogram).update(100L);
   }
 
   @Test


### PR DESCRIPTION
To allow us to gather metrics on its duration.

# Hey, I just made a Pull Request!

## Description
Add ActionAuthorizer metered wrapper and meter for it

## Motivation and Context
With the metered version of ActionAuthorizer we can measure the impact it add in latency.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
