### PR TITLE
Bump logback and urilib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <hamcrest.version>2.2</hamcrest.version>
     <errorprone.version>2.6.0</errorprone.version>
     <grpc.version>1.27.2</grpc.version>
+    <logback.version>1.2.9</logback.version>
   </properties>
 
   <repositories>
@@ -593,7 +594,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.2.7</version>
+        <version>${logback.version}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
@@ -645,7 +646,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
-        <version>1.2.7</version>
+        <version>${logback.version}</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/styx-e2e-test/flyte-test-workflow/requirements.txt
+++ b/styx-e2e-test/flyte-test-workflow/requirements.txt
@@ -117,7 +117,7 @@ typing-extensions==3.7.4.3
     # via typing-inspect
 typing-inspect==0.6.0
     # via dataclasses-json
-urllib3==1.25.11
+urllib3==1.26.5
     # via
     #   flytekit
     #   requests


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Bump logback and urlib

## Motivation and Context
To fix [CVE-2021-33503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33503) and [CVE-2021-42550](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42550).

Logback vulnerability is not really an issue unless an atacker could modify the logback config file. The python urlib is only used during integration testing with flyte.

## Have you tested this? If so, how?
Current tests suit should prove that the system keeps working

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
