### PR TITLE
Add endpoint with enabled state

### DIFF
--- a/doc/api.apib
+++ b/doc/api.apib
@@ -72,6 +72,47 @@ Resources related to the Workflows registered in Styx.
               }
         }]
 
+
+## Workflows [/{version}/workflows/full]
+
++ Parameters
+    + version: `v3` (enum[string]) - API version
+        + Members
+            + `v3`
+
+### Get Workflows with State [GET]
+
++ Response 200 (application/json)
+
+        [{
+            "workflow": {
+                "component_id": "styx-canary",
+                "workflow_id": "StyxCanary",
+                "component_uri": "file:///etc/styx/schedule.yaml",
+                "configuration": {
+                    "id": "StyxCanary",
+                    "schedule": "hours",
+                    "offset": null,
+                    "docker_image": null,
+                    "docker_args": [
+                      "luigi",
+                      "--module",
+                      "canary_job",
+                      "CanaryJob"
+                    ],
+                    "docker_termination_logging": false,
+                    "env": {"FOO": "bar"},
+                    "resources": [],
+                    "running_timeout": "PT2H"
+                  }
+            },
+            "state": {
+                "enabled": "true",
+                "next_natural_trigger": "2017-01-01T01:00:00Z",
+                "next_natural_offset_trigger": "2017-01-01T02:00:00Z"
+            }
+        }]
+
 ## Workflows [/{version}/workflows/{component_id}]
 
 + Parameters

--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -104,10 +104,10 @@ public final class WorkflowResource {
             json(), "GET", BASE + "/<cid>/<wfid>",
             rc -> workflow(arg("cid", rc), arg("wfid", rc))),
         Route.with(
-            json(), "GET", BASE + "/<cid>/<wfid>/full",
+            json(), "GET", BASE + "/<cid>/<wfid>/state",
             rc -> workflowWithState(arg("cid", rc), arg("wfid", rc))),
         Route.with(
-                json(), "GET", BASE + "/full",
+                json(), "GET", BASE + "/state",
                 rc -> workflowsWithState(rc.request())),
         Route.with(
             json(), "GET", BASE,

--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -108,7 +108,7 @@ public final class WorkflowResource {
             rc -> workflowWithState(arg("cid", rc), arg("wfid", rc))),
         Route.with(
                 json(), "GET", BASE + "/state",
-                rc -> workflowsWithState(rc.request())),
+                rc -> workflowsWithState()),
         Route.with(
             json(), "GET", BASE,
             rc -> workflows(rc.request())),
@@ -219,17 +219,10 @@ public final class WorkflowResource {
     return WorkflowConfigurationBuilder.from(workflowConfig).deploymentTime(time.get()).build();
   }
 
-  private Response<Collection<WorkflowWithState>> workflowsWithState(Request request) {
+  private Response<Collection<WorkflowWithState>> workflowsWithState() {
     try {
-      var paramFilters = Stream.of(QueryParams.values())
-              .map(e -> getFilterParams(request, e).map(param -> Map.entry(e, param)))
-              .flatMap(Optional::stream)
-              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
       Collection<WorkflowWithState> workflows = storage.workflowsWithState().values();
-
       return Response.forPayload(workflows);
-
     } catch (IOException e) {
       throw new RuntimeException("Failed to get workflows", e);
     }

--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -104,7 +104,7 @@ public final class WorkflowResource {
             json(), "GET", BASE + "/<cid>/<wfid>",
             rc -> workflow(arg("cid", rc), arg("wfid", rc))),
         Route.with(
-            json(), "GET", BASE + "/<cid>/<wfid>/state",
+            json(), "GET", BASE + "/<cid>/<wfid>/full",
             rc -> workflowWithState(arg("cid", rc), arg("wfid", rc))),
         Route.with(
                 json(), "GET", BASE + "/state",

--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -107,6 +107,9 @@ public final class WorkflowResource {
             json(), "GET", BASE + "/<cid>/<wfid>/full",
             rc -> workflowWithState(arg("cid", rc), arg("wfid", rc))),
         Route.with(
+                json(), "GET", BASE + "/full",
+                rc -> workflowsWithState(rc.request())),
+        Route.with(
             json(), "GET", BASE,
             rc -> workflows(rc.request())),
         Route.with(
@@ -214,6 +217,22 @@ public final class WorkflowResource {
     WorkflowConfiguration workflowConfig = OBJECT_MAPPER
         .readValue(payload.toByteArray(), WorkflowConfiguration.class);
     return WorkflowConfigurationBuilder.from(workflowConfig).deploymentTime(time.get()).build();
+  }
+
+  private Response<Collection<WorkflowWithState>> workflowsWithState(Request request) {
+    try {
+      var paramFilters = Stream.of(QueryParams.values())
+              .map(e -> getFilterParams(request, e).map(param -> Map.entry(e, param)))
+              .flatMap(Optional::stream)
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+      Collection<WorkflowWithState> workflows = storage.workflowsWithState().values();
+
+      return Response.forPayload(workflows);
+
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to get workflows", e);
+    }
   }
 
   private Response<Collection<Workflow>> workflows(Request request) {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/WorkflowResource.java
@@ -107,7 +107,7 @@ public final class WorkflowResource {
             json(), "GET", BASE + "/<cid>/<wfid>/full",
             rc -> workflowWithState(arg("cid", rc), arg("wfid", rc))),
         Route.with(
-                json(), "GET", BASE + "/state",
+                json(), "GET", BASE + "/full",
                 rc -> workflowsWithState()),
         Route.with(
             json(), "GET", BASE,

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -830,7 +830,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
     sinceVersion(Api.Version.V3);
 
     Response<ByteString> response = awaitResponse(
-            serviceHelper.request("GET", path("/full")));
+            serviceHelper.request("GET", path("/state")));
 
     var parsedResponse = Arrays.asList(deserialize(response.payload().orElseThrow(),  WorkflowWithState[].class));
     var expectedWF1 = WorkflowWithState.create(FLYTE_EXEC_WORKFLOW, WorkflowState.builder().enabled(false).build());
@@ -1097,7 +1097,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     storage.storeWorkflow(Workflow.create("other_component", WORKFLOW_CONFIGURATION));
 
-    var response = awaitResponse(serviceHelper.request("GET", path("/foo/bar/full")));
+    var response = awaitResponse(serviceHelper.request("GET", path("/foo/bar/state")));
 
     assertThat(response, hasStatus(withCode(Status.OK)));
     assertJson(response, "workflow.component_id", is("foo"));
@@ -1108,7 +1108,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
   public void shouldReturn404WhenWorkflowWithStateNotFound() throws Exception {
     sinceVersion(Api.Version.V3);
 
-    var response = awaitResponse(serviceHelper.request("GET", path("/example/workflow/full")));
+    var response = awaitResponse(serviceHelper.request("GET", path("/example/workflow/state")));
 
     assertThat(response, hasStatus(withCode(Status.NOT_FOUND)));
   }
@@ -1120,7 +1120,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
     when(storage.workflowWithState(WorkflowId.create("foo", "bar"))).thenThrow(new IOException());
 
     Response<ByteString> response = awaitResponse(
-        serviceHelper.request("GET", path("/foo/bar/full")));
+        serviceHelper.request("GET", path("/foo/bar/state")));
 
     assertThat(response, hasStatus(withCode(Status.INTERNAL_SERVER_ERROR)));
   }

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -1097,7 +1097,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     storage.storeWorkflow(Workflow.create("other_component", WORKFLOW_CONFIGURATION));
 
-    var response = awaitResponse(serviceHelper.request("GET", path("/foo/bar/state")));
+    var response = awaitResponse(serviceHelper.request("GET", path("/foo/bar/full")));
 
     assertThat(response, hasStatus(withCode(Status.OK)));
     assertJson(response, "workflow.component_id", is("foo"));

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -40,6 +40,7 @@ import static com.spotify.styx.testdata.TestData.QUERY_THRESHOLD_AFTER;
 import static com.spotify.styx.testdata.TestData.QUERY_THRESHOLD_BEFORE;
 import static com.spotify.styx.testdata.TestData.TEST_DEPLOYMENT_TIME;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -74,6 +75,7 @@ import com.spotify.styx.model.WorkflowConfigurationBuilder;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
 import com.spotify.styx.model.WorkflowState;
+import com.spotify.styx.model.WorkflowWithState;
 import com.spotify.styx.state.Trigger;
 import com.spotify.styx.storage.AggregateStorage;
 import com.spotify.styx.storage.BigtableMocker;
@@ -87,6 +89,7 @@ import com.spotify.styx.util.WorkflowValidator;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -820,6 +823,27 @@ public class WorkflowResourceTest extends VersionedApiTest {
 
     assertThat(response, hasStatus(withCode(Status.OK)));
     assertJson(response, "[*]", hasSize(2));
+  }
+
+  @Test
+  public void shouldReturnWorkflowsWithState() throws Exception {
+    sinceVersion(Api.Version.V3);
+
+    Response<ByteString> response = awaitResponse(
+            serviceHelper.request("GET", path("/full")));
+
+    var parsedResponse = Arrays.asList(deserialize(response.payload().orElseThrow(),  WorkflowWithState[].class));
+    var expectedWF1 = WorkflowWithState.create(FLYTE_EXEC_WORKFLOW, WorkflowState.builder().enabled(false).build());
+    var expectedWF2 = WorkflowWithState.create(WORKFLOW, WorkflowState.builder().enabled(false).build());
+
+    assertThat(response, hasStatus(withCode(Status.OK)));
+    assertJson(response, "[*]", hasSize(2));
+    assertThat(parsedResponse,
+            containsInAnyOrder(
+                    expectedWF1,
+                    expectedWF2
+            )
+    );
   }
 
   @Test

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -1108,7 +1108,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
   public void shouldReturn404WhenWorkflowWithStateNotFound() throws Exception {
     sinceVersion(Api.Version.V3);
 
-    var response = awaitResponse(serviceHelper.request("GET", path("/example/workflow/state")));
+    var response = awaitResponse(serviceHelper.request("GET", path("/example/workflow/full")));
 
     assertThat(response, hasStatus(withCode(Status.NOT_FOUND)));
   }
@@ -1120,7 +1120,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
     when(storage.workflowWithState(WorkflowId.create("foo", "bar"))).thenThrow(new IOException());
 
     Response<ByteString> response = awaitResponse(
-        serviceHelper.request("GET", path("/foo/bar/state")));
+        serviceHelper.request("GET", path("/foo/bar/full")));
 
     assertThat(response, hasStatus(withCode(Status.INTERNAL_SERVER_ERROR)));
   }

--- a/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/WorkflowResourceTest.java
@@ -830,7 +830,7 @@ public class WorkflowResourceTest extends VersionedApiTest {
     sinceVersion(Api.Version.V3);
 
     Response<ByteString> response = awaitResponse(
-            serviceHelper.request("GET", path("/state")));
+            serviceHelper.request("GET", path("/full")));
 
     var parsedResponse = Arrays.asList(deserialize(response.payload().orElseThrow(),  WorkflowWithState[].class));
     var expectedWF1 = WorkflowWithState.create(FLYTE_EXEC_WORKFLOW, WorkflowState.builder().enabled(false).build());

--- a/styx-client/src/test/java/com/spotify/styx/client/StyxOkHttpClientTest.java
+++ b/styx-client/src/test/java/com/spotify/styx/client/StyxOkHttpClientTest.java
@@ -405,7 +405,7 @@ public class StyxOkHttpClientTest {
     verify(client, timeout(30_000)).send(requestCaptor.capture());
     assertThat(r.isDone(), is(true));
     var request = requestCaptor.getValue();
-    var uri = URI.create(API_URL + "/workflows/component/workflow/full");
+    var uri = URI.create(API_URL + "/workflows/component/workflow/state");
     assertThat(request.url().toString(), is(uri.toString()));
     assertThat(request.method(), is("GET"));
     assertThat(r.join(), is(workflowWithState));

--- a/styx-client/src/test/java/com/spotify/styx/client/StyxOkHttpClientTest.java
+++ b/styx-client/src/test/java/com/spotify/styx/client/StyxOkHttpClientTest.java
@@ -405,7 +405,7 @@ public class StyxOkHttpClientTest {
     verify(client, timeout(30_000)).send(requestCaptor.capture());
     assertThat(r.isDone(), is(true));
     var request = requestCaptor.getValue();
-    var uri = URI.create(API_URL + "/workflows/component/workflow/state");
+    var uri = URI.create(API_URL + "/workflows/component/workflow/full");
     assertThat(request.url().toString(), is(uri.toString()));
     assertThat(request.method(), is("GET"));
     assertThat(r.join(), is(workflowWithState));

--- a/styx-service-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/AggregateStorage.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.HashMap;
 import org.apache.hadoop.hbase.client.Connection;
 
 /**
@@ -194,6 +195,11 @@ public class AggregateStorage implements Storage {
   @Override
   public Map<WorkflowId, Workflow> workflows() throws IOException {
     return datastoreStorage.workflows();
+  }
+
+  @Override
+  public HashMap<WorkflowId, WorkflowWithState> workflowsWithState() throws IOException {
+    return datastoreStorage.workflowsWithState();
   }
 
   @Override

--- a/styx-service-common/src/main/java/com/spotify/styx/storage/Storage.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/storage/Storage.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.HashMap;
 
 /**
  * The interface to the persistence layer.
@@ -128,6 +129,13 @@ public interface Storage extends Closeable {
    * Get all {@link Workflow}s.
    */
   Map<WorkflowId, Workflow> workflows() throws IOException;
+
+
+  /**
+   * Get all {@link WorkflowWithState}s.
+   * @return
+   */
+  HashMap<WorkflowId, WorkflowWithState> workflowsWithState() throws IOException;
 
   /** Get all {@link Workflow}s by doing strongly consistent batch fetch.
    * 

--- a/styx-service-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -84,6 +84,7 @@ import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StringValue;
 import com.google.common.collect.ImmutableSet;
 import com.spotify.styx.model.Backfill;
+import com.spotify.styx.model.WorkflowWithState;
 import com.spotify.styx.model.BackfillBuilder;
 import com.spotify.styx.model.ExecutionDescription;
 import com.spotify.styx.model.Resource;
@@ -554,6 +555,39 @@ public class DatastoreStorageTest {
     WorkflowState retrieved = storage.workflowState(WORKFLOW.id());
 
     assertThat(retrieved, is(state));
+  }
+
+  @Test
+  public void shouldReturnWorkflowsWithState() throws Exception {
+    assertThat(storage.workflowsWithState().isEmpty(), is(true));
+
+    Workflow workflow1 = workflow(WORKFLOW_ID1);
+    Workflow workflow2 = workflow(WORKFLOW_ID2);
+    Workflow workflow3 = workflow(WORKFLOW_ID3);
+
+    storage.store(workflow1);
+    storage.store(workflow2);
+    storage.store(workflow3);
+
+    var instant = Instant.parse("2016-03-14T14:00:00Z");
+    var state_workflow_id1 = WorkflowState.builder()
+            .enabled(true)
+            .nextNaturalTrigger(instant)
+            .nextNaturalOffsetTrigger(instant.plus(1, ChronoUnit.DAYS))
+            .build();
+    var state_workflow_id2 = state_workflow_id1.toBuilder().enabled(false).build();
+    var state_workflow_id3 = state_workflow_id1.toBuilder().nextNaturalOffsetTrigger(instant.plus(2, ChronoUnit.DAYS)).build();
+
+    storage.patchState(WORKFLOW_ID1, state_workflow_id1);
+    storage.patchState(WORKFLOW_ID2, state_workflow_id2);
+    storage.patchState(WORKFLOW_ID3, state_workflow_id3);
+
+    var workflows = storage.workflowsWithState();
+    assertThat(workflows.size(), is(3));
+
+    assertThat(workflows, hasEntry(WORKFLOW_ID1, WorkflowWithState.create(workflow1, state_workflow_id1)));
+    assertThat(workflows, hasEntry(WORKFLOW_ID2, WorkflowWithState.create(workflow2, state_workflow_id2)));
+    assertThat(workflows, hasEntry(WORKFLOW_ID3, WorkflowWithState.create(workflow3, state_workflow_id3)));
   }
 
   @Test

--- a/styx-service-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/storage/DatastoreStorageTest.java
@@ -570,24 +570,24 @@ public class DatastoreStorageTest {
     storage.store(workflow3);
 
     var instant = Instant.parse("2016-03-14T14:00:00Z");
-    var state_workflow_id1 = WorkflowState.builder()
+    var stateWorkflow1 = WorkflowState.builder()
             .enabled(true)
             .nextNaturalTrigger(instant)
             .nextNaturalOffsetTrigger(instant.plus(1, ChronoUnit.DAYS))
             .build();
-    var state_workflow_id2 = state_workflow_id1.toBuilder().enabled(false).build();
-    var state_workflow_id3 = state_workflow_id1.toBuilder().nextNaturalOffsetTrigger(instant.plus(2, ChronoUnit.DAYS)).build();
+    var stateWorkflow2 = stateWorkflow1.toBuilder().enabled(false).build();
+    var stateWorkflow3 = stateWorkflow1.toBuilder().nextNaturalOffsetTrigger(instant.plus(2, ChronoUnit.DAYS)).build();
 
-    storage.patchState(WORKFLOW_ID1, state_workflow_id1);
-    storage.patchState(WORKFLOW_ID2, state_workflow_id2);
-    storage.patchState(WORKFLOW_ID3, state_workflow_id3);
+    storage.patchState(WORKFLOW_ID1, stateWorkflow1);
+    storage.patchState(WORKFLOW_ID2, stateWorkflow2);
+    storage.patchState(WORKFLOW_ID3, stateWorkflow3);
 
     var workflows = storage.workflowsWithState();
     assertThat(workflows.size(), is(3));
 
-    assertThat(workflows, hasEntry(WORKFLOW_ID1, WorkflowWithState.create(workflow1, state_workflow_id1)));
-    assertThat(workflows, hasEntry(WORKFLOW_ID2, WorkflowWithState.create(workflow2, state_workflow_id2)));
-    assertThat(workflows, hasEntry(WORKFLOW_ID3, WorkflowWithState.create(workflow3, state_workflow_id3)));
+    assertThat(workflows, hasEntry(WORKFLOW_ID1, WorkflowWithState.create(workflow1, stateWorkflow1)));
+    assertThat(workflows, hasEntry(WORKFLOW_ID2, WorkflowWithState.create(workflow2, stateWorkflow2)));
+    assertThat(workflows, hasEntry(WORKFLOW_ID3, WorkflowWithState.create(workflow3, stateWorkflow3)));
   }
 
   @Test


### PR DESCRIPTION
# Hey, I just made a Pull Request!


## Description
<!--- Describe your changes -->

There is no endpoint for quickly getting all workflows enabled state. This PR adds it.

## Motivation and Context

Currently you need to make one request per workflow which takes a long time. Since we are making some changes internally it would be good to store this information to be able to recover it.

## Have you tested this? If so, how?
I have included unit tests

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [x] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [x] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
