### PR TITLE
add STYX_EXECUTION_COUNTER to docker env

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -45,6 +45,7 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.Message;
 import com.spotify.styx.state.RunState;
+import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
 import com.spotify.styx.state.StateTransitionConflictException;
 import com.spotify.styx.state.Trigger;
@@ -124,6 +125,7 @@ class KubernetesDockerRunner implements DockerRunner {
   static final String TRIGGER_TYPE = "STYX_TRIGGER_TYPE";
   static final String ENVIRONMENT = "STYX_ENVIRONMENT";
   static final String LOGGING = "STYX_LOGGING";
+  static final String STYX_EXECUTION_COUNTER = "STYX_EXECUTION_COUNTER";
   private static final int DEFAULT_POD_CLEANUP_INTERVAL_SECONDS = 60;
   private static final int DEFAULT_POD_DELETION_DELAY_SECONDS = 120;
   private static final Duration POD_FORCE_DELETION_TOLERATION = Duration.ofMinutes(30);
@@ -205,6 +207,8 @@ class KubernetesDockerRunner implements DockerRunner {
   public String start(RunState runState, RunSpec runSpec) throws IOException {
     var workflowInstance = runState.workflowInstance();
 
+    var stateData = runState.data();
+
     // First make cheap check for if pod already exists
     var existingPod = client.getPod(runSpec.executionId());
     if (existingPod.isPresent()) {
@@ -218,7 +222,7 @@ class KubernetesDockerRunner implements DockerRunner {
     // Create pod. This might fail with 409 Conflict if the pod already exists as despite the existence
     // check above it might have been concurrently created. That is fine.
     try {
-      var pod = createPod(workflowInstance, runSpec, secretSpec, styxEnvironment, podMutator, executionEnvVars);
+      var pod = createPod(workflowInstance, runSpec, secretSpec, styxEnvironment, podMutator, executionEnvVars, stateData);
       LOG.info("Creating pod: {}: {}", workflowInstance, pod);
       var createdPod = client.createPod(pod);
       stats.recordSubmission(runSpec.executionId());
@@ -271,7 +275,8 @@ class KubernetesDockerRunner implements DockerRunner {
                        KubernetesSecretSpec secretSpec,
                        String styxEnvironment,
                        PodMutator podMutator,
-                       final Map<String, String> executionEnvVars) {
+                       final Map<String, String> executionEnvVars,
+                       StateData stateData) {
     final String imageWithTag = runSpec.imageName().contains(":")
         ? runSpec.imageName()
         : runSpec.imageName() + ":latest";
@@ -297,7 +302,7 @@ class KubernetesDockerRunner implements DockerRunner {
         .withName(MAIN_CONTAINER_NAME)
         .withImage(imageWithTag)
         .withArgs(runSpec.args())
-        .withEnv(buildEnv(workflowInstance, runSpec, styxEnvironment, executionEnvVars))
+        .withEnv(buildEnv(workflowInstance, runSpec, styxEnvironment, executionEnvVars, stateData))
         .withResources(resourceRequirements.build());
 
     secretSpec.serviceAccountSecret().ifPresent(serviceAccountSecret -> {
@@ -361,7 +366,9 @@ class KubernetesDockerRunner implements DockerRunner {
   private static List<EnvVar> buildEnv(WorkflowInstance workflowInstance,
                                        RunSpec runSpec,
                                        String styxEnvironment,
-                                       Map<String, String> executionEnvVars) {
+                                       Map<String, String> executionEnvVars,
+                                       StateData stateData) {
+
     // store user provided env first to prevent accidentally/intentionally overwriting system ones
     final Map<String, String> env = new HashMap<>(runSpec.env());
     env.put(COMPONENT_ID, workflowInstance.workflowId().componentId());
@@ -377,6 +384,7 @@ class KubernetesDockerRunner implements DockerRunner {
     env.put(TRIGGER_TYPE, runSpec.trigger().map(TriggerUtil::triggerType).orElse(null));
     env.put(ENVIRONMENT, styxEnvironment);
     env.put(LOGGING, "structured");
+    env.put(STYX_EXECUTION_COUNTER, String.valueOf(stateData.tries()));
     executionEnvVars.forEach((key, value) -> {
       if (env.containsKey(key)) {
         LOG.info("Key already exists in execution environment variables {}. Key will be skipped", key);

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerPodPollerTest.java
@@ -235,6 +235,6 @@ public class KubernetesDockerRunnerPodPollerTest {
                                KubernetesSecretSpec secretSpec) {
     return KubernetesDockerRunner
         .createPod(workflowInstance, runSpec, secretSpec, STYX_ENVIRONMENT, PodMutator.NOOP,
-            Collections.emptyMap());
+            Collections.emptyMap(), StateData.zero());
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesDockerRunnerTest.java
@@ -906,6 +906,6 @@ public class KubernetesDockerRunnerTest {
                                KubernetesSecretSpec secretSpec) {
     return KubernetesDockerRunner
         .createPod(workflowInstance, runSpec, secretSpec, STYX_ENVIRONMENT, PodMutator.NOOP,
-            Collections.emptyMap());
+            Collections.emptyMap(), StateData.zero());
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManagerTest.java
@@ -48,6 +48,7 @@ import com.spotify.styx.docker.DockerRunner.RunSpec;
 import com.spotify.styx.docker.KubernetesDockerRunner.KubernetesSecretSpec;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
+import com.spotify.styx.state.StateData;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -570,6 +571,6 @@ public class KubernetesGCPServiceAccountSecretManagerTest {
                                Map<String, String> executionEnvVars) {
     return KubernetesDockerRunner
         .createPod(workflowInstance, runSpec, secretSpec, STYX_ENVIRONMENT, PodMutator.NOOP,
-            executionEnvVars);
+            executionEnvVars, StateData.zero());
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/docker/KubernetesPodEventTranslatorTest.java
@@ -33,6 +33,7 @@ import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.RunState.State;
+import com.spotify.styx.state.StateData;
 import com.spotify.styx.testdata.TestData;
 import io.fabric8.kubernetes.api.model.ContainerState;
 import io.fabric8.kubernetes.api.model.ContainerStateRunning;
@@ -65,7 +66,7 @@ public class KubernetesPodEventTranslatorTest {
   private static final String STYX_ENVIRONMENT = "testing";
 
   private final Pod pod = KubernetesDockerRunner.createPod(WFI, RUN_SPEC, SECRET_SPEC, STYX_ENVIRONMENT, PodMutator.NOOP,
-      Collections.emptyMap());
+      Collections.emptyMap(), StateData.zero());
 
   @Test
   public void terminateOnSuccessfulTermination() {
@@ -430,6 +431,7 @@ public class KubernetesPodEventTranslatorTest {
         SECRET_SPEC,
         STYX_ENVIRONMENT,
         PodMutator.NOOP,
-        Collections.emptyMap());
+        Collections.emptyMap(),
+        StateData.zero());
   }
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Adding STYX_EXECUTION_COUNTER env variable

## Motivation and Context
We want to have more control over execution in the code. Also STYX_EXECUTION_COUNTER is mentioned in the docs, but wasn't implemented yet.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
