### PR TITLE
Guard checkRole

### DIFF
--- a/styx-service-common/src/main/java/com/spotify/styx/api/ServiceAccountUsageAuthorizer.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/ServiceAccountUsageAuthorizer.java
@@ -250,9 +250,11 @@ public interface ServiceAccountUsageAuthorizer {
         checkRoleException = e;
       }
 
-      if (result.isEmpty()) {
-        result = checkIsPrincipalAdmin(principalEmail);
+      if (result.isPresent()) {
+        return result;
       }
+
+      result = checkIsPrincipalAdmin(principalEmail);
 
       if (result.isEmpty() && checkRoleException != null) {
         throw checkRoleException;

--- a/styx-service-common/src/main/java/com/spotify/styx/api/ServiceAccountUsageAuthorizer.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/ServiceAccountUsageAuthorizer.java
@@ -237,15 +237,6 @@ public interface ServiceAccountUsageAuthorizer {
               .build());
     }
 
-    private Optional<ServiceAccountUsageAuthorizationResult> checkIsPrincipalAdmin(
-        String principalEmail) {
-      return memberStatus(principalEmail, administrators)
-          .map(status -> ServiceAccountUsageAuthorizationResult.builder()
-              .authorized(true)
-              .message(String.format("Principal %s is an admin %s", principalEmail, status))
-              .build());
-    }
-
     private Optional<ServiceAccountUsageAuthorizationResult> checkRoleOrIsPrincipalAdmin(String serviceAccount,
                                                                                          String principalEmail,
                                                                                          Supplier<String> projectIdSupplier) {
@@ -267,6 +258,15 @@ public interface ServiceAccountUsageAuthorizer {
         throw checkRoleException;
       }
       return result;
+    }
+
+    private Optional<ServiceAccountUsageAuthorizationResult> checkIsPrincipalAdmin(
+        String principalEmail) {
+      return memberStatus(principalEmail, administrators)
+          .map(status -> ServiceAccountUsageAuthorizationResult.builder()
+              .authorized(true)
+              .message(String.format("Principal %s is an admin %s", principalEmail, status))
+              .build());
     }
 
     private Optional<ServiceAccountUsageAuthorizationResult> checkRole(String serviceAccount,

--- a/styx-service-common/src/test/java/com/spotify/styx/api/ServiceAccountUsageAuthorizerTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/ServiceAccountUsageAuthorizerTest.java
@@ -359,6 +359,18 @@ public class ServiceAccountUsageAuthorizerTest {
 
   @Parameters({SERVICE_ACCOUNT, MANAGED_SERVICE_ACCOUNT})
   @Test
+  public void shouldAuthorizeIfPrincipalIsAdminViaGroupEvenCheckRoleFails(String serviceAccount) throws IOException {
+    final Throwable cause = googleJsonResponseException(418);
+    var errorRequest = mock(Directory.Members.HasMember.class);
+    doThrow(cause).when(errorRequest).execute();
+    doReturn(errorRequest).when(members).hasMember(PROJECT_ADMINS_GROUP_EMAIL, PRINCIPAL_EMAIL);
+    doReturn(isMember).when(members).hasMember(STYX_ADMINS_GROUP_EMAIL, PRINCIPAL_EMAIL);
+    assertCachedSuccess(() -> sut.authorizeServiceAccountUsage(WORKFLOW_ID, serviceAccount, idToken));
+  }
+
+
+  @Parameters({SERVICE_ACCOUNT, MANAGED_SERVICE_ACCOUNT})
+  @Test
   public void shouldAuthorizeIfPrincipalHasUserRoleOnProjectViaGroup(String serviceAccount) throws IOException {
     doReturn(isMember).when(members).hasMember(PROJECT_ADMINS_GROUP_EMAIL, PRINCIPAL_EMAIL);
     assertCachedSuccess(() -> sut.authorizeServiceAccountUsage(WORKFLOW_ID, serviceAccount, idToken));


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
This fixes a regression introduced by #1000.

We guard `checkRole` and only throw if `checkIsPrincipalAdmin` does not pass.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Early throw of `checkRole` will skip `checkIsPrincipalAdmin` and will make administrators not being able to do anything.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit tests all pass.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
