### PR TITLE
Fix flyte error translation

### DIFF
--- a/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteEventTranslator.java
+++ b/styx-scheduler-service/src/main/java/com/spotify/styx/flyte/FlyteEventTranslator.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 public class FlyteEventTranslator {
   private static final Logger LOG = LoggerFactory.getLogger(FlyteEventTranslator.class);
-
+  private static final String RETRIES_EXHAUSTED = "RetriesExhausted|";
   private static final String PERSISTED_CODE = "USER:Persisted";
   private static final String NOT_RETRYABLE_CODE = "USER:NotRetryable";
   private static final String NOT_READY_CODE = "USER:NotReady";
@@ -96,7 +96,7 @@ public class FlyteEventTranslator {
       case FAILED:
       case ABORTED:
       case TIMED_OUT:
-        final String flyteCode = execution.getClosure().getError().getCode();
+        final String flyteCode = execution.getClosure().getError().getCode().replace(RETRIES_EXHAUSTED,"");
         final int styxCode = KNOWN_ERROR_CODES.getOrDefault(flyteCode, UNKNOWN_ERROR_EXIT_CODE);
         LOG.info("Issue 'terminate' event for: " + runState.workflowInstance());
         generatedEvents.add(Event.terminate(runState.workflowInstance(), Optional.of(styxCode)));

--- a/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteEventTranslatorTest.java
+++ b/styx-scheduler-service/src/test/java/com/spotify/styx/flyte/FlyteEventTranslatorTest.java
@@ -138,6 +138,19 @@ public class FlyteEventTranslatorTest {
         new Object[] { Execution.WorkflowExecution.Phase.FAILED, "USER:AnythingElse", UNKNOWN_ERROR_EXIT_CODE },
         new Object[] { Execution.WorkflowExecution.Phase.ABORTED, "USER:AnythingElse", UNKNOWN_ERROR_EXIT_CODE},
         new Object[] { Execution.WorkflowExecution.Phase.TIMED_OUT, "USER:AnythingElse", UNKNOWN_ERROR_EXIT_CODE},
+        new Object[] { Execution.WorkflowExecution.Phase.FAILED, "RetriesExhaused|USER:NotReady", MISSING_DEPS_EXIT_CODE },
+        new Object[] { Execution.WorkflowExecution.Phase.FAILED, "RetriesExhaused|USER:NotReady", MISSING_DEPS_EXIT_CODE },
+        new Object[] { Execution.WorkflowExecution.Phase.ABORTED, "RetriesExhaused|USER:NotReady", MISSING_DEPS_EXIT_CODE },
+        new Object[] { Execution.WorkflowExecution.Phase.TIMED_OUT, "RetriesExhaused|USER:NotReady", MISSING_DEPS_EXIT_CODE },
+        new Object[] { Execution.WorkflowExecution.Phase.FAILED, "RetriesExhaused|USER:NotRetryable", UNRECOVERABLE_FAILURE_EXIT_CODE },
+        new Object[] { Execution.WorkflowExecution.Phase.ABORTED, "RetriesExhaused|USER:NotRetryable", UNRECOVERABLE_FAILURE_EXIT_CODE},
+        new Object[] { Execution.WorkflowExecution.Phase.TIMED_OUT, "RetriesExhaused|USER:NotRetryable", UNRECOVERABLE_FAILURE_EXIT_CODE},
+        new Object[] { Execution.WorkflowExecution.Phase.FAILED, "RetriesExhaused|USER:Persisted", SUCCESS_EXIT_CODE },
+        new Object[] { Execution.WorkflowExecution.Phase.ABORTED, "RetriesExhaused|USER:Persisted", SUCCESS_EXIT_CODE},
+        new Object[] { Execution.WorkflowExecution.Phase.TIMED_OUT, "RetriesExhaused|USER:Persisted", SUCCESS_EXIT_CODE},
+        new Object[] { Execution.WorkflowExecution.Phase.FAILED, "RetriesExhaused|USER:AnythingElse", UNKNOWN_ERROR_EXIT_CODE },
+        new Object[] { Execution.WorkflowExecution.Phase.ABORTED, "RetriesExhaused|USER:AnythingElse", UNKNOWN_ERROR_EXIT_CODE},
+        new Object[] { Execution.WorkflowExecution.Phase.TIMED_OUT, "RetriesExhaused|USER:AnythingElse", UNKNOWN_ERROR_EXIT_CODE},
         };
   }
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Add a step to clean error codes in the FlyteEventTranslator class of the RetriesExhaused prefix.

## Motivation and Context
fixes #1083 

## Have you tested this? If so, how?
Added Tests to the FlyteEventTranslator test case to include one item for each scenario with the added prefix to ensure that the code is behaving as expected

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

