### PR TITLE
Add inputs on flyteExecConf to flyte executions

### DIFF
--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteAdminClient.java
@@ -79,6 +79,7 @@ public class FlyteAdminClient {
       ExecutionOuterClass.ExecutionMetadata.ExecutionMode executionMode,
       Map<String, String> labels,
       Map<String, String> annotations,
+      Map<String, String> inputs,
       Map<String, String> extraDefaultInputs) {
     LOG.debug("createExecution {} {} {}", project, domain, launchPlanId);
 
@@ -91,7 +92,7 @@ public class FlyteAdminClient {
 
     var launchPlan = getLaunchPlan(launchPlanId);
 
-    var inputs = launchPlan.getSpec().getDefaultInputs();
+    var defaultInputs = launchPlan.getSpec().getDefaultInputs();
 
     var spec =
         ExecutionOuterClass.ExecutionSpec.newBuilder()
@@ -112,7 +113,7 @@ public class FlyteAdminClient {
                 .setProject(project)
                 .setName(name)
                 .setSpec(spec)
-                .setInputs(fillParameterInInputs(inputs, extraDefaultInputs))
+                .setInputs(fillParameterInInputs(defaultInputs.getParametersMap(), inputs, extraDefaultInputs))
                 .build());
 
     verifyNotNull(

--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/FlyteInputsUtils.java
@@ -96,12 +96,14 @@ public class FlyteInputsUtils {
     var extraDefaultInput = extraDefaultInputs.get(lowercaseKey);
 
     // Order of if sentences specify priority
-    if (input != null) {
-      return literalOf(key, input, parameter.getVar().getType());
-    }
-
+    // extraDefaultInputs contain also the trigger inputs.
+    // FIXME move this earlier, merge the inputs and extraDefaultInputs before passing them to FlyteAdminClient
     if (extraDefaultInput != null) {
       return literalOf(key, extraDefaultInput, parameter.getVar().getType());
+    }
+
+    if (input != null) {
+      return literalOf(key, input, parameter.getVar().getType());
     }
 
     if (parameter.hasDefault()) {

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteAdminClientTest.java
@@ -94,7 +94,7 @@ public class FlyteAdminClientTest {
   public void shouldPropagateCreateExecutionToStub() {
     var workflowExecution =
         flyteAdminClient.createExecution(PROJECT, DOMAIN, NON_EXISTING_NAME, identifier(NON_EXISTING_NAME),
-            ExecutionMode.SCHEDULED, Map.of(), Map.of(), EXTRA_DEFAULT_INPUTS);
+            ExecutionMode.SCHEDULED, Map.of(), Map.of(), Map.of(), EXTRA_DEFAULT_INPUTS);
     assertThat(workflowExecution.getId().getProject(), equalTo(PROJECT));
     assertThat(workflowExecution.getId().getDomain(), equalTo(DOMAIN));
     assertThat(workflowExecution.getId().getName(), equalTo(NON_EXISTING_NAME));
@@ -104,7 +104,7 @@ public class FlyteAdminClientTest {
   public void shouldPropagateLabelsAndAnnotationsOnCreateExecutionToStub() {
     var workflowExecution =
         flyteAdminClient.createExecution(PROJECT, DOMAIN, NON_EXISTING_NAME, identifier(NON_EXISTING_NAME),
-            ExecutionMode.SCHEDULED, LABELS, ANNOTATIONS, EXTRA_DEFAULT_INPUTS);
+            ExecutionMode.SCHEDULED, LABELS, ANNOTATIONS, Map.of(), EXTRA_DEFAULT_INPUTS);
     assertThat(workflowExecution, notNullValue());
 
     var retrievedExecution = flyteAdminClient.getExecution(PROJECT, DOMAIN, NON_EXISTING_NAME);

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/FlyteInputsUtilsTest.java
@@ -114,7 +114,7 @@ public class FlyteInputsUtilsTest {
   }
 
   @Test
-  public void shouldFillParameterGivingPriorityToInputs() {
+  public void shouldFillParameterGivingPriorityToExtraInputs() {
     var parameterMap = Interface.ParameterMap.newBuilder()
         .putParameters("EXTRA_PARAMETER", Interface.Parameter.newBuilder()
             .setVar(Interface.Variable.newBuilder()
@@ -127,7 +127,7 @@ public class FlyteInputsUtilsTest {
         .build();
 
     var inputs = fillParameterInInputs(parameterMap.getParametersMap(),
-        Map.of("EXTRA_PARAMETER", "1970-01-01T01"), Map.of("EXTRA_PARAMETER", "2000-12-31T11"));
+        Map.of("EXTRA_PARAMETER", "2000-12-31T11"), Map.of("EXTRA_PARAMETER", "1970-01-01T01"));
 
     var timestamp = inputs.getLiteralsMap()
         .get("EXTRA_PARAMETER")

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -168,6 +168,7 @@ public class FlyteAdminClientRunner implements FlyteRunner {
         .put(STYX_WORKFLOW_INSTANCE_ANNOTATION, runState.workflowInstance().toKey())
         .put(STYX_EXECUTION_ID_ANNOTATION, styxVariables.get(STYX_EXECUTION_ID))
         .build();
+    final var inputs = flyteExecConf.inputFields();
     final var extraDefaultInputs = ImmutableMap.<String, String>builder()
         .putAll(styxVariables)
         .putAll(triggeredParams)
@@ -188,6 +189,7 @@ public class FlyteAdminClientRunner implements FlyteRunner {
           execMode,
           /* labels = */ labels,
           /* annotations = */ annotations,
+          /* inputs = */ inputs,
           /* extraDefaultInputs = */ extraDefaultInputs);
       return runnerId;
     } catch (StatusRuntimeException e) {

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
@@ -133,7 +133,7 @@ public class FlyteAdminClientRunnerTest {
     assertThat(runnerId, is(RUNNER_ID));
     verify(flyteAdminClient).createExecution(
         eq(LAUNCH_PLAN_IDENTIFIER.project()), eq(LAUNCH_PLAN_IDENTIFIER.domain()), eq(execName),
-        eq(toProto(LAUNCH_PLAN_IDENTIFIER)), eq(SCHEDULED), any(), any(), any());
+        eq(toProto(LAUNCH_PLAN_IDENTIFIER)), eq(SCHEDULED), any(), any(), any(), any());
   }
 
   private IdentifierOuterClass.Identifier toProto(FlyteIdentifier identifier) {
@@ -153,7 +153,7 @@ public class FlyteAdminClientRunnerTest {
     final RunState runState = runState(styxTrigger);
     flyteRunner.createExecution(runState, "test-create-execution", FLYTE_EXEC_CONF);
     verify(flyteAdminClient).createExecution(any(), any(), any(), any(), eq(flyteExecMode),
-        any(), any(), any());
+        any(), any(), any(), any());
   }
 
   private static Object[] styxTriggerToFlyteExecMode() {
@@ -182,7 +182,7 @@ public class FlyteAdminClientRunnerTest {
   @Test
   public void testThrowsFlyteLaunchPlanNotFound() {
     doThrow(new StatusRuntimeException(Status.NOT_FOUND))
-        .when(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(), any(), any());
+        .when(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(), any(), any(), any());
     assertThrows(
         FlyteRunner.LaunchPlanNotFound.class,
         () -> flyteRunner.createExecution(RUN_STATE, "exec", FLYTE_EXEC_CONF));
@@ -191,19 +191,19 @@ public class FlyteAdminClientRunnerTest {
   @Test
   public void testCreateExecutionForAlreadyExistsException() throws FlyteRunner.CreateExecutionException {
     doThrow(new StatusRuntimeException(Status.ALREADY_EXISTS))
-        .when(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(), any(), any());
+        .when(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(), any(), any(), any());
     var runnerId = flyteRunner.createExecution(RUN_STATE, "exec", FLYTE_EXEC_CONF);
 
     assertThat(runnerId, is(RUNNER_ID));
     verify(flyteAdminClient).createExecution(
         eq(LAUNCH_PLAN_IDENTIFIER.project()), eq(LAUNCH_PLAN_IDENTIFIER.domain()), eq("exec"),
-        eq(toProto(LAUNCH_PLAN_IDENTIFIER)), eq(SCHEDULED), any(), any(), any());
+        eq(toProto(LAUNCH_PLAN_IDENTIFIER)), eq(SCHEDULED), any(), any(), any(), any());
   }
 
   @Test
   public void testThrowsCreateExecutionExceptionForOtherCode() {
     doThrow(new StatusRuntimeException(Status.INTERNAL))
-        .when(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(), any(), any());
+        .when(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(), any(), any(), any());
     assertThrows(
         FlyteRunner.CreateExecutionException.class,
         () -> flyteRunner.createExecution(RUN_STATE, "exec", FLYTE_EXEC_CONF));
@@ -212,7 +212,7 @@ public class FlyteAdminClientRunnerTest {
   @Test
   public void testThrowsCreateExecutionExceptionForUnknownException() {
     doThrow(new IllegalStateException("test"))
-        .when(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(), any(), any());
+        .when(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(), any(), any(), any());
 
     assertThrows(
         FlyteRunner.CreateExecutionException.class,
@@ -460,12 +460,12 @@ public class FlyteAdminClientRunnerTest {
         .put("STYX_WORKFLOW_ID", "styx.TestEndpoint")
         .build();
 
-    verify(flyteAdminClient).createExecution(any(), any(), any(), any(), any(),
+    verify(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(),
         eq(expectedLabels), eq(expectedAnnotations), eq(expectedExtraInputs));
   }
 
   private void stubAdminClientCreateExec(String execName) {
-    when(flyteAdminClient.createExecution(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(
+    when(flyteAdminClient.createExecution(any(), any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(
         ExecutionOuterClass.ExecutionCreateResponse
             .newBuilder()
             .setId(IdentifierOuterClass.WorkflowExecutionIdentifier
@@ -496,7 +496,7 @@ public class FlyteAdminClientRunnerTest {
         .build();
 
     ArgumentCaptor<Map<String, String>> argCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(flyteAdminClient).createExecution(any(), any(), any(), any(), any(),
+    verify(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(),
         any(), any(), argCaptor.capture());
     assertThat(argCaptor.getValue(), hasEntry("HADES_OVERWRITE", "true"));
   }
@@ -515,7 +515,7 @@ public class FlyteAdminClientRunnerTest {
     flyteRunner.createExecution(runState(triggeredParams), execName, FLYTE_EXEC_CONF);
 
     ArgumentCaptor<Map<String, String>> argCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(flyteAdminClient).createExecution(any(), any(), any(), any(), any(),
+    verify(flyteAdminClient).createExecution(any(), any(), any(), any(), any(), any(),
         any(), any(), argCaptor.capture());
 
     assertThat(argCaptor.getValue(), allOf(


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Add inputs on flyteExecConf to flyte executions

## Motivation and Context
Flyte inputs described in the Flyte execution configuration is being ignored and this PR remediates that.
Now inputs are now populating the inpute parameter of the launch plan and they take precedent over triggered parameters

## Have you tested this? If so, how?
"I have included unit tests.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
