### PR TITLE
Update registry

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/docker/KubernetesDockerRunner.java
@@ -334,7 +334,7 @@ class KubernetesDockerRunner implements DockerRunner {
     return new ContainerBuilder()
         .withName(KEEPALIVE_CONTAINER_NAME)
         // Use the k8s pause container image. It sleeps forever until terminated.
-        .withImage("k8s.gcr.io/pause:3.1")
+        .withImage("registry.k8s.io/pause:3.1")
         .withNewResources()
         .withLimits(Map.of(
           "cpu", new QuantityBuilder()


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Email from Google 
```
We’re writing to let you know about the recent redirection of the Kubernetes Legacy k8s.gcr.io community image registry to registry.k8s.io. The redirect took place on March 22, 2023, with the eventual goal of sunsetting k8s.gcr.io.

What do you need to know?
As Kubernetes (k8s) has grown, the need for a community-owned and managed registry has also grown. k8s.gcr.io has been providing this role, but to ensure uninterrupted service for your workloads and meet the needs of a larger community, we will gradually roll out an HTTP redirect from [k8s.gcr.io](https://notifications.google.com/g/p/APHC3cp0pB_nwdmm2ZPHvsxOq-PCiq53TFr1_WeX_ygxpDcUZaCw9gxptsvJmh_Rj_34qK8yNM5x_CD0EcJSqFC1XcVIfxvA7p3zNbVXLKBDxh6VWRUU5StSrRhRSfjlIIdTCYuZueCfLGFjrZqSsyrOF03wy_jq_2lYMKy3XfWNXkw) to [registry.k8s.io](https://notifications.google.com/g/p/APHC3crwABFJRSO3IfZZuCZTSvnQ_cZA2VvsZQ73mWp_hYFg15e3tXYOMm2spzhOUNu-HqKul8WE6P_BdAzbMJ2tIPXOrNqNAOv8vj1IwE8xoP__9DCDf0FrLuwTTcqDBUc34uRg-aoWdagyYUWt-I1ac9OGTD_9yQRqROUTf2WSNIwBwbD3ZA).

Replace k8s.gcr.io with registry.k8s.io in your workload resource definitions (pods, deployments, Helm charts, etc.) as a long-term solution. In the interim, if your network rules allow HTTP redirects, add a rule to allow registry.k8s.io.
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
