### PR TITLE
Handle error state

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/AbstractRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/AbstractRunnerHandler.java
@@ -70,7 +70,7 @@ abstract class AbstractRunnerHandler implements OutputHandler {
         }
         safeTransitionInto(state, eventRouter);
         break;
-
+      case ERROR:
       case FAILED:
         if (maybeExecutionId.isEmpty()
             || maybeExecutionDescription.isEmpty()

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/FlyteRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/FlyteRunnerHandler.java
@@ -53,7 +53,7 @@ public class FlyteRunnerHandler extends AbstractRunnerHandler {
     if (!flyteRunner.isEnabled()) {
       var workflowInstance = state.workflowInstance();
       LOG.error("Unable to transition {} into {}. Flyte system is not available", workflowInstance, state.state());
-      // halt the execution if we have not; ERROR state is issued by halt event
+      // halt the execution if we have not; ERROR state is driven by halt event
       if (state.state() != RunState.State.ERROR) {
         eventRouter.receiveIgnoreClosed(Event.halt(workflowInstance), state.counter());
       }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/FlyteRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/FlyteRunnerHandler.java
@@ -53,7 +53,10 @@ public class FlyteRunnerHandler extends AbstractRunnerHandler {
     if (!flyteRunner.isEnabled()) {
       var workflowInstance = state.workflowInstance();
       LOG.error("Unable to transition {} into {}. Flyte system is not available", workflowInstance, state.state());
-      eventRouter.receiveIgnoreClosed(Event.halt(workflowInstance), state.counter());
+      // halt the execution if we have not; ERROR state is issued by halt event
+      if (state.state() != RunState.State.ERROR) {
+        eventRouter.receiveIgnoreClosed(Event.halt(workflowInstance), state.counter());
+      }
       return;
     }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/FlyteRunnerHandler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/state/handlers/FlyteRunnerHandler.java
@@ -65,6 +65,7 @@ public class FlyteRunnerHandler extends AbstractRunnerHandler {
       case RUNNING:
         pollingExecution(state);
         break;
+      case ERROR:
       case FAILED:
         cleanUpExecution(state);
         break;

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/AbstractRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/AbstractRunnerHandlerTest.java
@@ -128,7 +128,7 @@ public class AbstractRunnerHandlerTest {
   private static RunState.State[] relevantRunnerHandlerStates() {
     return Stream.concat(
         Arrays.stream(execRunnerHandlerStates()),
-        Stream.of(RunState.State.FAILED)
+        Stream.of(RunState.State.FAILED, RunState.State.ERROR)
     ).toArray(RunState.State[]::new);
   }
 
@@ -139,7 +139,6 @@ public class AbstractRunnerHandlerTest {
         RunState.State.QUEUED,
         RunState.State.PREPARE,
         RunState.State.TERMINATED,
-        RunState.State.ERROR,
         RunState.State.DONE
     };
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
@@ -138,6 +138,20 @@ public class FlyteRunnerHandlerTest {
     verify(eventRouter,  timeout(60_000)).receiveIgnoreClosed(Event.halt(WORKFLOW_INSTANCE), runState.counter());
   }
 
+  @Test
+  public void shouldNotHaltTransitionsWhenFlyteRunnerIsNotEnabledAndErrorState() throws Exception {
+    when(flyteRunner.isEnabled()).thenReturn(false);
+    RunState runState = RunState.create(WORKFLOW_INSTANCE, State.ERROR, StateData.newBuilder()
+        .executionId(EXECUTION_ID)
+        .executionDescription(FLYTE_EXECUTION_DESCRIPTION)
+        .build());
+
+    flyteRunnerHandler.transitionInto(runState, eventRouter);
+
+    verify(flyteRunner, never()).createExecution(any(), any(), any());
+    verifyNoInteractions(eventRouter);
+  }
+
 
   @Test()
   @Parameters({"SUBMITTING", "SUBMITTED", "RUNNING"})

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/state/handlers/FlyteRunnerHandlerTest.java
@@ -177,8 +177,9 @@ public class FlyteRunnerHandlerTest {
   }
 
   @Test
-  public void shouldTerminateExecutionsOnFailedState() {
-    RunState runState = RunState.create(WORKFLOW_INSTANCE, State.FAILED, StateData.newBuilder()
+  @Parameters({"FAILED", "ERROR"})
+  public void shouldTerminateExecutionsOnFailedandErrorState(State state) {
+    RunState runState = RunState.create(WORKFLOW_INSTANCE, state, StateData.newBuilder()
         .executionId(EXECUTION_ID)
         .executionDescription(FLYTE_EXECUTION_DESCRIPTION)
         .build());


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Handle `ERROR` state in `FlyteRunnerHandler`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`ERROR` state is driven by `halt` event, and when that happens, we should terminate the execution in Flyte.

We are not doing the same treatment to `DockerRunnerHandler` because halting we have a dedicated thread reaping pods, see https://github.com/spotify/styx/blob/efaf212940316987380a4f2b5813a1687b9942fa/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java#L537 and https://github.com/spotify/styx/blob/efaf212940316987380a4f2b5813a1687b9942fa/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java#L449

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
