### PR TITLE
Lenient header matching

### DIFF
--- a/styx-service-common/src/main/java/com/spotify/styx/api/Middlewares.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/Middlewares.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import com.google.common.net.HttpHeaders;
 import com.spotify.apollo.Request;
 import com.spotify.apollo.RequestContext;
@@ -45,6 +45,7 @@ import io.norberg.automatter.AutoMatter;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Tracer;
 import java.net.URI;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -68,8 +69,8 @@ public final class Middlewares {
 
   private static final Logger LOG = LoggerFactory.getLogger(Middlewares.class);
 
-  private static final Set<String> BLACKLISTED_HEADERS =
-      ImmutableSet.of(HttpHeaders.AUTHORIZATION.toLowerCase(Locale.ROOT));
+  private static final List<String> BLACKLISTED_HEADERS =
+      ImmutableList.of(HttpHeaders.AUTHORIZATION.toLowerCase(Locale.ROOT), "service-identity");
 
   private static final String REQUEST_ID = "request-id";
   private static final String X_STYX_REQUEST_ID = "X-Styx-Request-Id";
@@ -271,8 +272,10 @@ public final class Middlewares {
   private static Map<String, String> hideSensitiveHeaders(Map<String, String> headers) {
     return headers.entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey,
-            entry -> BLACKLISTED_HEADERS.contains(entry.getKey().toLowerCase(Locale.ROOT)) ? "<hidden>"
-                                                                                           : entry.getValue()));
+            entry -> BLACKLISTED_HEADERS.stream()
+                         .anyMatch(header -> entry.getKey().toLowerCase(Locale.ROOT).contains(header))
+                     ? "<hidden>"
+                     : entry.getValue()));
   }
 
   public static <T> Middleware<AsyncHandler<Response<T>>, AsyncHandler<Response<T>>> authenticator(

--- a/styx-service-common/src/main/java/com/spotify/styx/api/Middlewares.java
+++ b/styx-service-common/src/main/java/com/spotify/styx/api/Middlewares.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.net.HttpHeaders;
 import com.spotify.apollo.Request;
 import com.spotify.apollo.RequestContext;
@@ -70,7 +69,7 @@ public final class Middlewares {
   private static final Logger LOG = LoggerFactory.getLogger(Middlewares.class);
 
   private static final List<String> BLACKLISTED_HEADERS =
-      ImmutableList.of(HttpHeaders.AUTHORIZATION.toLowerCase(Locale.ROOT), "service-identity");
+      List.of(HttpHeaders.AUTHORIZATION.toLowerCase(Locale.ROOT), "service-identity");
 
   private static final String REQUEST_ID = "request-id";
   private static final String X_STYX_REQUEST_ID = "X-Styx-Request-Id";

--- a/styx-service-common/src/test/java/com/spotify/styx/api/MiddlewaresTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/MiddlewaresTest.java
@@ -539,7 +539,8 @@ public class MiddlewaresTest {
     Request request = Request.forUri("/", "PUT")
         .withPayload(ByteString.encodeUtf8("hello"))
         .withHeader(HttpHeaders.AUTHORIZATION, "Bearer s3cr3tp455w0rd")
-        .withHeader("foo-service-identity", "Bearer s3cr3tp455w0rd");
+        .withHeader("foo-service-identity", "Bearer s3cr3tp455w0rd")
+        .withHeader("foo-bar", "foo-bar");
     when(requestContext.request()).thenReturn(request);
 
     String email = "foo@bar.net";
@@ -557,7 +558,7 @@ public class MiddlewaresTest {
         request.method(),
         request.uri(),
         email,
-        Map.of(HttpHeaders.AUTHORIZATION, "<hidden>", "foo-service-identity", "<hidden>"),
+        Map.of(HttpHeaders.AUTHORIZATION, "<hidden>", "foo-service-identity", "<hidden>", "foo-bar", "foo-bar"),
         Map.of(),
         request.payload().orElseThrow().utf8());
   }

--- a/styx-service-common/src/test/java/com/spotify/styx/api/MiddlewaresTest.java
+++ b/styx-service-common/src/test/java/com/spotify/styx/api/MiddlewaresTest.java
@@ -538,7 +538,8 @@ public class MiddlewaresTest {
     RequestContext requestContext = mock(RequestContext.class);
     Request request = Request.forUri("/", "PUT")
         .withPayload(ByteString.encodeUtf8("hello"))
-        .withHeader(HttpHeaders.AUTHORIZATION, "Bearer s3cr3tp455w0rd");
+        .withHeader(HttpHeaders.AUTHORIZATION, "Bearer s3cr3tp455w0rd")
+        .withHeader("foo-service-identity", "Bearer s3cr3tp455w0rd");
     when(requestContext.request()).thenReturn(request);
 
     String email = "foo@bar.net";
@@ -556,7 +557,7 @@ public class MiddlewaresTest {
         request.method(),
         request.uri(),
         email,
-        Map.of(HttpHeaders.AUTHORIZATION, "<hidden>"),
+        Map.of(HttpHeaders.AUTHORIZATION, "<hidden>", "foo-service-identity", "<hidden>"),
         Map.of(),
         request.payload().orElseThrow().utf8());
   }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Matching headers as substring to handle cases we don't need to match full header name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are cases we cannot match full header name, so instead we check by substring match.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I modified unit test to cover this change.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] (optional) Changes are covered by system test
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
