### PR TITLE
Handle not enough keys from failed preconditions errors

### DIFF
--- a/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/AdHocTriggeringIT.java
+++ b/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/AdHocTriggeringIT.java
@@ -79,7 +79,7 @@ public class AdHocTriggeringIT extends EndToEndTestBase {
     assertThat(triggerResult, is("Triggered! Use `styx ls -c " + component1 + "` to check active workflow instances."));
 
     // Wait for instance to successfully complete
-    await().atMost(5, MINUTES).until(() -> {
+    await().atMost(10, MINUTES).until(() -> {
       var events = cliJson(new TypeReference<List<EventInfo>>() {}, "e", component1, workflowId1, instance);
       return events.stream().anyMatch(event -> event.name().equals("success"));
     });

--- a/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/EndToEndTestBase.java
+++ b/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/EndToEndTestBase.java
@@ -20,13 +20,6 @@
 
 package com.spotify.styx.e2e_tests;
 
-import static com.spotify.styx.e2e_tests.DatastoreUtil.deleteDatastoreNamespace;
-import static com.spotify.styx.testdata.TestData.TEST_DEPLOYMENT_TIME;
-import static java.lang.ProcessBuilder.Redirect.INHERIT;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static java.util.stream.Collectors.toList;
-import static org.awaitility.Awaitility.await;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
@@ -54,6 +47,15 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.norberg.automatter.AutoMatter;
+import javaslang.control.Try;
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -70,14 +72,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import javaslang.control.Try;
-import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static com.spotify.styx.e2e_tests.DatastoreUtil.deleteDatastoreNamespace;
+import static com.spotify.styx.testdata.TestData.TEST_DEPLOYMENT_TIME;
+import static java.lang.ProcessBuilder.Redirect.INHERIT;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toList;
+import static org.awaitility.Awaitility.await;
 
 public class EndToEndTestBase {
 
@@ -195,7 +197,7 @@ public class EndToEndTestBase {
       return null;
     });
 
-    await().atMost(300, SECONDS)
+    await().atMost(10, MINUTES)
         .until(() -> {
           if (styxSchedulerThread.isDone()) {
             styxSchedulerThread.get();

--- a/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/ScheduledTriggeringIT.java
+++ b/styx-e2e-test/src/test/java/com/spotify/styx/e2e_tests/ScheduledTriggeringIT.java
@@ -87,7 +87,7 @@ public class ScheduledTriggeringIT extends EndToEndTestBase {
     log.info("Expected instance: {}", instance);
 
     // Wait for expected instance to successfully complete
-    await().atMost(5, MINUTES).until(() -> {
+    await().atMost(10, MINUTES).until(() -> {
       var events = cliJson(new TypeReference<List<EventInfo>>() {}, "e", component1, workflowId1, instance);
       return events.stream().anyMatch(event -> event.name().equals("success"));
     });

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesGCPServiceAccountSecretManager.java
@@ -120,7 +120,7 @@ class KubernetesGCPServiceAccountSecretManager {
         throw new InvalidExecutionException(String.format(
             "Permission denied when creating keys for service account: %s. Styx needs to be Service Account Key Admin.",
             serviceAccount));
-      } else if (GcpUtil.isResourceExhausted(cause)) {
+      } else if (GcpUtil.isResourceExhausted(cause) || GcpUtil.isFailedPrecondition(cause)) {
         throw new InvalidExecutionException(String.format(
             "Maximum number of keys on service account reached: %s. Styx requires 4 keys to operate.",
             serviceAccount));

--- a/styx-service-common/src/main/java/com/spotify/styx/util/GcpUtil.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/util/GcpUtil.java
@@ -20,16 +20,16 @@
 
 package com.spotify.styx.util;
 
+import static com.spotify.apollo.Status.BAD_REQUEST;
+import static com.spotify.apollo.Status.FORBIDDEN;
+import static com.spotify.apollo.Status.TOO_MANY_REQUESTS;
+
 import com.google.api.client.googleapis.json.GoogleJsonError;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import java.util.Optional;
 import java.util.function.Predicate;
 
 public class GcpUtil {
-
-  private static final int BAD_REQUEST = 400;
-  private static final int FORBIDDEN = 403;
-  private static final int TOO_MANY_REQUEST_CODE = 429;
 
   private GcpUtil() {
     throw new UnsupportedOperationException();
@@ -41,7 +41,7 @@ public class GcpUtil {
   }
 
   public static boolean isPermissionDenied(GoogleJsonResponseException e) {
-    return matchesCodeAndError(e,  FORBIDDEN, GcpUtil::isPermissionDenied);
+    return matchesCodeAndError(e, FORBIDDEN.code(), GcpUtil::isPermissionDenied);
   }
 
   public static boolean isPermissionDenied(GoogleJsonError error) {
@@ -54,7 +54,7 @@ public class GcpUtil {
   }
 
   public static boolean isResourceExhausted(GoogleJsonResponseException e) {
-    return matchesCodeAndError(e, TOO_MANY_REQUEST_CODE,
+    return matchesCodeAndError(e, TOO_MANY_REQUESTS.code(),
         error -> matchesStatus(error, "RESOURCE_EXHAUSTED"));
   }
 
@@ -68,7 +68,7 @@ public class GcpUtil {
   }
 
   public static boolean isFailedPrecondition(GoogleJsonResponseException e) {
-    return matchesCodeAndError(e, BAD_REQUEST, GcpUtil::isFailedPrecondition);
+    return matchesCodeAndError(e, BAD_REQUEST.code(), GcpUtil::isFailedPrecondition);
   }
 
   public static boolean isFailedPrecondition(GoogleJsonError error) {

--- a/styx-service-common/src/main/java/com/spotify/styx/util/GcpUtil.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/util/GcpUtil.java
@@ -23,8 +23,13 @@ package com.spotify.styx.util;
 import com.google.api.client.googleapis.json.GoogleJsonError;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 public class GcpUtil {
+
+  private static final int BAD_REQUEST = 400;
+  private static final int FORBIDDEN = 403;
+  private static final int TOO_MANY_REQUEST_CODE = 429;
 
   private GcpUtil() {
     throw new UnsupportedOperationException();
@@ -36,13 +41,11 @@ public class GcpUtil {
   }
 
   public static boolean isPermissionDenied(GoogleJsonResponseException e) {
-    return e.getStatusCode() == 403 && Optional.ofNullable(e.getDetails())
-        .map(GcpUtil::isPermissionDenied)
-        .orElse(false);
+    return matchesCodeAndError(e,  FORBIDDEN, GcpUtil::isPermissionDenied);
   }
 
   public static boolean isPermissionDenied(GoogleJsonError error) {
-    return "PERMISSION_DENIED".equals(error.get("status"));
+    return matchesStatus(error, "PERMISSION_DENIED");
   }
 
   public static boolean isResourceExhausted(Throwable t) {
@@ -51,12 +54,35 @@ public class GcpUtil {
   }
 
   public static boolean isResourceExhausted(GoogleJsonResponseException e) {
-    return e.getStatusCode() == 429 && Optional.ofNullable(e.getDetails())
-        .map(GcpUtil::isResourceExhausted)
-        .orElse(false);
+    return matchesCodeAndError(e, TOO_MANY_REQUEST_CODE,
+        error -> matchesStatus(error, "RESOURCE_EXHAUSTED"));
   }
 
-  public static boolean isResourceExhausted(GoogleJsonError error) {
-    return "RESOURCE_EXHAUSTED".equals(error.get("status"));
+  public static boolean isResourceExhausted(GoogleJsonError e) {
+    return matchesStatus(e, "RESOURCE_EXHAUSTED");
+  }
+
+  public static boolean isFailedPrecondition(Throwable t) {
+    return t instanceof GoogleJsonResponseException
+        && isFailedPrecondition((GoogleJsonResponseException) t);
+  }
+
+  public static boolean isFailedPrecondition(GoogleJsonResponseException e) {
+    return matchesCodeAndError(e, BAD_REQUEST, GcpUtil::isFailedPrecondition);
+  }
+
+  public static boolean isFailedPrecondition(GoogleJsonError error) {
+    return matchesStatus(error, "FAILED_PRECONDITION");
+  }
+
+  private static boolean matchesStatus(GoogleJsonError error, String status) {
+    return status.equals(error.get("status"));
+  }
+
+  private static boolean matchesCodeAndError(GoogleJsonResponseException e, int code,
+      Predicate<GoogleJsonError> errMatcher) {
+    return e.getStatusCode() == code && Optional.ofNullable(e.getDetails())
+        .map(errMatcher::test)
+        .orElse(false);
   }
 }

--- a/styx-service-common/src/test/java/com/spotify/styx/util/GcpUtilTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/util/GcpUtilTest.java
@@ -20,8 +20,8 @@
 
 package com.spotify.styx.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import com.google.api.client.googleapis.json.GoogleJsonError;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
@@ -36,6 +36,9 @@ public class GcpUtilTest {
 
   private static final GoogleJsonError RESOURCE_EXHAUSTED_ERROR = new GoogleJsonError()
       .set("status", "RESOURCE_EXHAUSTED");
+
+  private static final GoogleJsonError FAILED_PRECONDITION_ERROR = new GoogleJsonError()
+      .set("status", "FAILED_PRECONDITION");
 
   @Test
   public void responseIsPermissionDenied() {
@@ -71,6 +74,13 @@ public class GcpUtilTest {
   }
 
   @Test
+  public void responseIsFailedPrecondition() {
+    final Throwable failedPrecondition = new GoogleJsonResponseException(
+        new HttpResponseException.Builder(400, "Precondition check failed", new HttpHeaders()), FAILED_PRECONDITION_ERROR);
+    assertThat(GcpUtil.isFailedPrecondition(failedPrecondition), is(true));
+  }
+
+  @Test
   public void notFoundResponseIsNotPResourceExhausted() {
     assertThat(GcpUtil.isResourceExhausted(new GoogleJsonResponseException(
         new HttpResponseException.Builder(404, "Not Found", new HttpHeaders()), new GoogleJsonError())), is(false));
@@ -81,6 +91,11 @@ public class GcpUtilTest {
   @Test
   public void errorIsResourceExhausted() {
     assertThat(GcpUtil.isResourceExhausted(RESOURCE_EXHAUSTED_ERROR), is(true));
+  }
+
+  @Test
+  public void errorIsFailedPrecondition() {
+    assertThat(GcpUtil.isFailedPrecondition(FAILED_PRECONDITION_ERROR), is(true));
   }
 
   @Test


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Handle not enough keys from failed preconditions errors

## Motivation and Context
Google now returns a different error to signal that it cannot create new keys. The code can handle both types of error now

This is the error produced
```
POST https://iam.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.iam.gserviceaccount.com/keys
{
  "code": 400,
  "errors": [
    {
      "domain": "global",
      "message": "Precondition check failed.",
      "reason": "failedPrecondition"
    }
  ],
  "message": "Precondition check failed.",
  "status": "FAILED_PRECONDITION"
}
   at com.spotify.styx.docker.KubernetesGCPServiceAccountSecretManager.ensureServiceAccountKeySecret(KubernetesGCPServiceAccountSecretManager.java:128)
   at com.spotify.styx.docker.KubernetesDockerRunner.lambda$ensureSecrets$0(KubernetesDockerRunner.java:263)
   at java.base/java.util.Optional.map(Optional.java:265)
   at com.spotify.styx.docker.KubernetesDockerRunner.ensureSecrets(KubernetesDockerRunner.java:261)
   at com.spotify.styx.docker.KubernetesDockerRunner.start(KubernetesDockerRunner.java:217)
   at com.spotify.styx.docker.RoutingDockerRunner.start(RoutingDockerRunner.java:42)
   at jdk.internal.reflect.GeneratedMethodAccessor116.invoke(Unknown Source)
   at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   at java.base/java.lang.reflect.Method.invoke(Method.java:566)
   at com.spotify.styx.monitoring.TracingProxy.invoke(TracingProxy.java:67)
   at com.sun.proxy.$Proxy61.start(Unknown Source)
   at jdk.internal.reflect.GeneratedMethodAccessor116.invoke(Unknown Source)
   at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   at java.base/java.lang.reflect.Method.invoke(Method.java:566)
   at com.spotify.styx.monitoring.MeteredProxy.lambda$invoke$0(MeteredProxy.java:63)
   at javaslang.control.Try.of(Try.java:39)
   at com.spotify.styx.monitoring.MeteredProxy.invoke(MeteredProxy.java:61)
   at com.sun.proxy.$Proxy61.start(Unknown Source)
   at com.spotify.styx.state.handlers.DockerRunnerHandler.safeTransitionInto(DockerRunnerHandler.java:65)
   at com.spotify.styx.state.handlers.AbstractRunnerHandler.transitionInto(AbstractRunnerHandler.java:71)
   at jdk.internal.reflect.GeneratedMethodAccessor92.invoke(Unknown Source)
   at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   at java.base/java.lang.reflect.Method.invoke(Method.java:566)
   at com.spotify.styx.monitoring.TracingProxy.invoke(TracingProxy.java:67)
   at com.sun.proxy.$Proxy62.transitionInto(Unknown Source)
   at com.spotify.styx.state.OutputHandler.lambda$fanOutput$0(OutputHandler.java:51)
   at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
   at com.spotify.styx.state.OutputHandler.lambda$fanOutput$1(OutputHandler.java:50)
   at com.spotify.styx.state.MDCDecoratingHandler.transitionInto(MDCDecoratingHandler.java:49)
   at com.spotify.styx.state.PersistentStateManager.postTransition(PersistentStateManager.java:356)
   at com.spotify.styx.state.PersistentStateManager.receive(PersistentStateManager.java:214)
   at com.spotify.styx.state.handlers.ExecutionDescriptionHandler.transitionInto(ExecutionDescriptionHandler.java:92)
   at jdk.internal.reflect.GeneratedMethodAccessor92.invoke(Unknown Source)
   at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   at java.base/java.lang.reflect.Method.invoke(Method.java:566)
   at com.spotify.styx.monitoring.TracingProxy.invoke(TracingProxy.java:67)
   at com.sun.proxy.$Proxy62.transitionInto(Unknown Source)
   at com.spotify.styx.state.OutputHandler.lambda$fanOutput$0(OutputHandler.java:51)
   at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
   at com.spotify.styx.state.OutputHandler.lambda$fanOutput$1(OutputHandler.java:50)
   at com.spotify.styx.state.MDCDecoratingHandler.transitionInto(MDCDecoratingHandler.java:49)
   at com.spotify.styx.state.PersistentStateManager.postTransition(PersistentStateManager.java:356)
   at com.spotify.styx.state.PersistentStateManager.receive(PersistentStateManager.java:214)
   at com.spotify.styx.state.
EventRouter.receiveIgnoreClosed(EventRouter.java:72)
   at jdk.internal.reflect.GeneratedMethodAccessor90.invoke(Unknown Source)
   at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   at java.base/java.lang.reflect.Method.invoke(Method.java:566)
   at com.spotify.styx.monitoring.TracingProxy.invoke(TracingProxy.java:67)
   at com.sun.proxy.$Proxy65.receiveIgnoreClosed(Unknown Source)
   at com.spotify.styx.Scheduler.sendDequeue(Scheduler.java:419)
   at com.spotify.styx.Scheduler.processInstance(Scheduler.java:319)
   at com.spotify.styx.Scheduler.lambda$processInstances$3(Scheduler.java:226)
   at io.opencensus.trace.CurrentSpanUtils$RunnableInSpan.run(CurrentSpanUtils.java:121)
   at io.opencensus.trace.SpanBuilder.startSpanAndRun(SpanBuilder.java:282)
   at com.spotify.styx.Scheduler.lambda$processInstances$4(Scheduler.java:224)
   at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1736)
   at io.grpc.Context$1.run(Context.java:579)
   at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
   at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
   at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
   at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
   at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
   at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
   Caused by: java.util.concurrent.ExecutionException: com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request
```

## Have you tested this? If so, how?
I have included unit tests.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
