### PR TITLE
Set scheduler as host header

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
@@ -30,7 +30,6 @@ import com.spotify.apollo.Response;
 import com.spotify.apollo.route.AsyncHandler;
 import com.spotify.apollo.route.Route;
 
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;

--- a/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
@@ -31,6 +31,7 @@ import com.spotify.apollo.route.AsyncHandler;
 import com.spotify.apollo.route.Route;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
@@ -55,16 +56,8 @@ public class SchedulerProxyResource {
 
   public SchedulerProxyResource(String schedulerServiceBaseUrl, Client client) {
     this.schedulerServiceBaseUrl = Objects.requireNonNull(schedulerServiceBaseUrl);
-    this.schedulerHost = getHost(schedulerServiceBaseUrl);
+    this.schedulerHost = URI.create(schedulerServiceBaseUrl).getHost();
     this.client = Objects.requireNonNull(client, "client");
-  }
-
-  private String getHost(String schedulerServiceBaseUrl) {
-    try {
-      return new URL(schedulerServiceBaseUrl).getHost();
-    } catch (MalformedURLException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   public Stream<Route<AsyncHandler<Response<ByteString>>>> routes() {

--- a/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
@@ -32,7 +32,6 @@ import com.spotify.apollo.route.Route;
 
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;

--- a/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
@@ -95,11 +95,7 @@ public class SchedulerProxyResource {
             .newBuilder();
     ImmutableSortedMap.copyOf(rc.request().parameters()).forEach((name, values) ->
         values.forEach(value -> builder.addQueryParameter(name, value)));
-    return client.send(withHost(withRequestId(rc.request().withUri(builder.build().toString()))));
-  }
-
-  private Request withHost(Request request) {
-    return request.withHeader("Host", schedulerHost);
+    return client.send(withRequestId(rc.request().withUri(builder.build().toString())).withHeader("Host", schedulerHost));
   }
 
   private Request withRequestId(Request request) {

--- a/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
@@ -138,4 +138,21 @@ public class SchedulerProxyResourceTest extends VersionedApiTest {
 
     assertThat(schedulerRequest.header("X-Request-Id"), is(Optional.of(requestId)));
   }
+
+  @Test
+  public void verifyReplaceHost() throws Exception {
+    sinceVersion(Api.Version.V3);
+
+    serviceHelper.stubClient()
+            .respond(Response.forStatus(Status.ACCEPTED))
+            .to(SCHEDULER_BASE + "/api/v0/trigger");
+
+    awaitResponse(serviceHelper.request(Request
+            .forUri(path("/trigger"), "POST")
+            .withHeader("Host", "styx-api")));
+
+    final Request schedulerRequest = Iterables.getOnlyElement(serviceHelper.stubClient().sentRequests());
+
+    assertThat(schedulerRequest.header("Host"), is("localhost"));
+  }
 }

--- a/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
@@ -153,6 +153,6 @@ public class SchedulerProxyResourceTest extends VersionedApiTest {
 
     final Request schedulerRequest = Iterables.getOnlyElement(serviceHelper.stubClient().sentRequests());
 
-    assertThat(schedulerRequest.header("Host"), is("localhost"));
+    assertThat(schedulerRequest.header("Host"), is(Optional.of("localhost")));
   }
 }

--- a/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
@@ -39,7 +39,10 @@ import org.slf4j.MDC;
 
 public class SchedulerProxyResourceTest extends VersionedApiTest {
 
-  private static final String SCHEDULER_BASE = "http://localhost:12345";
+  private static final String SCHEDULER_PROTOCOL = "http";
+  private static final String SCHEDULER_HOST = "localhost";
+  private static final String SCHEDULER_PORT = "12345";
+  private static final String SCHEDULER_BASE = String.format("%s://%s:%s",SCHEDULER_PROTOCOL, SCHEDULER_HOST, SCHEDULER_PORT);
 
   public SchedulerProxyResourceTest(Api.Version version) {
     super(SchedulerProxyResource.BASE, version);
@@ -153,6 +156,6 @@ public class SchedulerProxyResourceTest extends VersionedApiTest {
 
     final Request schedulerRequest = Iterables.getOnlyElement(serviceHelper.stubClient().sentRequests());
 
-    assertThat(schedulerRequest.header("Host"), is(Optional.of("localhost")));
+    assertThat(schedulerRequest.header("Host"), is(Optional.of(SCHEDULER_HOST)));
   }
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Currently the host header is just reused from the old request, while it should be the host of styx scheduler.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
