### PR TITLE
(CVE-2021-44832)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.0</version>
+        <version>2.17.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION

Fix this security vulnerability by upgrading to latest log4j 2.17.1
According to CVE-2021-44832, all versions from 2.17.0 to 2.17.1 are vulnerable



In this report, i have submitted all other repo's, inform your teammates to triage it and fix them all. 

