### PR TITLE
Close okhttp response

### DIFF
--- a/styx-client/src/main/java/com/spotify/styx/client/StyxOkHttpClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxOkHttpClient.java
@@ -216,7 +216,7 @@ class StyxOkHttpClient implements StyxClient {
   @Override
   public CompletionStage<Void> deleteWorkflow(String componentId, String workflowId) {
     return execute(forUri(urlBuilder("workflows", componentId, workflowId), "DELETE"))
-        .thenApply(response -> null);
+        .thenAccept(response -> Optional.ofNullable(response.body()).ifPresent(ResponseBody::close));
   }
 
   @Override
@@ -270,7 +270,7 @@ class StyxOkHttpClient implements StyxClient {
     return execute(
         forUri(urlBuilder("scheduler", "trigger")
             .addQueryParameter("allowFuture", String.valueOf(allowFuture)), "POST", triggerRequest))
-        .thenApply(response -> null);
+        .thenAccept(response -> Optional.ofNullable(response.body()).ifPresent(ResponseBody::close));
   }
 
   @Override
@@ -282,7 +282,7 @@ class StyxOkHttpClient implements StyxClient {
         WorkflowId.create(componentId, workflowId),
         parameter);
     return execute(forUri(url, "POST", workflowInstance))
-        .thenApply(response -> null);
+        .thenAccept(response -> Optional.ofNullable(response.body()).ifPresent(ResponseBody::close));
   }
 
   @Override
@@ -294,7 +294,7 @@ class StyxOkHttpClient implements StyxClient {
         WorkflowId.create(componentId, workflowId),
         parameter);
     return execute(forUri(url, "POST", workflowInstance))
-        .thenApply(response -> null);
+        .thenAccept(response -> Optional.ofNullable(response.body()).ifPresent(ResponseBody::close));
   }
 
   @Override
@@ -378,7 +378,8 @@ class StyxOkHttpClient implements StyxClient {
   public CompletionStage<Void> backfillHalt(String backfillId, boolean graceful) {
     var url = urlBuilder("backfills", backfillId);
     url.addQueryParameter("graceful", Boolean.toString(graceful));
-    return execute(forUri(url, "DELETE")).thenApply(response -> null);
+    return execute(forUri(url, "DELETE"))
+        .thenAccept(response -> Optional.ofNullable(response.body()).ifPresent(ResponseBody::close));
   }
 
   @Override


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Close okhttp response for requests we don't expect response body payload.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An OKHttp response must be closed (as explained [here](https://stackoverflow.com/questions/32080181/when-to-call-response-body-close)). For those requests we expect body payload, we read the body stream which results in `close` automatically, but for those we don't expect response body payload, currently we are not closing the response, which for some condition results in leaving threads hanging around. 

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Existing tests.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [x] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
