### PR TITLE
Upgrading to Log4j 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.15.0</version>
+        <version>2.17.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Switch to Log4j 2.17.0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Log4j 2.15 is vulnerable to log4shell and recursion vulnerabilities. 


No code changes.

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
