### PR TITLE
Check role first before checking admin

### DIFF
--- a/styx-service-common/src/main/java/com/spotify/styx/api/ServiceAccountUsageAuthorizer.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/ServiceAccountUsageAuthorizer.java
@@ -224,8 +224,8 @@ public interface ServiceAccountUsageAuthorizer {
       final Supplier<String> projectIdSupplier = Suppliers.memoize(() -> serviceAccountProjectId(serviceAccount));
 
       return checkIsPrincipalBlacklisted(principalEmail)
-          .or(() -> checkIsPrincipalAdmin(principalEmail))
           .or(() -> checkRole(serviceAccount, principalEmail, projectIdSupplier))
+          .or(() -> checkIsPrincipalAdmin(principalEmail))
           .orElseGet(() -> deny(serviceAccount, principalEmail, projectIdSupplier));
     }
 
@@ -394,7 +394,7 @@ public interface ServiceAccountUsageAuthorizer {
                 principalEmail, group);
             return false;
           } else if (statusCode == 404) {
-            log.info("Group {} does not exist", group, cause);
+            log.info("Group {} does not exist", group);
             return false;
           }
         }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Check role before checking administrators.

Also a minor fix to omit logging stacktrace for info level that was not covered by #999.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In most cases the principle would not be configured administrators, so the group member check would fail or return false, which is wasteful. Also the directory API call could be slow for unknown reason.

By swapping the two checks we should be able to save many unnecessary API calls.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit tests get this covered.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
