### PR TITLE
fix filter according to flyteconsole usage

### DIFF
--- a/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/RpcHelper.java
+++ b/styx-flyte-client/src/main/java/com/spotify/styx/flyte/client/RpcHelper.java
@@ -29,8 +29,7 @@ public class RpcHelper {
 
   private RpcHelper() {}
 
-  // Test this filter by printing it and using it on a flytectl command
-  // example:  flytectl get executions -p PROJECT -d DOMAIN --filter.fieldSelector="execution.phase in (RUNNING),execution.started_at>2022-02-07T18:23:05,execution.started_at<2022-02-08T18:10:05" -o json
+  // Test this filter by running it towards FlyteAdmin
   public static String getExecutionsListFilter(Instant timeNow, Duration since, Duration to) {
 
     final String dateSince = timeNow.minus(since)
@@ -44,6 +43,6 @@ public class RpcHelper {
         .toLocalDateTime()
         .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
 
-    return String.format("execution.phase in (RUNNING),execution.started_at>%s,execution.started_at<%s", dateSince, dateTo);
+    return String.format("value_in(phase,RUNNING)+gte(started_at,%s)+lte(started_at,%s)",dateSince,dateTo);
   }
 }

--- a/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/RpcHelperTest.java
+++ b/styx-flyte-client/src/test/java/com/spotify/styx/flyte/client/RpcHelperTest.java
@@ -46,7 +46,7 @@ public class RpcHelperTest {
         Duration.of(3, ChronoUnit.MINUTES));
 
     assertThat(executionsListFilter,
-        equalTo("execution.phase in (RUNNING),execution.started_at>2022-02-01T12:12:05,execution.started_at<2022-02-02T12:09:05"));
+        equalTo("value_in(phase,RUNNING)+gte(started_at,2022-02-01T12:12:05)+lte(started_at,2022-02-02T12:09:05)"));
 
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTerminateDanglingTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTerminateDanglingTest.java
@@ -152,11 +152,11 @@ public class FlyteAdminClientRunnerTerminateDanglingTest {
 
     ArgumentCaptor<String> filterCatcher = ArgumentCaptor.forClass(String.class);
     verify(adminClient).listExecutions(any(), any(), anyInt(), any(), filterCatcher.capture());
-    var filters = filterCatcher.getValue().split(",");
+    var filters = filterCatcher.getValue().split("+");
     assertThat(filters, arrayContainingInAnyOrder(
-        equalTo("execution.phase in (RUNNING)"),
-        startsWith("execution.started_at>"),
-        startsWith("execution.started_at<"))
+        equalTo("value_in(phase,RUNNING)"),
+        startsWith("gte(started_at,"),
+        startsWith("lte(started_at,"))
     );
   }
 

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTerminateDanglingTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTerminateDanglingTest.java
@@ -152,7 +152,7 @@ public class FlyteAdminClientRunnerTerminateDanglingTest {
 
     ArgumentCaptor<String> filterCatcher = ArgumentCaptor.forClass(String.class);
     verify(adminClient).listExecutions(any(), any(), anyInt(), any(), filterCatcher.capture());
-    var filters = filterCatcher.getValue().split("+");
+    var filters = filterCatcher.getValue().split("\\+");
     assertThat(filters, arrayContainingInAnyOrder(
         equalTo("value_in(phase,RUNNING)"),
         startsWith("gte(started_at,"),


### PR DESCRIPTION
https://github.com/flyteorg/flyteconsole/blob/2f0d88c98ac4eb9059e5a98deacdd1aef5c9d2ea/src/models/AdminEntity/AdminApiQuery.ts

# Hey, I just made a Pull Request!

The filters are not working the same way as flytectl.
I had to find some references in flyteconsole to fix them
https://github.com/flyteorg/flyteconsole/blob/2f0d88c98ac4eb9059e5a98deacdd1aef5c9d2ea/src/models/AdminEntity/AdminApiQuery.ts


The filter seperator is `+` and not `,`
instead of == or in, use the filter operation names

## Description
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
