### PR TITLE
Record dangling terminated flyte executions

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/StyxScheduler.java
@@ -218,7 +218,7 @@ public class StyxScheduler implements AppInit {
 
   @FunctionalInterface
   interface FlyteRunnerFactory {
-    FlyteRunner create(String runnerId, Config config, StateManager stateManager, FlyteAdminClientInterceptors flyteAdminClientInterceptors);
+    FlyteRunner create(String runnerId, Config config, StateManager stateManager, FlyteAdminClientInterceptors flyteAdminClientInterceptors, Stats stats);
   }
 
   @FunctionalInterface
@@ -429,7 +429,7 @@ public class StyxScheduler implements AppInit {
         flyteAdminClientInterceptorsFactory.apply(environment);
     final Function<RunState, String> flyteRunnerId = RunnerId.flyteRunnerId(styxConfig);
     final FlyteRunner flyteRunner = FlyteRunner.routing(
-        id -> flyteRunnerFactory.create(id, environment.config(), stateManager, interceptors),
+        id -> flyteRunnerFactory.create(id, environment.config(), stateManager, interceptors, stats),
         flyteRunnerId
     );
 
@@ -690,13 +690,15 @@ public class StyxScheduler implements AppInit {
         ));
   }
 
-  static FlyteRunner createFlyteRunner(String runnerId, Config config, StateManager stateManager, FlyteAdminClientInterceptors flyteAdminClientInterceptors) {
+  static FlyteRunner createFlyteRunner(String runnerId, Config config, StateManager stateManager,
+                                       FlyteAdminClientInterceptors flyteAdminClientInterceptors,
+                                       Stats stats) {
     if (!config.getBoolean(FLYTE_ENABLED)) {
       return FlyteRunner.noop();
     }
 
     var flyteAdminClient = getFlyteAdminClient(config, runnerId, flyteAdminClientInterceptors);
-    return FlyteRunner.flyteAdmin(runnerId, flyteAdminClient, stateManager);
+    return FlyteRunner.flyteAdmin(runnerId, flyteAdminClient, stateManager, stats);
   }
 
   private static FlyteAdminClient getFlyteAdminClient(Config rootConfig, String runnerId, FlyteAdminClientInterceptors flyteAdminClientInterceptors) {

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -105,7 +105,7 @@ public class FlyteAdminClientRunner implements FlyteRunner {
   private final Duration terminateDanglingFlyteExecInterval;
   private final ScheduledExecutorService scheduledExecutor;
   private final Time time;
-  private Stats stats;
+  private final Stats stats;
   private final Closer closer = Closer.create();
   private final ExecutorService executor;
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -42,6 +42,7 @@ import com.spotify.styx.model.Event;
 import com.spotify.styx.model.FlyteExecConf;
 import com.spotify.styx.model.TriggerParameters;
 import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
@@ -104,6 +105,7 @@ public class FlyteAdminClientRunner implements FlyteRunner {
   private final Duration terminateDanglingFlyteExecInterval;
   private final ScheduledExecutorService scheduledExecutor;
   private final Time time;
+  private Stats stats;
   private final Closer closer = Closer.create();
   private final ExecutorService executor;
 
@@ -113,7 +115,8 @@ public class FlyteAdminClientRunner implements FlyteRunner {
                          final StateManager stateManager,
                          final Duration terminateDanglingFlyteExecInterval,
                          final ScheduledExecutorService scheduledExecutor,
-                         final Time time) {
+                         final Time time,
+                         Stats stats) {
     this.runnerId = requireNonNull(runnerId, "runnerId");
     this.flyteAdminClient = requireNonNull(flyteAdminClient, "flyteAdminClient");
     this.stateManager = requireNonNull(stateManager, "stateManager");
@@ -123,6 +126,7 @@ public class FlyteAdminClientRunner implements FlyteRunner {
         "flyte-scheduled-executor"
     );
     this.time = requireNonNull(time, "time");
+    this.stats = requireNonNull(stats, "stats");;
 
     checkArgument(
         terminateDanglingFlyteExecInterval.compareTo(Duration.ZERO) > 0,
@@ -134,11 +138,12 @@ public class FlyteAdminClientRunner implements FlyteRunner {
 
   FlyteAdminClientRunner(final String runnerId,
                          final FlyteAdminClient flyteAdminClient,
-                         final StateManager stateManager) {
+                         final StateManager stateManager,
+                         final Stats stats) {
     this(runnerId, flyteAdminClient, stateManager,
         DEFAULT_TERMINATE_EXEC_INTERVAL,
         Executors.newSingleThreadScheduledExecutor(THREAD_FACTORY),
-        Instant::now);
+        Instant::now, stats);
   }
 
   @Override
@@ -331,6 +336,7 @@ public class FlyteAdminClientRunner implements FlyteRunner {
                           || !isFlyteExecRelatedToRunState(annotatedId, runState.orElseThrow());
     if (shouldTerminate) {
       var id = annotatedId.identifier();
+      stats.recordDanglingTerminatedFlyteExecution();
       flyteAdminClient.terminateExecution(id.project(), id.domain(), id.name(), TERMINATE_CAUSE);
     }
   }

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -116,7 +116,7 @@ public class FlyteAdminClientRunner implements FlyteRunner {
                          final Duration terminateDanglingFlyteExecInterval,
                          final ScheduledExecutorService scheduledExecutor,
                          final Time time,
-                         Stats stats) {
+                         final Stats stats) {
     this.runnerId = requireNonNull(runnerId, "runnerId");
     this.flyteAdminClient = requireNonNull(flyteAdminClient, "flyteAdminClient");
     this.stateManager = requireNonNull(stateManager, "stateManager");

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteAdminClientRunner.java
@@ -336,8 +336,8 @@ public class FlyteAdminClientRunner implements FlyteRunner {
                           || !isFlyteExecRelatedToRunState(annotatedId, runState.orElseThrow());
     if (shouldTerminate) {
       var id = annotatedId.identifier();
-      stats.recordDanglingTerminatedFlyteExecution();
       flyteAdminClient.terminateExecution(id.project(), id.domain(), id.name(), TERMINATE_CAUSE);
+      stats.recordDanglingTerminatedFlyteExecution();      
     }
   }
 

--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteRunner.java
@@ -22,6 +22,7 @@ package com.spotify.styx.flyte;
 
 import com.spotify.styx.flyte.client.FlyteAdminClient;
 import com.spotify.styx.model.FlyteExecConf;
+import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateManager;
 import java.io.Closeable;
@@ -45,8 +46,9 @@ public interface FlyteRunner extends Closeable {
 
   static FlyteRunner flyteAdmin(final String runnerId,
                                 final FlyteAdminClient flyteAdminClient,
-                                final StateManager stateManager) {
-    final var runner = new FlyteAdminClientRunner(runnerId, flyteAdminClient, stateManager);
+                                final StateManager stateManager,
+                                final Stats stats) {
+    final var runner = new FlyteAdminClientRunner(runnerId, flyteAdminClient, stateManager, stats);
     runner.init();
     return runner;
   }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerServiceFixture.java
@@ -141,7 +141,7 @@ public class StyxSchedulerServiceFixture {
     StyxScheduler.DockerRunnerFactory dockerRunnerFactory =
         (id, env, states, stats, debug, podMutator, time) -> fakeDockerRunner();
     StyxScheduler.FlyteRunnerFactory flyteRunnerFactory =
-        (id, config, stateManager, interceptors) -> fakeFlyteRunner();
+        (id, config, stateManager, interceptors, stats) -> fakeFlyteRunner();
     WorkflowResourceDecorator resourceDecorator = (rs, cfg, res) ->
         Sets.union(res, resourceIdsToDecorateWith);
     StyxScheduler.EventConsumerFactory eventConsumerFactory =

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/StyxSchedulerTest.java
@@ -278,7 +278,7 @@ public class StyxSchedulerTest {
     var configMap = ImmutableMap.<String, String>builder()
         .put("styx.flyte.enabled", "false");
     var config = ConfigFactory.parseMap(configMap.build());
-    final FlyteRunner flyteRunner = StyxScheduler.createFlyteRunner("runnerId", config, stateManager, FlyteAdminClientInterceptors.NOOP);
+    final FlyteRunner flyteRunner = StyxScheduler.createFlyteRunner("runnerId", config, stateManager, FlyteAdminClientInterceptors.NOOP, stats);
 
     assertThat(flyteRunner, instanceOf(NoopFlyteRunner.class));
   }
@@ -295,7 +295,7 @@ public class StyxSchedulerTest {
 
     var config = ConfigFactory.parseMap(configMap.build());
     final FlyteRunner flyteRunner = StyxScheduler.createFlyteRunner("production", config, stateManager,
-        FlyteAdminClientInterceptors.NOOP);
+        FlyteAdminClientInterceptors.NOOP, stats);
 
     assertThat(flyteRunner.isEnabled(), is(true));
   }
@@ -311,7 +311,7 @@ public class StyxSchedulerTest {
 
     assertThrows(
         IllegalArgumentException.class,
-        () -> StyxScheduler.createFlyteRunner("staging", config, stateManager, FlyteAdminClientInterceptors.NOOP)
+        () -> StyxScheduler.createFlyteRunner("staging", config, stateManager, FlyteAdminClientInterceptors.NOOP, stats)
     );
   }
 }

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTerminateDanglingTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTerminateDanglingTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -42,6 +43,7 @@ import com.spotify.styx.QuietDeterministicScheduler;
 import com.spotify.styx.flyte.client.FlyteAdminClient;
 import com.spotify.styx.model.WorkflowId;
 import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
@@ -100,6 +102,7 @@ public class FlyteAdminClientRunnerTerminateDanglingTest {
 
   @Mock private StateManager stateManager;
   @Mock private FlyteAdminClient adminClient;
+  private final Stats stats = mock(Stats.class);
 
   private final QuietDeterministicScheduler executor = spy(new QuietDeterministicScheduler());
   private final Set<WorkflowInstance> activeInstances = new LinkedHashSet<>();
@@ -111,7 +114,7 @@ public class FlyteAdminClientRunnerTerminateDanglingTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     runner = new FlyteAdminClientRunner(
-        "runnerId", adminClient, stateManager, TERMINATE_DANGLING_INTERVAL, executor, time);
+        "runnerId", adminClient, stateManager, TERMINATE_DANGLING_INTERVAL, executor, time, stats);
     when(adminClient.listProjects())
         .thenReturn(ProjectOuterClass.Projects.newBuilder()
             .addProjects(ProjectOuterClass.Project.newBuilder()

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteAdminClientRunnerTest.java
@@ -41,6 +41,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -57,6 +58,7 @@ import com.spotify.styx.model.TriggerParametersBuilder;
 import com.spotify.styx.model.Workflow;
 import com.spotify.styx.model.WorkflowConfiguration;
 import com.spotify.styx.model.WorkflowInstance;
+import com.spotify.styx.monitoring.Stats;
 import com.spotify.styx.state.RunState;
 import com.spotify.styx.state.StateData;
 import com.spotify.styx.state.StateManager;
@@ -110,12 +112,13 @@ public class FlyteAdminClientRunnerTest {
   @Mock private FlyteAdminClient flyteAdminClient;
   @Mock private StateManager stateManager;
 
+  private final Stats stats = mock(Stats.class);
   private FlyteAdminClientRunner flyteRunner;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    flyteRunner = new FlyteAdminClientRunner(RUNNER_ID, flyteAdminClient, stateManager);
+    flyteRunner = new FlyteAdminClientRunner(RUNNER_ID, flyteAdminClient, stateManager, stats);
   }
 
   @Test

--- a/styx-service-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/monitoring/MetricsStats.java
@@ -134,6 +134,10 @@ public final class MetricsStats implements Stats {
       .tagged("what", "natural-trigger-rate")
       .tagged("unit", "trigger");
 
+  static final MetricId DANGLING_TERMINATED_FLYTE_EXECUTIONS = BASE
+          .tagged("what", "dangling-terminated-flyte-executions")
+          .tagged("unit", "trigger");
+
   static final MetricId TERMINATION_LOG_MISSING = BASE
       .tagged("what", "termination-log-missing");
 
@@ -226,6 +230,7 @@ public final class MetricsStats implements Stats {
   private final ConcurrentMap<String, Meter> workflowConsumerMeters;
   private final ConcurrentMap<String, Histogram> tickHistograms;
   private final ConcurrentMap<Tuple2<String, String>, Meter> datastoreOperationMeters;
+  private final Meter danglingTerminatedFlyteExecutions;
 
   /**
    * Submission timestamps (nanotime) keyed on execution id.
@@ -269,6 +274,7 @@ public final class MetricsStats implements Stats {
     this.workflowConsumerMeters = new ConcurrentHashMap<>();
     this.tickHistograms = new ConcurrentHashMap<>();
     this.datastoreOperationMeters = new ConcurrentHashMap<>();
+    this.danglingTerminatedFlyteExecutions = registry.meter(DANGLING_TERMINATED_FLYTE_EXECUTIONS);
   }
 
   @Override
@@ -456,6 +462,11 @@ public final class MetricsStats implements Stats {
   @Override
   public void recordKubernetesOperationError(String operation, String type, int code) {
     kubernetesOpErrorMeter(operation, type, code).mark();
+  }
+
+  @Override
+  public void recordDanglingTerminatedFlyteExecution() {
+    danglingTerminatedFlyteExecutions.mark();
   }
 
   private void recordDatastoreOperations(String operation, String kind, int n) {

--- a/styx-service-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/monitoring/NoopStats.java
@@ -201,4 +201,9 @@ final class NoopStats implements Stats {
   public void recordKubernetesOperationError(String operation, String type, int code) {
     // nop
   }
+
+  @Override
+  public void recordDanglingTerminatedFlyteExecution() {
+    // nop
+  }
 }

--- a/styx-service-common/src/main/java/com/spotify/styx/monitoring/Stats.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/monitoring/Stats.java
@@ -100,4 +100,6 @@ public interface Stats {
   void recordKubernetesOperation(String operation, long durationMillis, String status);
 
   void recordKubernetesOperationError(String operation, String type, int code);
+
+  void recordDanglingTerminatedFlyteExecution();
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Adds a metric to track the number of dangling flyte workflows that get terminated 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
