### PR TITLE
Reducing log sizes for INFO logs

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -223,7 +223,8 @@ class KubernetesDockerRunner implements DockerRunner {
       LOG.info("Creating pod: {}: {}", workflowInstance, pod);
       var createdPod = client.createPod(pod);
       stats.recordSubmission(runSpec.executionId());
-      LOG.info("Created pod: {}: {}", workflowInstance, createdPod);
+      LOG.info("Created pod: {}", workflowInstance);
+      LOG.debug("Pod details: {}", createdPod);
     } catch (KubernetesClientException kce) {
       if (kce.getCode() == 409 && kce.getStatus().getReason().equals("AlreadyExists")) {
         LOG.info("Pod already existed when creating: {}: {}", workflowInstance, runSpec.executionId());

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/DockerRunnerHandler.java
@@ -61,7 +61,7 @@ public class DockerRunnerHandler extends AbstractRunnerHandler {
 
         final String runnerId;
         try {
-          LOG.info("running:{}, spec:{}, state:{}", state.workflowInstance(), runSpec, state);
+          LOG.info("running: {}, spec: {}, state: {}", state.workflowInstance(), runSpec, state);
           runnerId = dockerRunner.start(state, runSpec);
         } catch (Throwable e) {
           try {


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Some of our Log Info lines are too big so this PR splits unnecessary big lines into Log.Info and Log.Debug. Also improved formatting

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Creating massive log lines that are impacting disk writing.
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
