### PR TITLE
add test and fix for explicitly positive offsets

### DIFF
--- a/styx-common/src/main/java/com/spotify/styx/util/TimeUtil.java
+++ b/styx-common/src/main/java/com/spotify/styx/util/TimeUtil.java
@@ -235,6 +235,8 @@ public class TimeUtil {
     // Change sign of offset string and add
     if (offset.startsWith("-")) {
       return addOffset(time, offset.substring(1));
+    } else if (offset.startsWith("+")) {
+      return addOffset(time, "-" + offset.substring(1));
     } else {
       return addOffset(time, "-" + offset);
     }

--- a/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
+++ b/styx-common/src/test/java/com/spotify/styx/util/TimeUtilTest.java
@@ -29,11 +29,11 @@ import static com.spotify.styx.util.TimeUtil.nextInstant;
 import static com.spotify.styx.util.TimeUtil.offsetInstant;
 import static com.spotify.styx.util.TimeUtil.subtractOffset;
 import static java.time.Instant.parse;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.spotify.styx.model.Schedule;
@@ -215,6 +215,24 @@ public class TimeUtilTest {
     String offset = "-PT1H7M5S";
     ZonedDateTime time = ZonedDateTime.parse("2017-01-22T09:14:16.22Z");
     ZonedDateTime offsetTime = addOffset(time, offset);
+
+    assertThat(offsetTime, is(ZonedDateTime.parse("2017-01-22T08:07:11.22Z")));
+  }
+
+  @Test
+  public void shouldSubtractPositiveOffset() {
+    String offset = "P1M3DT1H7M5S";
+    ZonedDateTime time = ZonedDateTime.parse("2017-02-25T09:14:16.22Z");
+    ZonedDateTime offsetTime = subtractOffset(time, offset);
+
+    assertThat(offsetTime, is(ZonedDateTime.parse("2017-01-22T08:07:11.22Z")));
+  }
+
+  @Test
+  public void shouldSubtractExplicitlyPositiveOffset() {
+    String offset = "+P1M3DT1H7M5S";
+    ZonedDateTime time = ZonedDateTime.parse("2017-02-25T09:14:16.22Z");
+    ZonedDateTime offsetTime = subtractOffset(time, offset);
 
     assertThat(offsetTime, is(ZonedDateTime.parse("2017-01-22T08:07:11.22Z")));
   }


### PR DESCRIPTION
## Description
Fixes a bug where `subtractOffset` would not work with periods starting with a plus (`+`) sign.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
