### PR TITLE
Override arch to work around compiling on Apple silicon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
   <version>2.1.167-SNAPSHOT</version>
 
   <properties>
+    <!-- FIXME: temporarily hard code arch to work around compiling on Apple silicon -->
+    <os.detected.arch>x86_64</os.detected.arch>
     <maven.compiler.version>3.8.0</maven.compiler.version>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.source>11</maven.compiler.source>

--- a/styx-flyte-client/pom.xml
+++ b/styx-flyte-client/pom.xml
@@ -66,12 +66,14 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.6.1</version>
         <configuration>
+          <!-- FIXME: temporarily separate name from arch to work around compiling on Apple silicon -->
           <protocArtifact>
-            com.google.protobuf:protoc:3.11.0:exe:${os.detected.classifier}
+            com.google.protobuf:protoc:3.11.0:exe:${os.detected.name}-${os.detected.arch}
           </protocArtifact>
           <pluginId>grpc-java</pluginId>
+          <!-- FIXME: temporarily separate name from arch to work around compiling on Apple silicon -->
           <pluginArtifact>
-            io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
+            io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.name}-${os.detected.arch}
           </pluginArtifact>
           <checkStaleness>true</checkStaleness>
         </configuration>


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Override arch to work around compiling on Apple silicon

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The gRPC and protobuf deps we are using now are not compatible with Apple silicon, and upgrading those is not trivial (see https://github.com/spotify/styx/pull/1061). This introduce a workaround so that we can compile on Apple silicon.

Reference: https://github.com/trustin/os-maven-plugin#generated-properties

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
