### PR TITLE
Increase upper bound

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/StyxApi.java
@@ -84,7 +84,9 @@ public class StyxApi implements AppInit {
   private static final String DEFAULT_SCHEDULER_SERVICE_BASE_URL = "http://localhost:8080";
 
   private static final String STYX_RUNNING_STATE_TTL_CONFIG = "styx.stale-state-ttls.running";
+
   private static final Duration DEFAULT_STYX_RUNNING_STATE_TTL = Duration.ofHours(24);
+  private static final Duration MAX_STYX_RUNNING_STATE_TTL = Duration.ofHours(30);
 
   private final String serviceName;
   private final StorageFactory storageFactory;
@@ -203,7 +205,7 @@ public class StyxApi implements AppInit {
         new WorkflowActionAuthorizer(storage, serviceAccountUsageAuthorizer, actionAuthorizer);
 
     var workflowValidator = new ExtendedWorkflowValidator(
-        new BasicWorkflowValidator(new DockerImageValidator()), runningStateTtl);
+        new BasicWorkflowValidator(new DockerImageValidator()), MAX_STYX_RUNNING_STATE_TTL);
 
     final WorkflowResource workflowResource = new WorkflowResource(storage, workflowValidator,
         new WorkflowInitializer(storage, time), workflowConsumer, workflowActionAuthorizer, time);


### PR DESCRIPTION
# Hey, I just made a Pull Request!

We have users that want more than 24h due to an ML pipeline running for a long time that doesn't make sense to split.
Ideally this should be made configurable, but we can separate the upper bound from the max value.

## Description
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
