### PR TITLE
Rename X-Request-Id

### DIFF
--- a/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
+++ b/styx-api-service/src/main/java/com/spotify/styx/api/SchedulerProxyResource.java
@@ -90,7 +90,7 @@ public class SchedulerProxyResource {
   }
 
   private Request withRequestId(Request request) {
-    if (request.headers().containsKey("X-Request-Id")) {
+    if (request.headers().containsKey("X-Styx-Request-Id")) {
       return request;
     }
     // Unfortunately it is not possible for middleware to set headers on
@@ -99,6 +99,6 @@ public class SchedulerProxyResource {
     if (requestId == null) {
       return request;
     }
-    return request.withHeader("X-Request-Id", requestId);
+    return request.withHeader("X-Styx-Request-Id", requestId);
   }
 }

--- a/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
+++ b/styx-api-service/src/test/java/com/spotify/styx/api/SchedulerProxyResourceTest.java
@@ -112,14 +112,14 @@ public class SchedulerProxyResourceTest extends VersionedApiTest {
     awaitResponse(serviceHelper.request(Request
         .forUri(path("/trigger"), "POST")
         .withHeader("foo", "bar")
-        .withHeader("X-Request-Id", requestId)
+        .withHeader("X-Styx-Request-Id", requestId)
         .withHeader(HttpHeaders.AUTHORIZATION, "decafbad")));
 
     final Request schedulerRequest = Iterables.getOnlyElement(serviceHelper.stubClient().sentRequests());
 
     assertThat(schedulerRequest.header("foo"), is(Optional.of("bar")));
     assertThat(schedulerRequest.header(HttpHeaders.AUTHORIZATION), is(Optional.of("decafbad")));
-    assertThat(schedulerRequest.header("X-Request-Id"), is(Optional.of(requestId)));
+    assertThat(schedulerRequest.header("X-Styx-Request-Id"), is(Optional.of(requestId)));
   }
 
   @Test
@@ -139,7 +139,7 @@ public class SchedulerProxyResourceTest extends VersionedApiTest {
 
     final Request schedulerRequest = Iterables.getOnlyElement(serviceHelper.stubClient().sentRequests());
 
-    assertThat(schedulerRequest.header("X-Request-Id"), is(Optional.of(requestId)));
+    assertThat(schedulerRequest.header("X-Styx-Request-Id"), is(Optional.of(requestId)));
   }
 
   @Test

--- a/styx-client/src/main/java/com/spotify/styx/client/StyxOkHttpClient.java
+++ b/styx-client/src/main/java/com/spotify/styx/client/StyxOkHttpClient.java
@@ -449,7 +449,7 @@ class StyxOkHttpClient implements StyxClient {
         throw new ClientErrorException("Request failed: " + request.method() + " " + request.url(), e);
       } else {
         final String effectiveRequestId;
-        final String responseRequestId = response.headers().get("X-Request-Id");
+        final String responseRequestId = response.headers().get("X-Styx-Request-Id");
         if (responseRequestId != null && !responseRequestId.equals(requestId)) {
           // If some proxy etc dropped our request ID header, we might get another one back.
           effectiveRequestId = responseRequestId;
@@ -470,7 +470,7 @@ class StyxOkHttpClient implements StyxClient {
     var builder = request
         .newBuilder()
         .addHeader("User-Agent", STYX_CLIENT_VERSION)
-        .addHeader("X-Request-Id", requestId);
+        .addHeader("X-Styx-Request-Id", requestId);
     authToken.ifPresent(t -> builder.addHeader("Authorization", "Bearer " + t));
     return builder.build();
   }

--- a/styx-client/src/test/java/com/spotify/styx/client/StyxOkHttpClientTest.java
+++ b/styx-client/src/test/java/com/spotify/styx/client/StyxOkHttpClientTest.java
@@ -742,7 +742,7 @@ public class StyxOkHttpClientTest {
         response(HTTP_OK, Collections.emptyList())));
     styx.workflows();
     final Request request = requestCaptor.getValue();
-    assertThat(request.header("X-Request-Id"), isValidUuid());
+    assertThat(request.header("X-Styx-Request-Id"), isValidUuid());
   }
 
   @Test
@@ -750,7 +750,7 @@ public class StyxOkHttpClientTest {
     final String responseRequestId = "foobar";
     when(client.send(any())).thenReturn(CompletableFuture.completedFuture(
         responseBuilder(HTTP_INTERNAL_ERROR, Collections.emptyList())
-            .addHeader("X-Request-Id", responseRequestId).build()));
+            .addHeader("X-Styx-Request-Id", responseRequestId).build()));
 
     try {
       styx.workflows().toCompletableFuture().get();
@@ -774,7 +774,7 @@ public class StyxOkHttpClientTest {
       assertThat(e.getCause(), instanceOf(ApiErrorException.class));
       final ApiErrorException apiError = (ApiErrorException) e.getCause();
       final Request request = requestCaptor.getValue();
-      assertThat(apiError.getRequestId(), is(request.header("X-Request-Id")));
+      assertThat(apiError.getRequestId(), is(request.header("X-Styx-Request-Id")));
     }
   }
 

--- a/styx-e2e-test/src/test/resources/reference.conf
+++ b/styx-e2e-test/src/test/resources/reference.conf
@@ -24,8 +24,8 @@ styx.datastore.project-id = "styx-oss-test"
 styx.datastore.namespace = ${styx.test.namespace}
 
 # configuration for http interface
-http.server.extraWhitelistedRequestHeaders = ["Authorization", "X-Request-Id"]
-http.server.extraWhitelistedResponseHeaders = ["X-Request-Id"]
+http.server.extraWhitelistedRequestHeaders = ["Authorization", "X-Styx-Request-Id"]
+http.server.extraWhitelistedResponseHeaders = ["X-Styx-Request-Id"]
 http.server.workerThreads = 2
 http.server.ttlMillis = 75000
 

--- a/styx-service-common/src/main/java/com/spotify/styx/api/Middlewares.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/Middlewares.java
@@ -70,7 +70,7 @@ public final class Middlewares {
   private static final Set<String> BLACKLISTED_HEADERS = ImmutableSet.of(HttpHeaders.AUTHORIZATION);
 
   private static final String REQUEST_ID = "request-id";
-  private static final String X_REQUEST_ID = "X-Styx-Request-Id";
+  private static final String X_STYX_REQUEST_ID = "X-Styx-Request-Id";
 
   private Middlewares() {
     throw new UnsupportedOperationException();
@@ -124,7 +124,7 @@ public final class Middlewares {
     return innerHandler -> requestContext -> {
 
       // Accept the request id from the incoming request if present. Otherwise generate one.
-      final String requestIdHeader = requestContext.request().headers().get(X_REQUEST_ID);
+      final String requestIdHeader = requestContext.request().headers().get(X_STYX_REQUEST_ID);
       final String requestId = (requestIdHeader != null)
           ? requestIdHeader
           : UUID.randomUUID().toString().replace("-", ""); // UUID with no dashes, easier to deal with
@@ -143,17 +143,17 @@ public final class Middlewares {
           } else {
             response = r;
           }
-          return response.withHeader(X_REQUEST_ID, requestId);
+          return response.withHeader(X_STYX_REQUEST_ID, requestId);
         });
       } catch (ResponseException e) {
         return completedFuture(e.<T>getResponse()
-            .withHeader(X_REQUEST_ID, requestId));
+            .withHeader(X_STYX_REQUEST_ID, requestId));
       } catch (Throwable t) {
         var internalServerErrorReason = internalServerErrorReason(requestId, t);
         LOG.warn(internalServerErrorReason, t);
         return completedFuture(Response.<T>forStatus(INTERNAL_SERVER_ERROR
             .withReasonPhrase(internalServerErrorReason))
-            .withHeader(X_REQUEST_ID, requestId));
+            .withHeader(X_STYX_REQUEST_ID, requestId));
       }
     };
   }

--- a/styx-service-common/src/main/java/com/spotify/styx/api/Middlewares.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/Middlewares.java
@@ -70,7 +70,7 @@ public final class Middlewares {
   private static final Set<String> BLACKLISTED_HEADERS = ImmutableSet.of(HttpHeaders.AUTHORIZATION);
 
   private static final String REQUEST_ID = "request-id";
-  private static final String X_REQUEST_ID = "X-Request-Id";
+  private static final String X_REQUEST_ID = "X-Styx-Request-Id";
 
   private Middlewares() {
     throw new UnsupportedOperationException();

--- a/styx-service-common/src/test/java/com/spotify/styx/api/MiddlewaresTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/MiddlewaresTest.java
@@ -310,7 +310,7 @@ public class MiddlewaresTest {
         .toCompletableFuture().get(5, SECONDS);
 
     assertThat(response, hasStatus(is(Status.IM_A_TEAPOT)));
-    assertThat(response, hasHeader("X-Request-Id", is(requestId.get())));
+    assertThat(response, hasHeader("X-Styx-Request-Id", is(requestId.get())));
     assertThat(requestId.get(), isValidUuid());
   }
 
@@ -335,7 +335,7 @@ public class MiddlewaresTest {
         .toCompletableFuture().get(5, SECONDS);
 
     assertThat(response, hasStatus(is(Status.IM_A_TEAPOT)));
-    assertThat(response, hasHeader("X-Request-Id", is(requestId.get())));
+    assertThat(response, hasHeader("X-Styx-Request-Id", is(requestId.get())));
     assertThat(requestId.get(), isValidUuid());
   }
 
@@ -375,7 +375,7 @@ public class MiddlewaresTest {
     assertThat(response, hasStatus(withCode(Status.INTERNAL_SERVER_ERROR)));
     assertThat(response, hasStatus(withReasonPhrase(is(
         "Internal Server Error (Request ID: " + requestId.get() + "): " + expectedMessage))));
-    assertThat(response, hasHeader("X-Request-Id", is(requestId.get())));
+    assertThat(response, hasHeader("X-Styx-Request-Id", is(requestId.get())));
     assertThat(requestId.get(), isValidUuid());
   }
 
@@ -401,7 +401,7 @@ public class MiddlewaresTest {
     assertThat(response, hasStatus(withCode(Status.INTERNAL_SERVER_ERROR)));
     assertThat(response, hasStatus(withReasonPhrase(is(
         "Internal Server Error (Request ID: " + requestId.get() + "): RuntimeException: fubar: IOException: deadbeef"))));
-    assertThat(response, hasHeader("X-Request-Id", is(requestId.get())));
+    assertThat(response, hasHeader("X-Styx-Request-Id", is(requestId.get())));
     assertThat(requestId.get(), isValidUuid());
   }
 
@@ -423,7 +423,7 @@ public class MiddlewaresTest {
         .toCompletableFuture().get(5, SECONDS);
 
     assertThat(response, hasStatus(withCode(Status.OK)));
-    assertThat(response, hasHeader("X-Request-Id", is(requestId.get())));
+    assertThat(response, hasHeader("X-Styx-Request-Id", is(requestId.get())));
     assertThat(requestId.get(), isValidUuid());
   }
   @Test
@@ -432,7 +432,7 @@ public class MiddlewaresTest {
     final RequestContext requestContext = mock(RequestContext.class);
     final String requestId = UUID.randomUUID().toString();
     final Request request = Request.forUri("/", "GET")
-        .withHeader("X-Request-Id", requestId);
+        .withHeader("X-Styx-Request-Id", requestId);
     final AtomicReference<String> propagatedRequestId = new AtomicReference<>();
     when(requestContext.request()).thenReturn(request);
 
@@ -446,7 +446,7 @@ public class MiddlewaresTest {
         .toCompletableFuture().get(5, SECONDS);
 
     assertThat(response, hasStatus(withCode(Status.OK)));
-    assertThat(response, hasHeader("X-Request-Id", is(requestId)));
+    assertThat(response, hasHeader("X-Styx-Request-Id", is(requestId)));
     assertThat(propagatedRequestId.get(), is(requestId));
   }
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Rename `X-Request-Id` header to `X-Styx-Request-Id`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, the proxy could override the header `X-Request-Id` using its own one and this produce a warning in the clients:
```
com.spotify.styx.client.StyxOkHttpClient - Request ID mismatch: '1f872480b8494988a4676bd967062a24' != '28d50a8faa45427fb6a6ad0f5ebd855c'
```
So, we decided to use a custom styx request-id header to avoid conflicts with the proxy one.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
